### PR TITLE
Bug fixes, knobs for output fmt/no-dirty, Reproducible runs, Passdown…

### DIFF
--- a/polproj.py
+++ b/polproj.py
@@ -1,20 +1,23 @@
 #!/usr/bin/env python
 # SPDX-FileCopyrightText: (C) 2025 Tenstorrent
 # SPDX-License-Identifier: Apache-2.0
-import sys
 import os
+import sys
 import argparse
-import logging
-import yaml
-import ttsim.config.runcfgmodel as runcfgmodel
-from git import Repo
+import copy
 import datetime
-import jinja2
-from jinja2 import Template
+import json
+import logging
+import shutil
 import subprocess
-from typing import Any, Union
+from typing import Any, Tuple, Union
 
+import jinja2
+import yaml
+from git import GitCommandError, Repo
+from jinja2 import Template
 
+import ttsim.config.runcfgmodel as runcfgmodel
 
 SCRIPT_ROOT_DIR = os.path.abspath(os.path.dirname(__file__))
 
@@ -60,13 +63,12 @@ def timestamp(tm: datetime.datetime) -> str:
 
 # TODO: P0 Use polaris directly, instead of through separate process
 def execute(runcfg: RUNCFG_TYPE, jtemplate: JTemplate, jdict: JDICT_TYPE,
-            args: argparse.Namespace, diagnostic: bool = True) -> int:
-    outputdir = jtemplate.expand(runcfg.output, jdict)
+            args: argparse.Namespace, passdown_args: list[str], diagnostic: bool = True) -> int:
     command_words = ['python', 'polaris.py',
                      '--odir', jtemplate.expand(runcfg.output, jdict),
                      '--study', jtemplate.expand(runcfg.study, jdict),
                      ]
-    if runcfg.runtype == 'inference':
+    if runcfg.filterrun == 'inference':
         rt_inference, rt_training = (True, False)
     else:
         rt_inference, rt_training = (False, True)
@@ -99,9 +101,15 @@ def execute(runcfg: RUNCFG_TYPE, jtemplate: JTemplate, jdict: JDICT_TYPE,
         command_words.extend(['--frequency'] + [str(_tmp) for _tmp in runcfg.frequency])
     if runcfg.batchsize is not None:
         command_words.extend(['--batchsize'] + [str(_tmp) for _tmp in runcfg.batchsize])
+    command_words.extend(passdown_args)
+
+    infopath = os.path.join(runcfg.output, 'inputs', 'runinfo.json')
+    os.makedirs(os.path.dirname(infopath), exist_ok=True)
+    with open(infopath, 'w') as fout:
+        json.dump(jdict, fout, indent=4)
 
     logging.info('executing %s', command_words)
-    logging.info('executing %s', " ".join(command_words))
+    logging.info('executing %s', ' '.join(command_words))
     ret = subprocess.run(command_words)
     if ret.returncode != 0 and diagnostic:
         logging.error('command "%s" failed with exit code %d' % (command_words, ret.returncode))
@@ -110,55 +118,144 @@ def execute(runcfg: RUNCFG_TYPE, jtemplate: JTemplate, jdict: JDICT_TYPE,
 
 def jinja_variables(rootrepo: Repo) -> dict[str, Any]:
     head = rootrepo.head.commit
+    print(f'{head=}')
     commit_time = head.committed_datetime
     author_time = head.authored_datetime
-    tag = rootrepo.tags[0]
+    is_detached = False
+    try:
+        rootrepo.active_branch
+    except TypeError:
+        is_detached = True
     return {
-        'gitroot': rootrepo.working_tree_dir,
+        'giturl': rootrepo.remote('origin').url,
         'githash': head.hexsha,
-        'gitbranch': rootrepo.active_branch.name,
-        'tags': [tag.name for tag in rootrepo.tags if tag.commit == head],
-        'commit_tstamp': timestamp(commit_time),
+        'gitdirty': rootrepo.is_dirty(),
+        'gituntracked': rootrepo.is_dirty(untracked_files=True),
+        'gitroot': rootrepo.working_tree_dir if not is_detached else '',
+        'gitbranch': rootrepo.active_branch.name if not is_detached else '',
+        'author': head.author.email,
         'author_tstamp': timestamp(author_time),
+        'committer': head.committer.email,
+        'commit_tstamp': timestamp(commit_time),
         'tstamp': timestamp(datetime.datetime.now()),
         'commit_year': commit_time.year,
-        'commit_month': commit_time.month,
-
+        'commit_month': f'{commit_time.month:02}',
+        'commit_message': head.message,
     }
 
-def determine_commits(ab_repo: Repo, githash: runcfgmodel.TYPE_GITHASH) -> Union[list[str], None]:
+
+def determine_commit(rootrepo: Repo, githash: runcfgmodel.TYPE_GITHASH) -> Union[list[str], None]:
+    head = rootrepo.head.commit
     if githash is None:
         return None
-    raise NotImplementedError('githash support')
+    if head.hexsha == githash:  # Current head is the same as the required githash, so do nothing
+        return None
+    try:
+        commits = list(rootrepo.iter_commits(githash, max_count=1))
+    except GitCommandError as _e:
+        logging.error('invalid githash "%s"', githash)
+        raise
+    return commits[0]
 
-def get_args() -> argparse.Namespace:
+
+def get_args() -> Tuple[argparse.Namespace, list[str]]:
     parser = argparse.ArgumentParser('polproj.py')
     parser.add_argument('--config', '-c', required=True, help='Run configuration yaml file')
+    parser.add_argument('--no-dirty', dest='no_dirty', action='store_true',
+                        help='fail if repository is dirty (changes and/or untracked files)')
     parser.add_argument('--dryrun', '-n', action='store_true', help='Show the commands, but do not execute')
 
     if not sys.argv[1:]:
         parser.print_help()
         exit(0)
-    args = parser.parse_args()
-    return args
+    args, passdown_args = parser.parse_known_args()
+    return args, passdown_args
+
+
+def prepare_for_run(runconfig: RUNCFG_TYPE, jtemplate: JTemplate, jdict: dict[str, Any], 
+                    args: argparse.Namespace, passdown_args: list[str]) -> RUNCFG_TYPE:
+    outdir = jtemplate.expand(runconfig.output, jdict)
+    study = jtemplate.expand(runconfig.study, jdict)
+    runconfig.output = outdir
+    runconfig.study = study
+    if not os.path.isdir(outdir):
+        os.makedirs(outdir)
+    studydir = os.path.join(outdir, study)
+    if not os.path.isdir(studydir):
+        os.makedirs(studydir)
+    inputsdir = os.path.join(outdir, 'inputs')
+    if not os.path.isdir(inputsdir):
+        os.makedirs(inputsdir)
+    shutil.copyfile(runconfig.wlspec, os.path.join(inputsdir, os.path.basename(runconfig.wlspec)))
+    shutil.copyfile(runconfig.archspec, os.path.join(inputsdir, os.path.basename(runconfig.archspec)))
+    shutil.copyfile(runconfig.wlmapspec, os.path.join(inputsdir, os.path.basename(runconfig.wlmapspec)))
+    runconfig.saved_copy = True
+    runconfig.githash = jdict['githash']
+    with open(os.path.join(inputsdir, os.path.basename(args.config)), 'w') as fout:
+        yaml.dump(runconfig.model_dump(), fout, indent=4, Dumper=yaml.CDumper)
+    with open(os.path.join(inputsdir, 'rerun.sh'), 'w') as fout:
+        fout.write('#!/bin/bash\n')
+        fout.write('set -e\n')
+        fout.write('set -x\n')
+        fout.write('python polproj.py ' + 
+                   f'--config {inputsdir}/{os.path.basename(args.config)}' +
+                   ' '.join(passdown_args) + 
+                   '\n')
+    return runconfig
+
+
+def override_runconfig(runconfig: RUNCFG_TYPE, passdown_args: list[str]) -> None:
+    for ndx, arg in enumerate(passdown_args):
+        if arg == '--odir':
+            if ndx + 1 >= len(passdown_args):
+                raise ValueError('missing argument for --odir')
+            runconfig.output = passdown_args[ndx + 1]
+            logging.warning('overriding output directory with %s', runconfig.output)
+        elif arg == '--study':
+            if ndx + 1 >= len(passdown_args):
+                raise ValueError('missing argument for --study')
+            runconfig.study = passdown_args[ndx + 1]
+            logging.warning('overriding output directory with %s', runconfig.output)
 
 
 def main() -> int:
     logging.basicConfig(level=logging.INFO, format='%(levelname)s:%(filename)s:%(lineno)d:%(message)s')
-    args: argparse.Namespace = get_args()
-    runconfig : RUNCFG_TYPE = load_runconfig(args.config)
+    args: argparse.Namespace
+    passdown_args: list[str]
+    args, passdown_args = get_args()
+    runconfig: RUNCFG_TYPE = load_runconfig(args.config)
 
-    repodir : str = os.getcwd()
-    rootrepo : Repo = Repo(repodir)
+    repodir: str = os.getcwd()
+    rootrepo: Repo = Repo(repodir)
 
-    commits = determine_commits(rootrepo, runconfig.githash)
+    if args.no_dirty:
+        if rootrepo.is_dirty():
+            logging.error('Repository is dirty (changes and/or untracked files), please commit or stash changes before running')
+            return 1
+        logging.info('Repository is clean')
 
-    if commits is None:
-        jinjadict = jinja_variables(rootrepo)
-        mytemplate = JTemplate()
-        ret = execute(runconfig, mytemplate, jinjadict, args)
-        return ret
-    raise NotImplementedError('githash not supported yet')
+    commit = determine_commit(rootrepo, runconfig.githash)
+
+    override_runconfig(runconfig, passdown_args)
+
+    if commit is not None:
+        if rootrepo.is_dirty():
+            logging.error('Repository is dirty (trying to checkout %s), please commit or stash changes before running', 
+                        commit)
+            return 1
+        rootrepo.git.checkout(commit)
+        logging.warning('checked out requested git hash %s', commit)
+
+    jinjadict = jinja_variables(rootrepo)
+    mytemplate = JTemplate()
+    prepared_config: RUNCFG_TYPE
+    if runconfig.saved_copy:
+        prepared_config = runconfig
+    else:
+        prepared_config = copy.copy(runconfig)
+        prepare_for_run(prepared_config, mytemplate, jinjadict, args, passdown_args)
+    ret = execute(prepared_config, mytemplate, jinjadict, args, passdown_args)
+    return ret
 
 
 if __name__ == '__main__':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,16 @@ exclude_also = [
 [tool.coverage.html]
 # Output directory, prefix __ to ensure it is ignored by .gitignore
 directory = "__htmlcov"
+
+[tool.isort]
+force_to_top = ["sys" , "os"]
+honor_noqa = true
+line_length = 120
+
+[tool.ruff]
+line-length = 120
+indent-width = 4
+
+[tool.ruff.format]
+quote-style = "single"
+

--- a/ttsim/config/runcfgmodel.py
+++ b/ttsim/config/runcfgmodel.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 # SPDX-FileCopyrightText: (C) 2025 Tenstorrent
 # SPDX-License-Identifier: Apache-2.0
-from typing import Optional, Literal, Tuple, Union
-from pydantic import BaseModel, Field, field_validator, ValidationInfo
+from typing import Literal, Optional, Tuple, Union
+
+from pydantic import BaseModel, Field, ValidationInfo, field_validator
 
 type TYPE_SWEEP = Literal['all', 'first-parent']
 type TYPE_RUN = Literal['inference', 'training']
@@ -54,7 +55,6 @@ class PolarisRunConfig(BaseModel, extra='forbid'):
     filterrun: Optional[TYPE_RUN] = Field(
         default='inference',
         description='Filter either inference or training runs',
-        alias='runtype'
     )
 
     filter: Optional[str] = Field(
@@ -68,6 +68,8 @@ class PolarisRunConfig(BaseModel, extra='forbid'):
 
     @field_validator('frequency')
     def validate_frequency(cls, v: TYPE_frequency, info: ValidationInfo) -> TYPE_frequency:
+        if v is None:
+            return v
         if any([v[0] <= 0, v[1] <= 0, v[2] <= 0]):
             raise AssertionError(f'frequency values should be positive in {v}')
         if v[0] >= v[1]:
@@ -76,6 +78,8 @@ class PolarisRunConfig(BaseModel, extra='forbid'):
 
     @field_validator('batchsize')
     def validate_batchsize(cls, v: TYPE_batchsize, info: ValidationInfo) -> TYPE_batchsize:
+        if v is None:
+            return v
         if any([v[0] <= 0, v[1] <= 0, v[2] <= 0]):
             raise AssertionError(f'batchsize values should be positive in {v}')
         if v[2] == 1:
@@ -103,9 +107,10 @@ class PolarisRunConfig(BaseModel, extra='forbid'):
         default=None, description='Particular git commit'
     )
 
-    @property
-    def runtype(self):
-        return self.filterrun
+    saved_copy: Optional[bool] = Field(
+        default=False,
+        description='Only for internal use. This attribute should be true for yaml copies saved by polaris system only'
+    )
 
 
 type TYPE_GITHASH = Union[str, None]


### PR DESCRIPTION
… args

- remove dead variable for repo tag in polproj
- fix polproj failure if the workspace did not have any tag
- CLI knobs to choose output format for projection outputs
- CLI Knob --outputformat to choose between json (default), yaml, pickle or none for architecture information
- CLI Knob --dumpstatscsv to choose whether projection metrics should be output in CSV format
- cleaned up most affected files w.r.t. ruff and isort
- Ensuring projection runs can be reproduced easily
- Save all the used input configuration yaml files
- Save run configuration yaml file, ensuring the input yaml files point to the saved configurations, and the effective commit hash is explicitly stored.
- Save the command (polproj command) to redo the run
- Support for githash in run config file
- Allow passdown_args to polproj, which get passed down to polaris
- save run information (git repo details) info inputs/runinfo.json
- no-dirty knob for polproj, for scenarios require repo to be clean