### PR TITLE
Support for html comparisons of projections

### DIFF
--- a/.github/workflows/checkin_tests.yml
+++ b/.github/workflows/checkin_tests.yml
@@ -36,7 +36,9 @@ jobs:
         conda config --show-sources
     - name: Run Unit and Coverage Tests
       run: | 
+        coverage erase
         coverage run -m pytest --junitxml __ci/xml/junit.xml
+        coverage combine
         coverage report 
         coverage html -d __ci/html/
         coverage xml -o __ci/xml/coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ __pycache__/
 
 # Temporary / transient directories
 __*/
+# Temporary files
+__*
+# Directory not to be checked in
+private/
 
 # Macbook etc.
 .DS_Store

--- a/checkin_tests.py
+++ b/checkin_tests.py
@@ -20,7 +20,7 @@ def prepare_commands_coverage(condaenvprefix: OptionalString) -> list[str]:
     # Knobs for coverage, pytest (as part of coverage run), mypy are picked up from
     # pyproject.toml. These knobs are NOT replicated here, to avoid inconsistency
     commands = [
-        f'{condaenvprefix} coverage run -m pytest && coverage report && coverage html',
+        f'{condaenvprefix} coverage erase && coverage run -m pytest && coverage combine &&  coverage report && coverage html',
     ]
     return commands
 
@@ -55,7 +55,6 @@ def prepare_commands_run_all_tests(condaenvprefix: OptionalString) -> list[str]:
 
     for exp_no, exp in enumerate(ALL_EXPS):
         exp_str    = "".join(exp)
-        study_name = f"study_{exp_no+1:02}"
         command    = f"{cmd} --study PLACEHOLDER {exp_str} --log_level debug"
         commands.append(command)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ exclude = "^__.*/"
 [tool.coverage.run]
 branch = true
 omit = ["tests/*"]
+parallel = true    # Enable data collection from sub-processes called through tests
 
 [tool.coverage.report]
 # Regexes for lines to exclude from consideration
@@ -19,6 +20,7 @@ exclude_also = [
     # Don't complain about missing debug-only code:
     "def __repr__",
     "if self\\.debug",
+    "if DEBUG",
 
     # Don't complain about TYPE_CHECKING code
     "if TYPE_CHECKING",
@@ -46,4 +48,4 @@ indent-width = 4
 
 [tool.ruff.format]
 quote-style = "single"
-
+skip-magic-trailing-comma = true    # Avoid always splitting function arguments (in definitions) one per line

--- a/tests/test_tools/test_compare_proj.py
+++ b/tests/test_tools/test_compare_proj.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import pytest
+import subprocess
+import yaml
+from typing import Any
+from pathlib import Path
+
+def run_polproj(runcfg_dict: dict[str, Any], runcfgfile_path: Path) -> None:
+    """
+    Run the polproj script with the given paths.
+    """
+    with open(runcfgfile_path, 'w') as f:
+        yaml.dump(runcfg_dict, f)
+    polproj_cmd = ['python', 'polproj.py', '--config', runcfgfile_path.as_posix()]
+    ret = subprocess.run(polproj_cmd, check=True)
+    assert ret.returncode == 0, f"polproj script {polproj_cmd} failed with return code {ret.returncode}"
+
+
+def run_projcmp(dir1: Path, dir2: Path, output: Path, extra_args: None|list[str]=None, expected_return: int = 0) -> None:
+    """
+    Run the compare_projections script with the given directories and output path.
+    """
+    if extra_args is None:
+        extra_args = []
+    compare_cmd = ['python', 'tools/compare_projections.py',
+                   '--dir1', dir1.as_posix(),
+                   '--dir2', dir2.as_posix(),
+                   '--output', output.as_posix()
+                   ] + extra_args
+    ret = subprocess.run(compare_cmd, check=False)
+    assert ret.returncode == expected_return, f"compare_projections script {compare_cmd} exited with return code {ret.returncode} != expected {expected_return}"
+
+
+def test_compare_proj(tmp_path_factory):
+    """
+    Test the comparison of two project files using the polproj script.
+    """
+    polproj_path = 'tools/polproj.py'
+    arch_cfg = 'config/all_archs.yaml'
+    wl_cfg = 'config/mlperf_inference.yaml'
+    wlmap_cfg = 'config/wl2archmapping.yaml'
+    archs = 'A100'
+
+    tmpdirnames = ['run1', 'run2', 'run3', 'comparison1', 'comparison2', 'comparison3', 'temp']
+    tmpdir = {x: tmp_path_factory.mktemp(x) for x in tmpdirnames}
+    for tmp in tmpdir.values():
+        os.makedirs(tmp, exist_ok=True)
+
+    study_name = 'projcmp'
+
+    runcfg1_dict = {
+        'title': 'Test Projection Comparison',
+        'study': study_name,
+        'odir': tmpdir['run1'].as_posix(),
+        'wlspec': wl_cfg,
+        'archspec': arch_cfg,
+        'wlmapspec': wlmap_cfg,
+        'filterarch': ",".join(archs),
+        'filterwli': 'b1024',
+        'filterarch': 'A100'
+    }
+    run_polproj(runcfg1_dict, tmpdir['temp'] / 'runcfg1.yaml')
+    with open(arch_cfg) as fin:
+        arch_dict = yaml.safe_load(fin)
+
+    nvidia_entry = next((entry for ndx, entry in enumerate(arch_dict['packages']) if 'nvidia' in entry['name'].lower()), None)
+    assert nvidia_entry is not None, "NVIDIA entry not found in architecture configuration"
+    a100_entry = next((entry for ndx, entry in enumerate(nvidia_entry['instances']) if 'a100' in entry['name'].lower()), None)
+    assert a100_entry is not None, "A100 entry not found in NVIDIA architecture configuration"
+    compute_entry = next((entry for ndx, entry in enumerate(a100_entry['ipgroups']) if entry['iptype'].lower() == 'compute'), None)
+    assert compute_entry is not None, "Compute entry not found in A100 architecture configuration"
+    for override_name in compute_entry['ip_overrides']:
+        if override_name.lower().endswith('freq_mhz'):
+            compute_entry['ip_overrides'][override_name] -= 100 # Decrease frequency by 100 MHz for testing
+    arch_cfg2_path = tmpdir['temp'] / 'all_archs_2.yaml'
+    with open(arch_cfg2_path, 'w') as fout:
+        yaml.dump(arch_dict, fout)
+    runcfg2_dict = {x: y for x, y in runcfg1_dict.items()}
+    runcfg2_dict['archspec'] = arch_cfg2_path.as_posix()
+    runcfg2_dict['odir'] = tmpdir['run2'].as_posix()
+    run_polproj(runcfg2_dict, tmpdir['temp'] / 'runcfg2.yaml')
+
+    runcfg3_dict = {x: y for x, y in runcfg1_dict.items()}
+    runcfg3_dict['odir'] = tmpdir['run3'].as_posix()
+    run_polproj(runcfg3_dict, tmpdir['temp'] / 'runcfg3.yaml')
+
+
+    run_projcmp(tmpdir['run1'], tmpdir['run2'], tmpdir['comparison1'], expected_return=1)
+    assert (tmpdir['comparison1'] / study_name / 'html').is_dir(), f"HTML comparison directory not created at {tmpdir['comparison1'].stem}"
+    run_projcmp(tmpdir['run1'], tmpdir['run2'], tmpdir['comparison2'], extra_args=['--no-html'], expected_return=1)
+    assert not (tmpdir['comparison2'] / study_name / 'html').exists(), f"HTML comparison directory not created at {tmpdir['comparison2'].stem}"
+    run_projcmp(tmpdir['run1'], tmpdir['run3'], tmpdir['comparison3'], extra_args=['--no-html'], expected_return=0)
+    assert not (tmpdir['comparison3'] / study_name / 'html').exists(), f"HTML comparison directory not created at {tmpdir['comparison3'].stem}"

--- a/tools/compare_projections.py
+++ b/tools/compare_projections.py
@@ -1,26 +1,31 @@
 #!/usr/bin/env python
 # SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
-import sys
 import os
+import sys
+import statistics
+
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-import json
 import argparse
+import json
 import logging
-from jinja2 import Environment, PackageLoader, select_autoescape, StrictUndefined
-from pydantic import BaseModel, model_validator
 import math
+from collections import Counter, defaultdict, namedtuple
 from enum import Enum
 from pathlib import Path
-from collections import namedtuple, Counter, defaultdict
+from typing import Any, Tuple
+
+from jinja2 import Environment, PackageLoader, StrictUndefined
+
+import tools.statattr as statattr
 from ttsim.utils.common import print_csv
-from typing import Tuple, Any, Literal
 
-logfile = open('comparison-log.txt', 'w')
+DEBUG = True
 
-type IndexTuple = Tuple[int|None, int|None]
+type IndexTuple = Tuple[int | None, int | None]
 
 ATTRIBUTES_TO_SKIP: set[str] = {'type', 'stat_filename'}
+
 
 class ComparisonStatus(str, Enum):
     Only_in_1 = 'keys_only_in_1'
@@ -31,39 +36,43 @@ class ComparisonStatus(str, Enum):
     Match = 'match'
 
 
-def flatten_dict(d: dict[str, Any], param_sep: str='_') -> dict[str, Any]:
+class Jinja2Environment:
+    def __init__(self) -> None:
+        self.env = Environment(loader=PackageLoader('tools', 'templates'), undefined=StrictUndefined)
+
+    def render(self, template_name: str, context: dict[str, Any]) -> str:
+        template = self.env.get_template(template_name)
+        return template.render(context)
+
+
+def flatten_dict_as_str(d: dict[str, Any], param_sep: str = '_') -> dict[str, Any]:
     """
-        Flatten a nested dictionary into a single level dictionary with keys
-        concatenated by sep.
-        :param d: The dictionary to flatten
-        :param param_sep: Separator
-        :return: A flattened dictionary
+    Flatten a nested dictionary into a single level dictionary with keys
+    concatenated by sep.
+    :param d: The dictionary to flatten
+    :param param_sep: Separator
+    :return: A flattened dictionary
     """
+
     def _flatten(d: dict[str, Any], parent_key: str, param_sep: str) -> dict[str, Any]:
         items: list[Tuple[str, Any]] = []
         for k, v in d.items():
-            new_key = f"{parent_key}{param_sep}{k}" if parent_key else k
-            if isinstance(v, dict):
-                items.extend(_flatten(v, new_key, param_sep=param_sep).items())
-            elif isinstance(v, list):
-                for i, item in enumerate(v):
-                    if isinstance(item, dict):
-                        items.extend(_flatten(item, f"{new_key}{param_sep}{i}", param_sep=param_sep).items())
-                    else:
-                        items.append((f"{new_key}{param_sep}{i}", item))
+            new_key = f'{parent_key}{param_sep}{k}' if parent_key else k
+            if isinstance(v, (dict, list)):
+                items.append((k, json.dumps(v)))
             else:
                 items.append((new_key, v))
         return dict(items)
+
     return _flatten(d, parent_key='', param_sep=param_sep)
 
 
 JobKey = namedtuple('JobKey', ['devname', 'wlcls', 'wlname', 'wlinstance', 'bs'])
 
+
 def jobkey_2_str(key: JobKey) -> str:
     return f'{key.devname}_{key.wlcls}_{key.wlname}_{key.wlinstance}_b{key.bs}'
 
-def tuple_2_jobkey(key: tuple) -> JobKey:
-    return JobKey(*key)
 
 def summary_index(summary_list: list[dict[str, Any]]) -> dict[JobKey, dict]:
     row_dict: dict[JobKey, dict[str, Any]] = {}
@@ -78,12 +87,14 @@ def summary_index(summary_list: list[dict[str, Any]]) -> dict[JobKey, dict]:
 def is_value_numeric(v: Any) -> bool:
     return isinstance(v, (int, float))
 
+
 def status_2_freqcount(values: list[ComparisonStatus]) -> Counter:
     status_count: Counter = Counter()
     for stat in values:
         assert isinstance(stat, ComparisonStatus)
         status_count[stat] += 1
     return status_count
+
 
 def rollup_status(status_list: list[ComparisonStatus]) -> ComparisonStatus:
     assert isinstance(status_list, list)
@@ -93,7 +104,6 @@ def rollup_status(status_list: list[ComparisonStatus]) -> ComparisonStatus:
                        ComparisonStatus.ApproxMatch, ComparisonStatus.Match]
            if status_count[x] != 0]
     return found_status[0]
-
 
 
 def status_2_csvrow(summary: dict[str, Any]) -> dict[str, Any]:
@@ -131,13 +141,9 @@ def compare_value(value1: Any, value2: Any, epsilon: float) -> dict[str, Any]:
         else:
             result['status'] = ComparisonStatus.Mismatch
         result['diff'] = value1 - value2
-        result['ratio'] = value1 / value2 if value2 != 0 else float('inf')
+        result['ratio'] = value2 / value1 if value1 != 0 else 1 if value2 == 0 else 0  # float('inf')
         result['type'] = 'numeric'
         assert 'status' in result
-        return result
-    if isinstance(value1, (list, dict)) and isinstance(value2, (list, dict)):
-        result['type'] = 'container'
-        result['status'] = ComparisonStatus.Match
         return result
     result['type'] = 'non-numeric'
     if value1 == value2:
@@ -150,9 +156,7 @@ def compare_value(value1: Any, value2: Any, epsilon: float) -> dict[str, Any]:
     return result
 
 def next_matching_op(opstats: list[dict[str, Any]], start_index: int, ref_op: dict[str, Any]) -> int | None:
-    matching_indices = (
-        ndx for ndx in range(start_index, len(opstats)) if opstats[ndx]['optype'] == ref_op['optype']
-    )
+    matching_indices = (ndx for ndx in range(start_index, len(opstats)) if opstats[ndx]['optype'] == ref_op['optype'])
     assert not isinstance(matching_indices, list)  # it MUST be a generator, we do NOT want to create a list
     try:
         return next(matching_indices)
@@ -178,10 +182,11 @@ def pair_layers(opstatlist_1: list[dict[str, Any]], opstatlist_2: list[dict[str,
             pairs.append((ndx1, None,))
             ndx1 += 1
             continue
-        logging.error('could not match %d:%s and %d:%s', ndx1, opstatlist_1[ndx1]['optype'],
-                      ndx2, opstatlist_2[ndx2]['optype'])
-        logging.error('closest match to %d is %s', ndx1, next1)
-        logging.error('closest match to %d is %s', ndx2, next2)
+        if DEBUG:
+            logging.error('could not match %d:%s and %d:%s', ndx1, opstatlist_1[ndx1]['optype'],
+                          ndx2, opstatlist_2[ndx2]['optype'])
+            logging.error('closest match to %d is %s', ndx1, next1)
+            logging.error('closest match to %d is %s', ndx2, next2)
         raise NotImplementedError('ambiguous layer matching not implemented')
     return pairs
 
@@ -220,8 +225,7 @@ def compare_dicts(dict1: dict, dict2: dict, epsilon: float) -> dict[str, Any]:
     return result
 
 
-
-def classify_keys(dict_1: dict, dict_2: dict)->dict:
+def classify_keys(dict_1: dict, dict_2: dict) -> dict:
     return {
         'keys_common': dict_1.keys() & dict_2.keys(),
         'keys_only_in_1': dict_1.keys() - dict_2.keys(),
@@ -238,7 +242,7 @@ class ProjectionRun:
 
         self.subdirs = {d for d in self.studypath.iterdir() if d.is_dir()}
         if {sd.stem for sd in self.subdirs} != {'CONFIG', 'STATS', 'SUMMARY'}:
-            raise RuntimeError(f'{self.rootpath} contains unexpected subdirectories: {self.subdirs}')
+            raise AssertionError(f'{self.rootpath} contains unexpected subdirectories: {self.subdirs}')
 
         summary_file = self.studypath / 'SUMMARY' / 'study-summary.json'
         self.name = path.name
@@ -247,7 +251,7 @@ class ProjectionRun:
         self.runinfo = json.load((self.rootpath / 'inputs' / 'runinfo.json').open('r'))
         self.confignames = {d.stem for d in (self.studypath / 'CONFIG').iterdir() if d.is_file()}
 
-    def classify_keys(self, run2: 'ProjectionRun')->dict:
+    def classify_keys(self, run2: 'ProjectionRun') -> dict:
         return classify_keys(self.summary_dict, run2.summary_dict)
 
     def statfilename(self, key: JobKey) -> str:
@@ -259,18 +263,21 @@ class ProjectionRun:
         val = json.load(statpath.open('r'))
         flat_operator_stats = []
         for opstat in val['operatorstats']:
-            flat_operator_stats.append(flatten_dict(opstat))
+            flat_operator_stats.append(flatten_dict_as_str(opstat))
         val['operatorstats'] = flat_operator_stats
         return val
 
 
 class StudyComparison:
-    def __init__(self, path1: Path, path2: Path, output_path: Path, epsilon: float, study: str) -> None:
+    def __init__(self, path1: Path, path2: Path, output_path: Path, epsilon: float, study: str,
+                 jinja2env: Jinja2Environment, flag_generate_html: bool) -> None:
         self.study = study
         self.run1 = ProjectionRun(path1, self.study)
         self.run2 = ProjectionRun(path2, self.study)
         self.epsilon = epsilon
         self.output_path = output_path
+        self.jinja2env = jinja2env
+        self.flag_generate_html = flag_generate_html
         os.makedirs(self.output_path, exist_ok=True)
         self.keys_classified = self.run1.classify_keys(self.run2)
 
@@ -282,8 +289,8 @@ class StudyComparison:
         config_status.update({cfg: {'status': ComparisonStatus.Only_in_1} for cfg in configs_only_in_1})
         config_status.update({cfg: {'status': ComparisonStatus.Only_in_2} for cfg in configs_only_in_2})
         for cfg in configs_common:
-            config1 = flatten_dict(json.load((self.run1.studypath / 'CONFIG' / f'{cfg}.json').open('r')))
-            config2 = flatten_dict(json.load((self.run2.studypath / 'CONFIG' / f'{cfg}.json').open('r')))
+            config1 = flatten_dict_as_str(json.load((self.run1.studypath / 'CONFIG' / f'{cfg}.json').open('r')))
+            config2 = flatten_dict_as_str(json.load((self.run2.studypath / 'CONFIG' / f'{cfg}.json').open('r')))
             config_status[cfg] = compare_dicts(config1, config2, self.epsilon)
         result = {
             'elem_status': config_status,
@@ -291,6 +298,187 @@ class StudyComparison:
         }
         return result
 
+    def generate_cfgsummaries(self, config_result: dict[str, Any], cfg_summary_path: Path) -> None:
+        if not self.flag_generate_html:
+            return
+        status_frequency: Counter = Counter()
+        cfgsummary_data = []
+        sr = 0
+        for cfg, cfgstatus in sorted(config_result['elem_status'].items()):
+            sr += 1
+            row = [sr, cfg, cfgstatus['rollup_status'].value, '']
+            cfgsummary_data.append(row)
+            status_frequency[cfgstatus['rollup_status']] += 1
+        cfgsummary_data_json = json.dumps(cfgsummary_data, indent=4)
+
+        jdict = {}
+        jdict['cfg_compare_result'] = config_result['rollup_status'].value
+        jdict['config_dataset'] = cfgsummary_data_json
+        jdict['config_columns'] = ['Sr', 'Config', 'Status', 'Link']
+        jdict['study_name'] = self.study
+        jdict['run1_name'] = self.run1.rootpath.stem
+        jdict['run2_name'] = self.run2.rootpath.stem
+        jdict['exact_matches'] = status_frequency[ComparisonStatus.Match]
+        jdict['approx_matches'] = status_frequency[ComparisonStatus.ApproxMatch]
+        jdict['mismatches'] = status_frequency[ComparisonStatus.Mismatch]
+        jdict['only_in_1_or_2'] = status_frequency[ComparisonStatus.Only_in_1] + status_frequency[ComparisonStatus.Only_in_2]
+        jdict['total'] = len(config_result['elem_status'])
+        cfgsummary_html = self.jinja2env.render('template-cfgsummary.html', jdict)
+        open(self.output_path / self.study / 'cfgsummary.html', 'w').write(cfgsummary_html)
+
+
+    def generate_jobsummaries_datatable(self, job_result: dict[str, Any], wl_compare_dtable: Path) -> None:
+        if not self.flag_generate_html:
+            return
+        status_frequency: Counter = Counter()
+        jobsummary_data = []
+        sr = 0
+        job_columns: list[str] = []
+        html_table_rows = []
+        html_table_header_row_1 = ['<th rowspan="2">Sr</th>', '<th rowspan="2">Job</th>', '<th rowspan="2">Status</th>']
+        html_table_header_row_2 = []
+        first_key = next((k for k in job_result['elem_status']))
+        first_jobstatus = job_result['elem_status'][first_key]
+        for col, colentry in first_jobstatus['elem_status'].items():
+            # Reduce length by 1 - since we do NOT add the "type" column
+            html_table_header_row_1.append(f'<th colspan="{len(first_jobstatus["elem_status"][col]) - 1}">{col}</th>')
+            for col2 in colentry:
+                html_table_header_row_2.append(f'<th>{col2}</th>')
+        for job, jobstatus in sorted(job_result['elem_status'].items()):
+            sr += 1
+            row = [sr, job, jobstatus['rollup_status'].value]
+            status_frequency[jobstatus['rollup_status']] += 1
+            elem_status = jobstatus['elem_status']
+            if job_columns == []:
+                job_columns.extend(['Sr', 'Job', 'Status'])
+                for col, colentry in elem_status.items():
+                    if col in ATTRIBUTES_TO_SKIP:
+                        continue
+                    first_flag = True
+                    for col2 in colentry:
+                        if col2 in ATTRIBUTES_TO_SKIP:
+                            continue
+                        if first_flag:
+                            job_columns.append(col + '&rarr;<br>' + col2)
+                            first_flag = False
+                        else:
+                            job_columns.append(col2)
+            for col, colentry in elem_status.items():
+                if col in ATTRIBUTES_TO_SKIP:
+                    continue
+                for col2, col2value in colentry.items():
+                    if col2 in ATTRIBUTES_TO_SKIP:
+                        continue
+                    if isinstance(col2value, ComparisonStatus):
+                        row.append(col2value.value)
+                    elif isinstance(col2value, float):
+                        row.append(f'{col2value:.3f}')
+                    else:
+                        row.append(str(col2value))
+                # row.extend([str(col2value) if not isinstance(col2value, ComparisonStatus) else col2value.value for col2, col2value in colentry.items()])
+            jobsummary_data.append(row)
+            html_table_rows.append('\n'.join(['<tr>'] + [f'<td>{x}</td>' for x in row] + ['</tr>']))
+            assert len(job_columns) == len(row)
+        html_header = '\n'.join(['<tr>'] + html_table_header_row_1 + ['</tr>', '<tr>'] + html_table_header_row_2 + ['</tr>'])
+        jobsummary_data_json = json.dumps(jobsummary_data, indent=4)
+
+        jdict = {}
+        jdict['job_compare_result'] = job_result['rollup_status'].value
+        jdict['job_dataset'] = jobsummary_data_json
+        jdict['job_html_header'] = html_header
+        jdict['job_html_body'] = '\n'.join(html_table_rows)
+        jdict['job_columns'] = job_columns
+        jdict['study_name'] = self.study
+        jdict['run1_name'] = self.run1.rootpath.stem
+        jdict['run2_name'] = self.run2.rootpath.stem
+        jdict['exact_matches'] = status_frequency[ComparisonStatus.Match]
+        jdict['approx_matches'] = status_frequency[ComparisonStatus.ApproxMatch]
+        jdict['mismatches'] = status_frequency[ComparisonStatus.Mismatch]
+        jdict['only_in_1_or_2'] = status_frequency[ComparisonStatus.Only_in_1] + status_frequency[ComparisonStatus.Only_in_2]
+        jdict['total'] = len(job_result['elem_status'])
+
+        jobsummary_html = self.jinja2env.render('template-jobsummary.html', jdict)
+        open(wl_compare_dtable, 'w').write(jobsummary_html)
+
+    def generate_jobsummaries_gchart(self, job_result: dict[str, Any], wl_compare_gchart_path: Path) -> None:
+        if not self.flag_generate_html:
+            return
+        attrname_2_desc = {attrdesc.name: attrdesc for ndx, attrdesc in enumerate(sorted(statattr.StatAttributeDescriptors.job_attribute_list, key=lambda x: x.seq))}
+        jdict: dict[str, Any] = {}
+        jdict['report_title'] = 'Comparison of Projections - Summary'
+        jdict['cwd'] = os.path.abspath(os.getcwd())
+        jdict['result_final'] = job_result['rollup_status'].value
+        jdict['epsilon'] = self.epsilon
+        jdict['run1_name'] = self.run1.rootpath.stem
+        jdict['run2_name'] = self.run2.rootpath.stem
+        jdict['epsilon_str'] = f'{self.epsilon:.3e}'
+        jdict['comparison_data'] = json.dumps(job_result, indent=4)
+        jdict['linkdir'] = (self.output_path / self.study / 'html').relative_to(self.output_path / self.study).as_posix()
+        jdict['attr_desc'] = json.dumps({attr: json.loads(model.model_dump_json()) for attr, model in attrname_2_desc.items()}, indent=4)
+        results = [jobstat['rollup_status'] == ComparisonStatus.Match for jobstat in job_result['elem_status'].values()]
+        jdict['num_rows'] = len(results)
+        jdict['num_matches'] = results.count(True)
+        jdict['num_mismatches'] = results.count(False)
+        jobsummary_html = self.jinja2env.render('template-cmpperf.html', jdict)
+        open(wl_compare_gchart_path, 'w').write(jobsummary_html)
+
+    def generate_comparison_gchart(self,
+                                   comparison_result: dict[str, Any],
+                                   leftname: str,
+                                   rightname: str,
+                                   attrlist: statattr.StatAttributeDescriptorList,
+                                   filepath:Path) -> None:
+        if not self.flag_generate_html:
+            return
+        attrname_2_desc = {attrdesc.name: attrdesc for ndx, attrdesc in enumerate(sorted(attrlist, key=lambda x: x.seq))}
+        jdict: dict[str, Any] = {}
+        jdict['report_title'] = 'Comparison of Layerwise Performance - ' + leftname.split('/')[-1]
+        jdict['cwd'] = os.path.abspath(os.getcwd())
+        jdict['result_final'] = comparison_result['rollup_status'].value
+        jdict['epsilon'] = self.epsilon
+        jdict['run1_name'] = leftname
+        jdict['run2_name'] = rightname
+        jdict['epsilon_str'] = f'{self.epsilon:.3e}'
+        jdict['comparison_data'] = json.dumps(comparison_result, indent=4)
+        jdict['attr_desc'] = json.dumps({attr: json.loads(model.model_dump_json()) for attr, model in attrname_2_desc.items()}, indent=4)
+        results = [jobstat['rollup_status'] == ComparisonStatus.Match for jobstat in comparison_result['elem_status'].values()]
+        jdict['num_rows'] = len(results)
+        jdict['num_matches'] = results.count(True)
+        jdict['num_mismatches'] = results.count(False)
+
+        comparison_html = self.jinja2env.render('template-cmpperf.html', jdict)
+        open(filepath, 'w').write(comparison_html)
+
+    def generate_topsummary(self, job_result: dict[str, Any],
+                            cfg_compare_html: Path,
+                            wl_compare_html: Path,
+                            output_html_path: Path) -> None:
+        if not self.flag_generate_html:
+            return
+        workload_result_list = [(entry['rollup_status'], entry['elem_status']['tot_cycles']['ratio']) for entry in job_result['elem_status'].values()]
+        stat_all = [tuple_entry[1] for tuple_entry in workload_result_list]
+        stat_mismatches = [tuple_entry[1] for tuple_entry in workload_result_list
+                           if tuple_entry[0] == ComparisonStatus.Mismatch]
+        all_geomean = statistics.geometric_mean(stat_all) if stat_all else None
+        all_stdev = statistics.stdev(stat_all) if len(stat_all) >= 2 else None
+        mismatch_geomean = statistics.geometric_mean(stat_mismatches) if stat_mismatches else None
+        mismatch_stdev = statistics.stdev(stat_mismatches) if len(stat_mismatches) >= 2 else None
+
+        final_result = job_result['rollup_status']
+        jdict: dict[str, Any] = {}
+        jdict['result_final'] = final_result.value
+        jdict['run1_name'] = self.run1.rootpath.stem
+        jdict['run2_name'] = self.run2.rootpath.stem
+        jdict['stats'] = json.dumps({
+            'all_geomean': all_geomean,
+            'all_stdev': all_stdev,
+            'mismatch_geomean': mismatch_geomean,
+            'mismatch_stdev': mismatch_stdev,
+        }, indent=4)
+        jdict['config_comparison_html'] = cfg_compare_html.relative_to(output_html_path.parent, walk_up=True).as_posix()
+        jdict['workload_comparison_html'] = wl_compare_html.relative_to(output_html_path.parent, walk_up=True).as_posix()
+        topsummary_html = self.jinja2env.render('template-projrun-summary.html', jdict)
+        open(output_html_path, 'w').write(topsummary_html)
 
     def compare_summary_dir(self) -> dict[str, Any]:
         os.makedirs(self.output_path / self.study, exist_ok=True)
@@ -328,8 +516,8 @@ class StudyComparison:
             if attrname.startswith('attrs_'):
                 return 'attrs'
             return 'fixed'
-        os.makedirs(self.output_path / self.study / 'csv', exist_ok=True)
-        os.makedirs(self.output_path / self.study / 'json', exist_ok=True)
+        for ext in ['csv', 'json'] + (['html'] if self.flag_generate_html else []):
+            os.makedirs(self.output_path / self.study / ext, exist_ok=True)
         keys_classified = self.keys_classified
         keys_common = keys_classified['keys_common']
         keys_only_in_1 = keys_classified['keys_only_in_1']
@@ -344,7 +532,7 @@ class StudyComparison:
         job_status.update({jobkey_2_str(k): {'rollup_status': ComparisonStatus.Only_in_2} for k in keys_only_in_2})
         for k in sorted(keys_common):
             kstr: str = jobkey_2_str(k)
-            logging.info('Comparing %s i.e. %s', k, kstr)
+            logging.info('Comparing %s', kstr)
             csv_table: list[dict[str, Any]] = []
             statdict1, statdict2 = self.run1.load_stat(k), self.run2.load_stat(k)
             jstat = compare_operator_stats(statdict1['operatorstats'], statdict2['operatorstats'], self.epsilon)
@@ -371,9 +559,15 @@ class StudyComparison:
             all_variable_keys = []
             for attrk in sorted(variable_keys):
                 all_variable_keys.extend(sorted(variable_keys[attrk]))
+
             print_csv(sorted(fixed_keys) + all_variable_keys, csv_table, self.output_path / self.study / 'csv' / f'{kstr}.csv')
             with open(output_filename, 'w') as fout:
                 json.dump(jstat, fout, indent=4)
+            self.generate_comparison_gchart(jstat,
+                                            self.run1.rootpath.stem + '/' + self.study + '/' + kstr,
+                                            self.run2.rootpath.stem + '/' + self.study + '/' + kstr,
+                                            statattr.StatAttributeDescriptors.op_attribute_list,
+                                            self.output_path / self.study / 'html' / f'{kstr}.html')
         result['rollup_status'] = rollup_status([job_status[k]['rollup_status'] for k in job_status])
         rollup_csv_table: list[dict[str, Any]] = []
         for jobname, jobentry in sorted(job_status.items()):
@@ -391,15 +585,24 @@ class StudyComparison:
         study_path1 = self.run1.studypath
         study_path2 = self.run2.studypath
         output_path_for_study = self.output_path / self.study
+        os.makedirs(output_path_for_study, exist_ok=True)
         if not study_path1.is_dir() or not study_path2.is_dir():
-            raise RuntimeError(f"Study Directory {self.study} not found in both project run directories")
-        logging.info("Comparing %s <-> %s", study_path1, study_path2)
+            raise AssertionError(f'Study Directory {self.study} not found in both project run directories')
+        logging.info('Comparing %s <-> %s', study_path1, study_path2)
 
         config_result = self.compare_config_dir()
+        config_compare_html = self.output_path / self.study / 'cfgsummary.html'
+        self.generate_cfgsummaries(config_result, config_compare_html)
 
         job_result = self.compare_summary_dir()
+        workload_compare_html_gchart = self.output_path / self.study / 'jobsummary.html'
+        workload_compare_html_dtable = self.output_path / self.study / 'jobsummary-dt.html'
+        self.generate_jobsummaries_gchart(job_result, workload_compare_html_gchart)
+        self.generate_jobsummaries_datatable(job_result, workload_compare_html_dtable)
 
         stat_result = self.compare_stat_dir()
+        topsummary_html = self.output_path / self.study / 'summary.html'
+        self.generate_topsummary(job_result, config_compare_html, workload_compare_html_gchart, topsummary_html)
 
         logging.info('status=%s', stat_result['rollup_status'])
         with open(output_path_for_study / 'config-comparison.json', 'w') as fout:
@@ -414,11 +617,15 @@ class StudyComparison:
 
 
 class ProjComparison:
-    def __init__(self, path1: Path, path2: Path, output_path: Path, epsilon: float) -> None:
+    def __init__(self, path1: Path, path2: Path,
+                 output_path: Path, epsilon: float, jinja2env: Jinja2Environment,
+                 flag_generate_html: bool) -> None:
         self.path1 = path1
         self.path2 = path2
         self.epsilon = epsilon
         self.output_path = output_path
+        self.jinja2env = jinja2env
+        self.flag_generate_html = flag_generate_html
         self.__setup__()
         os.makedirs(self.output_path, exist_ok=True)
 
@@ -427,26 +634,33 @@ class ProjComparison:
         path2_contents = [f1.stem for f1 in self.path1.iterdir()]
         common_contents = set(path1_contents) & set(path2_contents)
         if 'inputs' not in common_contents:
-            raise RuntimeError('inputs directory not found in the project run directories')
+            raise AssertionError('inputs directory not found in the project run directories')
+        if '.DS_Store' in common_contents:  # pragma: no cover
+            common_contents = common_contents - {'.DS_Store'}
         self.studies = common_contents - {'inputs'}
 
     def compare_studies(self) -> ComparisonStatus:
         results: list[ComparisonStatus] = []
         for study in self.studies:
-            study_comp = StudyComparison(self.path1, self.path2, self.output_path, self.epsilon, study)
+            study_comp = StudyComparison(self.path1, self.path2, self.output_path, self.epsilon,
+                                         study, self.jinja2env, self.flag_generate_html)
             results.append(study_comp.compare_study())
         return rollup_status(results)
 
 
-
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Comparing Performance Reports")
-    parser.add_argument('--output',  '-o',  required=True, metavar='<outfile>',       help="Output Directory")
-    parser.add_argument('--dir1',    '-d1', required=True, metavar='<perf-report-1>', help="Projection Report-1 (root directory of projection run)")
-    parser.add_argument('--dir2',    '-d2', required=True, metavar='<perf-report-2>', help="Projection Report-2 (root directory of projection run)")
-    parser.add_argument('--epsilon', '-e',  required=False, default=0.05, metavar='<error-bar>',     help="Error Bar(float), default=0.05, i.e. 5%%")
+    parser = argparse.ArgumentParser(description='Comparing Performance Reports')
+    parser.add_argument('--output',  '-o',  required=True, metavar='<outfile>', help='Output Directory')
+    parser.add_argument('--dir1',    '-d1', required=True, metavar='<perf-report-1>',
+                        help='Projection Run-1 (root directory of projection run)')
+    parser.add_argument('--dir2',    '-d2', required=True, metavar='<perf-report-2>',
+                        help='Projection Run-2 (root directory of projection run)')
+    parser.add_argument('--epsilon', '-e',  required=False, default=0.05, metavar='<error-bar>',
+                        help='Error Bar(float), default=0.05, i.e. 5%%')
+    parser.add_argument('--generate-html', '--html', dest='generate_html', action=argparse.BooleanOptionalAction,
+                        default=True, help='Generate HTML output')
 
-    if len(sys.argv) <= 1:
+    if len(sys.argv) <= 1:  # pragma: no cover
         parser.print_help(sys.stderr)
         sys.exit(1)
     args = parser.parse_args()
@@ -456,7 +670,9 @@ def main() -> int:
     path1 = Path(args.dir1)
     path2 = Path(args.dir2)
     output_path = Path(args.output)
-    cmp = ProjComparison(path1, path2, output_path, args.epsilon)
+    jinja2_env = Jinja2Environment()
+    statattr.StatAttributeDescriptors.setup_attribute_descriptors()
+    cmp = ProjComparison(path1, path2, output_path, args.epsilon, jinja2_env, args.generate_html)
     result = cmp.compare_studies()
     if result == ComparisonStatus.Match:
         return 0
@@ -464,5 +680,5 @@ def main() -> int:
         return 1
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     exit(main())

--- a/tools/js/cmputil.js
+++ b/tools/js/cmputil.js
@@ -1,0 +1,484 @@
+perfdata = null;
+
+function gchart_setup(loadopts)
+{
+  google.charts.load('current', loadopts);
+  google.charts.setOnLoadCallback(drawVisualization);
+}
+
+
+function savecsv(tbl, fname, proxyid)
+{
+    let hdrstr = tbl[0].join();
+    let datstr = tbl.slice(1).map(function(obj){
+        let rowstr = obj.join();
+        return rowstr;
+    }).join("\n");
+    let csvstr = hdrstr + "\n" + datstr + "\n";
+    let proxy = document.getElementById(proxyid);
+    proxy.download = fname;
+    proxy.href = 'data:application/csv;charset=utf-8,' + encodeURIComponent(csvstr);
+    proxy.target = '_blank';
+    proxy.click()
+}
+
+function type2jstype(tp)
+{
+    switch (tp) {
+        case "int":
+        case "float":
+            return "number";
+        case "bool":
+            return "boolean";
+        default:
+            return "string";
+    }
+}
+
+function show_specific_columns(cols)
+{
+    perfdata.cTableChart.setView({'columns': Array.from(cols).sort((a, b) => a-b)});
+    perfdata.bind_dashboard();
+}
+
+
+function toggle_catg(val, catg)
+{
+    let current_columns = new Set(perfdata.cTableChart.getView().columns);
+    let new_columns = null;
+    let colsets = perfdata.column_sets;
+    if (val.checked)
+    {
+        new_columns = current_columns.union(colsets[catg]);
+    }
+    else
+    {
+        new_columns = current_columns.difference(colsets[catg]).union(colsets['key']).union(colsets['always']);
+    }
+    show_specific_columns(new_columns);
+}
+
+function showall()
+{
+    document.getElementById('toggle_same_cb').checked = true;
+    document.getElementById('toggle_comp_cb').checked = true;
+    document.getElementById('toggle_mem_cb').checked = true;
+    show_specific_columns(perfdata.column_sets['all']);
+}
+
+class PerfData
+{
+    constructor(attr_desc, comparison_data, linkdir)
+    {
+        this.attr_desc = attr_desc;
+        this.comparison_data = comparison_data;
+        this.linkdir = linkdir;
+        this.attr_status_frequency = {};
+        this.is_attr_identical = {};
+        this.column_sets = {};
+        this.secondary_column_sets = {};
+        this.table_column_names = [];
+        this.table_rows = [];
+        this.colsummary_table_column_names = ['Colname', 'Seq', '#Matches', 'Total', 'Match?'];
+        this.colsummary_table_rows = [];
+        this.num_jobs = Object.keys(this.comparison_data['elem_status']).length;
+        this.update_numeric_attr();
+        this.update_attr_status_frequency();
+    }
+
+    update_numeric_attr()
+    {
+        // is_numeric is a "property" of the python structure, hence does NOT get saved
+        // Hence, we explicitly set this attribute.
+        for (let attr in this.attr_desc)
+        {
+            let desc = this.attr_desc[attr];
+            desc.is_numeric = desc.attrtype == 'int' || desc.attrtype == 'float';
+        }
+    }
+    update_attr_status_frequency()
+    {
+        let comparison_data = this.comparison_data;
+        let num_jobs = this.num_jobs;
+        this.attr_status_frequency = {};
+        for (let k in comparison_data['elem_status'])
+        {
+            let value = comparison_data['elem_status'][k];
+            for (let attr in value['elem_status'])
+            {
+                if (this.attr_status_frequency[attr] == undefined)
+                {
+                    this.attr_status_frequency[attr] = {};
+                }
+                let status = value['elem_status'][attr]['status'];
+                if (this.attr_status_frequency[attr][status] == undefined)
+                {
+                    this.attr_status_frequency[attr][status] = 0;
+                }
+                this.attr_status_frequency[attr][status] += 1;
+            }
+        }
+        this.is_attr_identical = {};
+        for (let attr in this.attr_status_frequency)
+        {
+            this.is_attr_identical[attr] = this.attr_status_frequency[attr]['match'] == num_jobs;
+        }
+    }
+
+
+    determine_column_sequence_for_attributes()
+    {
+        let is_attr_identical = this.is_attr_identical;
+        let attr_status_frequency = {};
+        this.column_sets = {};
+        let column_categories = ['all', 'key', 'perf', 'comp', 'mem', 'info', 'misc', 'same', 'diff', 'numeric', 'integer', 'always'];
+        this.column_filters = [];
+        let secondary_categories = ['ratios', 'diffs'];
+        for (let sndx = 0; sndx < column_categories.length; ++sndx )
+        {
+            this.column_sets[column_categories[sndx]] = new Set();
+        }
+        for (let sndx = 0; sndx < secondary_categories.length; ++sndx )
+        {
+            this.secondary_column_sets[secondary_categories[sndx]] = new Set();
+        }
+
+        this.table_column_names = ['Sr'];
+        this.column_sets['key'].add(0);
+        this.column_sets['all'].add(0);
+
+        this.entries_in_sequence = Object.entries(this.attr_desc).sort(function(a, b) {
+            return a[1].seq - b[1].seq;
+        });
+        let entries = this.entries_in_sequence;
+        let num_columns = 0;
+        let column_numbers_for_attr = {};
+        for (let i = 0; i < entries.length; i++) {
+            let desc = entries[i][1];
+            let is_identical = is_attr_identical[desc.name];
+            let num_cols_for_attr = is_identical ? 1 : desc.is_numeric ? 5 : 3;
+            let column_number_list = Array.from({length: num_cols_for_attr}, (_, j) => num_columns + 1 + j)
+            column_numbers_for_attr[desc.name]  = column_number_list;
+            let column_numbers = new Set(column_number_list);
+            num_columns += num_cols_for_attr;
+            let same_or_diff = is_identical ? 'same' : 'diff';
+            this.column_sets[same_or_diff] = this.column_sets[same_or_diff].union(column_numbers);
+
+            if (desc.is_numeric) {
+                let numtype = desc.attrtype == 'int' ? 'integer' : 'numeric';
+                if (is_identical)
+                {
+                    this.column_sets[numtype] = this.column_sets[numtype].union(column_numbers);
+                }
+                else
+                {
+                    // 0, 1, 3: numeric, 4: float
+                    this.column_sets[numtype].add(column_number_list[0]);
+                    this.column_sets[numtype].add(column_number_list[1]);
+                    this.column_sets[numtype].add(column_number_list[3]);
+                    this.column_sets['numeric'].add(column_number_list[4]);  // ratio can be float
+                    this.secondary_column_sets['diffs'].add(column_number_list[3]);
+                    this.secondary_column_sets['ratios'].add(column_number_list[4]);
+                }
+            }
+            this.column_sets[desc.catg] = this.column_sets[desc.catg].union(column_numbers);
+            this.column_sets['all'] = this.column_sets['all'].union(column_numbers);
+            let suffix = is_attr_identical[desc.name] ? '' : ''; // &check;
+            if (desc.is_filter) {
+                let name = desc.name;
+                if (is_attr_identical[desc.name]) {
+                    name += suffix;
+                }
+                // It is the label that seems to be used in filters?? TODO
+                if (desc.is_numeric) {
+                    this.column_filters.push([desc.label, 'NumberRangeFilter', is_attr_identical[desc.name], desc.label]);
+                } else {
+                    this.column_filters.push([desc.label, 'CategoryFilter', is_attr_identical[desc.name], desc.label]);
+                }
+            }
+            let jstype = type2jstype(desc.attrtype);
+            if (is_attr_identical[desc.name]) {
+                this.table_column_names.push({'label': desc.label + suffix, 'name': desc.name, 'type': jstype});
+            } else {
+                this.table_column_names.push({'label': desc.label + '_1', 'name': desc.name + '_1', 'type': jstype});
+                if (desc.is_numeric) {
+                    this.table_column_names.push({'label': desc.label + '_2', 'name': desc.name + '_2', 'type': jstype});
+                    this.table_column_names.push({'label': desc.label + '_result', 'name': desc.name + '_result', 'type': 'boolean'});
+                    this.table_column_names.push({'label': desc.label + '_diff', 'name': desc.name + '_diff', 'type': jstype});
+                    this.table_column_names.push({'label': desc.label + '_ratio', 'name': desc.name + '_ratio', 'type': jstype});
+                } else {
+                    this.table_column_names.push({'label': desc.label + '_2', 'name': desc.name + '_2', jstype});
+                    this.table_column_names.push({'label': desc.label + '_result', 'name': desc.name + '_result', 'type': 'boolean'});
+                }
+            }
+        }
+        if (this.linkdir != "")
+        {
+            this.table_column_names.push({'label': 'Link', 'name': 'link', 'type': 'string'});
+            this.column_sets['all'].add(num_columns + 1);
+            this.column_sets['always'].add(num_columns + 1);
+        }
+        let catg_toggle_checkboxes = ['same', 'comp', 'mem'];
+        let catg_toggle_checkboxes_title = {
+            'same': 'Identical',
+            'comp': 'Compute',
+            'mem' : 'Memory'
+        };
+        for (let i = 0; i < catg_toggle_checkboxes.length; ++i)
+        {
+            let catg = catg_toggle_checkboxes[i];
+            let checkbox = document.getElementById('toggle_' + catg);
+            let nn = this.column_sets[catg].difference(this.column_sets['key']).size
+            checkbox.innerHTML = `&nbsp;&nbsp;  ${catg_toggle_checkboxes_title[catg]} Columns (${nn})`; // backticks ` for interpolation
+        }
+    }
+
+    populate_comparison_table()
+    {
+        this.table_rows = [];
+        this.table_rows.push(this.table_column_names);
+        let sr = 0;
+        for (const [jobname, jobstatus] of Object.entries(this.comparison_data.elem_status))
+        {
+            sr += 1;
+            let row = [sr];
+            let elem_status = jobstatus['elem_status'];
+            for (let ndx = 0; ndx < this.entries_in_sequence.length; ndx++)
+            {
+                let col = this.entries_in_sequence[ndx][0];
+                let col_status = elem_status[col];
+                let col_desc = this.attr_desc[col];
+                if (this.is_attr_identical[col]) {
+                    row.push(col_status.value1);
+                } else {
+                    row.push(col_status.value1, col_status.value2, col_status.status == 'match' || col_status.status == 'approx_match');
+                    if (col_desc.is_numeric) {
+                        row.push(col_status.diff, col_status.ratio);
+                    }
+                }
+            }
+            if (this.linkdir != "")
+            {
+                row.push('<a href="' + this.linkdir + '/' + jobname + '.html' + '" target="_blank">Link</a>');
+            }
+            this.table_rows.push(row)
+            if (row.length != this.table_column_names.length) {
+                console.error('Error: ', row.length, this.table_column_names.length);
+                window.stop();
+            }
+        }
+    }
+
+    update_column_summary()
+    {
+        this.colsummary_table_rows = [];
+        this.colsummary_table_rows.push(this.colsummary_table_column_names);
+        for (const [colname, colmatches] of Object.entries(this.attr_status_frequency)) {
+            let coldesc = this.attr_desc[colname];
+            if (! coldesc)
+                continue;
+            let num_matches = colmatches['match'] || 0;
+            num_matches += colmatches['approx_match'] || 0;
+            this.colsummary_table_rows.push([colname, coldesc.seq, num_matches, this.num_jobs, num_matches == this.num_jobs])
+        }
+    }
+
+    setup_gchart_options()
+    {
+        this.tblcolSummaryOptions = {
+            'allowHtml'     : true,
+            'showRowNumber' : true,
+            'page'          : 'enable',
+            'pageSize'      : 5,
+            'frozenColumns' : 4,
+        };
+
+        this.tblChartOptions = {
+            'allowHtml'     : true,
+            'showRowNumber' : false,
+            'page'          : 'enable',
+            'pageSize'      : 10,
+            'frozenColumns' : this.column_sets['key'].size,
+        };
+        this.uioptions = {
+            'labelStacking'       : 'vertical',
+            'selectedValuesLayout': 'belowStacked'
+        };
+        this.uioptions_ratio = {
+            'labelStacking'       : 'vertical',
+            'selectedValuesLayout': 'belowStacked',
+            'unitIncrement'       : 0.05,
+            'blockIncrement'      : 0.1,
+        };
+        this.percentFormat    = new google.visualization.NumberFormat({fractionDigits: 2, suffix: "%"});
+        this.noDecimalFormat  = new google.visualization.NumberFormat({fractionDigits: 0});
+        this.twoDecimalFormat = new google.visualization.NumberFormat({fractionDigits: 2});
+        this.highlightFormat  = new google.visualization.ColorFormat();
+        this.highlightFormat.addRange(1-epsilon,1+epsilon,'white','green');
+        this.diffTwoDecimalFormat = new google.visualization.NumberFormat({negativeColor: 'red', fractionDigits: 2});
+    }
+
+    setup_filters()
+    {
+        let filters = this.column_filters;
+        let filter_divs_in_effect = Array();
+        if (filters.length == 0)
+        {
+            console.log('No filter attributes. The dashboard can not be shown.');
+            window.stop();
+        }
+        for(let i=0; i < filters.length; i++){
+            let filtertype = filters[i][1];
+            let filter_value_identical = filters[i][2];
+
+            filter_divs_in_effect.push('filter-' + i + '-div')
+            if (filtertype == 'CategoryFilter' && ! filter_value_identical) {
+                filter_divs_in_effect.push('filter-' + i + '-1-div');
+            }
+        }
+        let filterstr = filter_divs_in_effect.map(function(divname){
+            return '<div class="col-md-3" id="' + divname + '"></div>';
+        }).join('\n');
+        filterstr = '<div class="row">\n' + filterstr + '\n</div>\n';
+        document.getElementById('abs-stat-filter-div').innerHTML = filterstr;
+        this.filterObjs = [];
+        for(let i=0; i < filters.length; i++){
+            let origcolname    = filters[i][0];
+            let filtertype = filters[i][1];
+            let filter_value_identical = filters[i][2];
+            let colname_label = filters[i][3];
+            let options    = this.uioptions;
+            let colname = null;
+            if(filtertype == 'NumberRangeFilter' && ! filter_value_identical){
+                colname = origcolname + '_ratio';
+                options = this.uioptions_ratio;
+            }else{
+                colname = filter_value_identical ? origcolname : origcolname + '_1';
+                options = this.uioptions;
+            }
+            options = JSON.parse(JSON.stringify(options));
+            options.label = colname; // colname_label;
+            let filterdiv  = 'filter-' + i + '-div';
+            this.filterObjs.push(new google.visualization.ControlWrapper({
+                'controlType': filtertype,
+                'containerId': filterdiv,
+                'options': {
+                    'filterColumnLabel': colname,
+                    'ui': options
+                }}));
+            if (filtertype != 'NumberRangeFilter' && ! filter_value_identical) {
+                let colname = origcolname + '_result';
+                options = this.uioptions;
+                let filterdiv  = 'filter-' + i + '-1-div';
+                this.filterObjs.push(new google.visualization.ControlWrapper({
+                    'controlType': filtertype,
+                    'containerId': filterdiv,
+                    'options': {
+                        'filterColumnLabel': colname,
+                        'ui': this.uioptions
+                    }}));
+            }
+        }
+
+    }
+
+
+    setup_dashboard()
+    {
+        this.sDashBoard  = new google.visualization.Dashboard(document.getElementById('comparison-summary-dashboard-div'));
+        this.sTableChart = new google.visualization.ChartWrapper({
+            'chartType'  : 'Table',
+            'containerId': 'comparison-summary-tbl-div',
+            'options'    : this.tblcolSummaryOptions
+        });
+        this.sFilter = new google.visualization.ControlWrapper({
+            'controlType': 'CategoryFilter',
+            'containerId': 'comparison-summary-filter-div',
+            'options'    : { 'filterColumnLabel': 'Colname', 'ui': this.uioptions }
+        });
+        document.getElementById('colpagesize-dropdown').addEventListener('change', function() {
+            thius.tblcolSummaryOptions.setOption('pageSize', parseInt(this.value));
+            this.sTableChart.draw();
+        });
+
+        this.summaryDataTable  = google.visualization.arrayToDataTable(this.colsummary_table_rows,false);
+        this.summaryDataTable.sort([{'column': 1, 'desc': false}]);
+        this.sDashBoard.bind( [this.sFilter], this.sTableChart).draw(this.summaryDataTable);
+
+        this.cDashBoard  = new google.visualization.Dashboard(document.getElementById('abs-stat-dashboard-div'));
+        this.cTableChart = new google.visualization.ChartWrapper({
+            'chartType'  : 'Table',
+            'containerId': 'abs-stat-tbl-div',
+            'options'    : this.tblChartOptions
+        });
+        this.absDataTable  = google.visualization.arrayToDataTable(this.table_rows, false);
+        let htmltab = document.getElementById('filter-row-status-table');
+        htmltab.rows[0].cells[0].innerHTML = this.table_rows.length-1;
+        htmltab.rows[0].cells[2].innerHTML = this.table_rows.length-1;
+
+        let self = this;  // To be used in the callback functions
+        // The this passed as the second argument to the map, is the context = "this" for the function being called by map
+        Array.from(this.column_sets.numeric).map(function(c) { self.twoDecimalFormat.format(self.absDataTable, c) });
+        Array.from(this.column_sets.integer).map(function(c) { self.noDecimalFormat.format(self.absDataTable, c) });
+        Array.from(this.secondary_column_sets.ratios).map(function(c)    { self.highlightFormat.format(self.absDataTable, c)});
+        Array.from(this.secondary_column_sets.diffs).map(function(c)    { self.diffTwoDecimalFormat.format(self.absDataTable, c)});
+        google.visualization.events.addListener(this.cTableChart, 'ready', function() {
+            let htmltab = document.getElementById('filter-row-status-table');
+            htmltab.rows[0].cells[0].innerHTML = self.cTableChart.getDataTable().getNumberOfRows();
+        });
+        this.cTableChart.setView({'columns': Array.from(this.column_sets['all'])});
+    }
+
+    bind_dashboard()
+    {
+        let htmltab2 = document.getElementById('filter-column-status-table');
+        htmltab2.rows[0].cells[0].innerHTML = this.cTableChart.getView().columns.length;
+        htmltab2.rows[0].cells[2].innerHTML = this.column_sets['all'].size;
+        this.cDashBoard.bind(this.filterObjs, this.cTableChart ).draw(this.absDataTable);
+    }
+
+}
+
+function refreshVisualization()
+{
+}
+
+
+function drawVisualization()
+{
+    perfdata = new PerfData(attr_desc, comparison_data, linkdir);
+
+    perfdata.determine_column_sequence_for_attributes();
+    perfdata.populate_comparison_table();
+    perfdata.update_column_summary();
+    perfdata.setup_gchart_options();
+    perfdata.setup_filters();
+    perfdata.setup_dashboard();
+    perfdata.bind_dashboard();
+
+
+    /* TODO: Make sure this works even if no filters are specified by users
+       i.e. filterObjs array is empty */
+
+    /* TODO: GroupBy support
+    let grpDataTable = new google.visualization.data.group(absDataTable,[{ {grp_col} }],[
+            {column: { {grp1_col} }, aggregation:google.visualization.data.sum, type:'number'},
+            {column: { {grp2_col} }, aggregation:google.visualization.data.sum, type:'number'},
+    ]);
+
+    [0,1].map(function(c){ noDecimalFormat.format(grpDataTable,c);});-->
+    let xDashBoard  = new google.visualization.Dashboard(document.getElementById('abs-stat-summary-dashboard-div'));
+    let xTableChart = new google.visualization.ChartWrapper({
+        'chartType'  : 'Table',
+        'containerId': 'abs-stat-summary-tbl-div',
+        'options'    : tblChartOptions
+    });
+    let xFilter = new google.visualization.ControlWrapper({
+        'controlType': 'CategoryFilter',
+        'containerId': 'abs-stat-summary-title-div',
+        'options'    : { 'filterColumnLabel': { {filtercolname} }, 'ui': uioptions }
+    });
+    xDashBoard.bind( [ xFilter ], xTableChart ).draw(grpDataTable);
+    */
+
+  }

--- a/tools/parse_nv_mlperf_results.py
+++ b/tools/parse_nv_mlperf_results.py
@@ -148,7 +148,7 @@ class MLPerfTrainingLogParser:
 
             if self.stack.size() > 0:
                 __tmp_stack_top = self.stack.top() #to help mypy type checking
-                assert isinstance(__tmp_stack_top, dict), f"self.stack.top needs returned None!!"
+                assert isinstance(__tmp_stack_top, dict), "self.stack.top needs returned None!!"
                 parent_timestamp = __tmp_stack_top['timestamp']
                 parent_node = self.tree
                 for node in parent_node['intervals']:

--- a/tools/run_onnx_shape_inference.py
+++ b/tools/run_onnx_shape_inference.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import argparse
 import onnx
-from onnx import helper, shape_inference
+from onnx import shape_inference
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser('run_onnx_shape_inference')

--- a/tools/statattr.py
+++ b/tools/statattr.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 # SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
+import logging
 from typing import Any, Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 category_2_seq: dict[str, int] = {'key': 0, 'info': 1, 'perf': 2, 'comp': 3, 'mem': 4, 'cache': 5, 'misc': 6}
 
@@ -16,6 +17,7 @@ class StatAttributeDescriptor(BaseModel, extra='forbid'):
     catg: Literal['key', 'info', 'perf', 'comp', 'mem', 'cache', 'misc']
     prio: int
     is_filter: bool = False
+    label: str | None = None
 
     @property
     def is_numeric(self):
@@ -26,10 +28,12 @@ class StatAttributeDescriptor(BaseModel, extra='forbid'):
         return not self.is_numeric()
 
 
+type StatAttributeDescriptorList = list[StatAttributeDescriptor]
+
 
 class StatAttributeDescriptors():
-    job_attributes: list[StatAttributeDescriptor]
-    op_attributes: list[StatAttributeDescriptor]
+    job_attribute_list: StatAttributeDescriptorList
+    op_attribute_list: StatAttributeDescriptorList
 
     @classmethod
     def setup_attribute_descriptors(cls) -> None:
@@ -39,12 +43,12 @@ class StatAttributeDescriptors():
     @classmethod
     def setup_job_attribute_descriptors(cls) -> None:
         tmp_job_attributes_list: list[dict[str, Any]] = [
-            {'name': 'devname', 'catg':'key', 'prio':0, 'attrtype': 'str', 'is_filter': True},
-            {'name': 'freq_Mhz', 'catg':'key', 'prio':0, 'attrtype': 'float'},
-            {'name': 'wlcls', 'catg':'key', 'prio':0, 'attrtype': 'str', 'is_filter': True},
-            {'name': 'wlname', 'catg':'key', 'prio':0, 'attrtype': 'str', 'is_filter': True},
-            {'name': 'wlinstance', 'catg':'key', 'prio':0, 'attrtype': 'str'},
-            {'name': 'bs', 'catg':'key', 'prio':0, 'attrtype': 'int'},
+            {'name': 'devname', 'catg':'key', 'prio':0, 'attrtype': 'str', 'is_filter': True, 'label': 'Device'},
+            {'name': 'freq_Mhz', 'catg':'info', 'prio':0, 'attrtype': 'float', 'label': 'Freq'},
+            {'name': 'wlcls', 'catg':'info', 'prio':0, 'attrtype': 'str', 'is_filter': True, 'label': 'API'},
+            {'name': 'wlname', 'catg':'key', 'prio':0, 'attrtype': 'str', 'is_filter': True, 'label': 'Workload'},
+            {'name': 'wlinstance', 'catg':'key', 'prio':0, 'attrtype': 'str', 'label': 'WL/Instance'},
+            {'name': 'bs', 'catg':'info', 'prio':0, 'attrtype': 'int', 'label': 'Batch'},
             {'name': 'inParams', 'catg':'info', 'prio':1, 'attrtype': 'int'},
             {'name': 'inActs', 'catg':'info', 'prio':1, 'attrtype': 'int'},
             {'name': 'outActs', 'catg':'info', 'prio':1, 'attrtype': 'int'},
@@ -53,63 +57,74 @@ class StatAttributeDescriptors():
             {'name': 'inActBytes', 'catg':'mem', 'prio':1, 'attrtype': 'int'},
             {'name': 'outActBytes', 'catg':'mem', 'prio':1, 'attrtype': 'int'},
             {'name': 'maxActBytes', 'catg':'mem', 'prio':1, 'attrtype': 'int'},
-            {'name': 'tot_cycles', 'catg':'perf', 'prio':0, 'attrtype': 'int'},
-            {'name': 'tot_msecs', 'catg':'perf', 'prio':0, 'attrtype': 'float'},
+            {'name': 'tot_cycles', 'catg':'key', 'prio':0, 'attrtype': 'int', 'is_filter': True, 'label': 'Cycles'},
+            {'name': 'tot_msecs', 'catg':'perf', 'prio':0, 'attrtype': 'float', 'label': 'Time (ms)'},
             {'name': 'throughput', 'catg':'perf', 'prio':0, 'attrtype': 'float'},
-            {'name': 'mem_size_GB', 'catg':'info', 'prio':0, 'attrtype': 'float'},
-            {'name': 'device_mem_GB', 'catg':'info', 'prio':0, 'attrtype': 'float'},
+            {'name': 'mem_size_GB', 'catg':'info', 'prio':0, 'attrtype': 'float', 'label': 'Memory footprint (GB)'},
+            {'name': 'device_mem_GB', 'catg':'info', 'prio':0, 'attrtype': 'float', 'label': 'Device Memory (GB)'},
             {'name': 'fits_device', 'catg':'info', 'prio':0, 'attrtype': 'bool'},
-            {'name': 'rsrc_mem', 'catg':'perf', 'prio':0, 'attrtype': 'str', 'is_filter': True},
-            {'name': 'rsrc_comp', 'catg':'perf', 'prio':0, 'attrtype': 'str', 'is_filter': True},
+            {'name': 'rsrc_mem', 'catg':'perf', 'prio':0, 'attrtype': 'float', 'label': 'MemBound', 'is_filter': True},
+            {'name': 'rsrc_comp', 'catg':'perf', 'prio':0, 'attrtype': 'float', 'label': 'CmpBound', 'is_filter': True},
         ]
-        cls.job_attributes = [StatAttributeDescriptor(**x) for x in tmp_job_attributes_list]
-        StatAttributeDescriptors.update_attribute_descriptors(cls.job_attributes)
+        cls.job_attribute_list = [StatAttributeDescriptor(**x) for x in tmp_job_attributes_list]
+        StatAttributeDescriptors.update_attribute_descriptors(cls.job_attribute_list)
 
     @classmethod
     def setup_op_attribute_descriptors(cls) -> None:
         tmp_op_attributes_list: list[dict[str, Any]] = [
-            {'name': 'pipe',           'attrtype': 'str',   'catg': 'comp', 'prio': 0},
-            {'name': 'precision',      'attrtype': 'str',   'catg': 'comp', 'prio': 0},
-            {'name': 'opnum',          'attrtype': 'int',   'catg': 'key',     'prio': 0},
-            {'name': 'opname',         'attrtype': 'str',   'catg': 'info',    'prio': 0},
-            {'name': 'is_input_node',  'attrtype': 'bool',  'catg': 'info',    'prio': 0},
-            {'name': 'is_output_node', 'attrtype': 'bool',  'catg': 'info',    'prio': 0},
-            {'name': 'optype',         'attrtype': 'str',   'catg': 'info',    'prio': 0},
-            {'name': 'op_rpt_count',   'attrtype': 'int',   'catg': 'info',    'prio': 0},
-            {'name': 'attrs',          'attrtype': 'dict',  'catg': 'info',    'prio': 0},
-            {'name': 'inList',         'attrtype': 'list',  'catg': 'info',    'prio': 0},
-            {'name': 'outList',        'attrtype': 'list',  'catg': 'info',    'prio': 0},
-            {'name': 'domain',         'attrtype': 'str',   'catg': 'info',    'prio': 0},
-            {'name': 'opclass',        'attrtype': 'str',   'catg': 'info',    'prio': 0},
-            {'name': 'removed',        'attrtype': 'bool',  'catg': 'info',    'prio': 0},
-            {'name': 'fused',          'attrtype': 'bool',  'catg': 'info',    'prio': 0},
-            {'name': 'fused_with_op',  'attrtype': 'str',   'catg': 'info',    'prio': 0},
-            {'name': 'inElems',        'attrtype': 'int',   'catg': 'info',    'prio': 0},
-            {'name': 'outElems',       'attrtype': 'int',   'catg': 'info',    'prio': 0},
-            {'name': 'inBytes',        'attrtype': 'int',   'catg': 'mem',  'prio': 0},
-            {'name': 'outBytes',       'attrtype': 'int',   'catg': 'mem',  'prio': 0},
-            {'name': 'instrs',         'attrtype': 'dict',  'catg': 'comp', 'prio': 0},
-            {'name': 'inParamCount',   'attrtype': 'int',   'catg': 'info',    'prio': 0},
-            {'name': 'inActCount',     'attrtype': 'int',   'catg': 'info',    'prio': 0},
-            {'name': 'outActCount',    'attrtype': 'int',   'catg': 'info',    'prio': 0},
-            {'name': 'instr_count',    'attrtype': 'int',   'catg': 'comp', 'prio': 0},
-            {'name': 'compute_cycles', 'attrtype': 'float', 'catg': 'comp', 'prio': 0},
-            {'name': 'mem_rd_cycles',  'attrtype': 'float', 'catg': 'mem',  'prio': 0},
-            {'name': 'mem_wr_cycles',  'attrtype': 'float', 'catg': 'mem',  'prio': 0},
-            {'name': 'ramp_penalty',   'attrtype': 'float', 'catg': 'misc',    'prio': 0},
-            {'name': 'rsrc_bnck',      'attrtype': 'str',   'catg': 'perf',    'prio': 0},
-            {'name': 'cycles',         'attrtype': 'float', 'catg': 'perf',    'prio': 0},
-            {'name': 'msecs',         'attrtype': 'float',  'catg': 'perf',    'prio': 0}
+            {'name': 'opnum',          'attrtype': 'int',   'catg': 'key',   'prio': 0, 'label': 'Op#'},
+            {'name': 'opname',         'attrtype': 'str',   'catg': 'key',   'prio': 0, 'label': 'Op'},
+            {'name': 'pipe',           'attrtype': 'str',   'catg': 'comp',  'prio': 0, 'is_filter': True},
+            {'name': 'precision',      'attrtype': 'str',   'catg': 'comp',  'prio': 0},
+            {'name': 'is_input_node',  'attrtype': 'bool',  'catg': 'info',  'prio': 0, 'label': 'Is NW Input'},
+            {'name': 'is_output_node', 'attrtype': 'bool',  'catg': 'info',  'prio': 0, 'label': 'Is NW Output'},
+            {'name': 'optype',         'attrtype': 'str',   'catg': 'info',  'prio': 0, 'is_filter': True, 'label': 'Op Type'},
+            {'name': 'op_rpt_count',   'attrtype': 'int',   'catg': 'info',  'prio': 0, 'label': 'Op Rpt Count'},
+            {'name': 'attrs',          'attrtype': 'dict',  'catg': 'info',  'prio': 0, 'label': 'Attributes'},
+            {'name': 'inList',         'attrtype': 'list',  'catg': 'info',  'prio': 0},
+            {'name': 'outList',        'attrtype': 'list',  'catg': 'info',  'prio': 0},
+            {'name': 'domain',         'attrtype': 'str',   'catg': 'info',  'prio': 0},
+            {'name': 'opclass',        'attrtype': 'str',   'catg': 'info',  'prio': 0},
+            {'name': 'removed',        'attrtype': 'bool',  'catg': 'info',  'prio': 0, 'label': 'Is Removed'},
+            {'name': 'fused',          'attrtype': 'bool',  'catg': 'info',  'prio': 0, 'is_filter': True, 'label': 'Is Fused'},
+            {'name': 'fused_with_op',  'attrtype': 'str',   'catg': 'info',  'prio': 0, 'label': 'Fused With'},
+            {'name': 'inElems',        'attrtype': 'int',   'catg': 'info',  'prio': 0},
+            {'name': 'outElems',       'attrtype': 'int',   'catg': 'info',  'prio': 0},
+            {'name': 'inBytes',        'attrtype': 'int',   'catg': 'mem',   'prio': 0},
+            {'name': 'outBytes',       'attrtype': 'int',   'catg': 'mem',   'prio': 0},
+            {'name': 'instrs',         'attrtype': 'dict',  'catg': 'comp',  'prio': 0, 'label': 'Instructions'},
+            {'name': 'inParamCount',   'attrtype': 'int',   'catg': 'info',  'prio': 0},
+            {'name': 'inActCount',     'attrtype': 'int',   'catg': 'info',  'prio': 0},
+            {'name': 'outActCount',    'attrtype': 'int',   'catg': 'info',  'prio': 0},
+            {'name': 'instr_count',    'attrtype': 'int',   'catg': 'comp',  'prio': 0},
+            {'name': 'compute_cycles', 'attrtype': 'float', 'catg': 'comp',  'prio': 0, 'label': 'Compute Cycles'},
+            {'name': 'mem_rd_cycles',  'attrtype': 'float', 'catg': 'mem',   'prio': 0, 'label': 'Read Cycles'},
+            {'name': 'mem_wr_cycles',  'attrtype': 'float', 'catg': 'mem',   'prio': 0, 'label': 'Write Cycles'},
+            {'name': 'ramp_penalty',   'attrtype': 'float', 'catg': 'misc',  'prio': 0, 'label': 'Ramp Penalty'},
+            {'name': 'rsrc_bnck',      'attrtype': 'str',   'catg': 'perf',  'prio': 0, 'is_filter': True, 'label': 'Resource Bound'},
+            {'name': 'cycles',         'attrtype': 'float', 'catg': 'key',  'prio': 0, 'is_filter': True, 'label': 'Cycles'},
+            {'name': 'msecs',          'attrtype': 'float',  'catg': 'perf', 'prio': 0, 'label': 'Time (ms)'},
         ]
-        cls.op_attributes = [StatAttributeDescriptor(**x) for x in tmp_op_attributes_list]
-        StatAttributeDescriptors.update_attribute_descriptors(cls.op_attributes)
+        cls.op_attribute_list = []
+        for x in tmp_op_attributes_list:
+            try:
+                cls.op_attribute_list.append(StatAttributeDescriptor(**x))
+            except ValidationError:
+                logging.error('Invalid attribute descriptor for attribute %s', x)
+                raise
+        StatAttributeDescriptors.update_attribute_descriptors(cls.op_attribute_list)
 
     @staticmethod
     def update_attribute_descriptors(attrlist: list[StatAttributeDescriptor]) -> None:
         """
         Update the attribute descriptors, setting serial number (sr) and sequence number (seq)
         """
+        filter_attrs = [attrdesc.name for attrdesc in attrlist if attrdesc.is_filter]
+        if not filter_attrs:
+            raise NotImplementedError('comparison summary without any filter attribute not supported')
         for ndx, attrdesc in enumerate(attrlist):
             attrdesc.sr = ndx
+            if attrdesc.label is None:
+                attrdesc.label = attrdesc.name
         for ndx, attrdesc in enumerate(sorted(attrlist, key=lambda x: (category_2_seq[x.catg], x.prio, x.sr))):
             attrdesc.seq = ndx

--- a/tools/templates/template-cfgsummary.html
+++ b/tools/templates/template-cfgsummary.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Summary: Comparison of Performance Projections - Configurations</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Performance Comparison">
+    <meta name="author" content="Samvit Kaul; Shreeniwas Sapre">
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.js"></script>
+    <link href="https://nightly.datatables.net/css/dataTables.dataTables.css" rel="stylesheet" type="text/css" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-SgOJa3DmI69IUzQ2PVdRZhwQ+dy64/BUtbMJw1MZ8t5HZApcHrRKUc4W0kG879m7" crossorigin="anonymous">
+    <script type="text/javascript" src="https://cdn.datatables.net/2.2.2/js/dataTables.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js" integrity="sha384-I7E8VVD/ismYTF4hNIPjVp/Zjvgyol6VFvRkX/vR+Vc4jQkC+hVqc2pM8ODewa9r" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/js/bootstrap.min.js" integrity="sha384-VQqxDN0EQCkWoxt/0vsQvZswzTHUVOImccYmSyhJTp7kGtPed0Qcx8rK9h9YEgx+" crossorigin="anonymous"></script>  </body>
+</head>
+<body>
+  <div class="container-fluid"> <!-- toplevel container -->
+    <h1 style="text-align:center;">Comparison of Performance Projection Run: Configurations</h1>
+    <table id="cfgheader" class="display" style="width:100%" border="1"></table>
+    <table id="cfgsummary" class="display" style="width:100%" border="1"></table>
+
+  <script type="text/javascript">
+    var config_columns = {{ config_columns }};
+    var config_column_structure = config_columns.map(function(column) {
+        return { title: column };
+    });
+    var config_dataset = {{config_dataset}};
+
+    var hdrtable = new DataTable('#cfgheader', {
+        columns: [
+            { title: 'Projection Run1' },
+            { title: 'Projection Run2' },
+            { title: 'Study' },
+            { title: 'Config Comparison Result' },
+            { title: 'Exact Matches' },
+            { title: 'Matches Within Threshold' },
+            { title: 'Misatches' },
+            { title: 'Only in 1 or 2'},
+            { title: 'Total' }
+        ],
+        data: [
+            ['{{ run1_name }}', '{{ run2_name }}', '{{ study_name }}', '{{ cfg_compare_result }}',
+             '{{ exact_matches }}', '{{ approx_matches }}', '{{ mismatches }}', '{{ only_in_1_or_2 }}',
+             '{{ total }}' ]
+        ],
+        paging: false,
+        searching: false,
+        ordering: false,
+        info: false,
+        lengthChange: false
+    });
+
+    var table = new DataTable('#cfgsummary', {
+        columns: config_column_structure,
+        data: config_dataset,
+        lengthMenu: [
+            [10, 25, 50, -1],
+            [10, 25, 50, 'All']
+	]
+      }
+    );
+  </script>
+  </div>
+</body>
+</html>

--- a/tools/templates/template-cmpperf.html
+++ b/tools/templates/template-cmpperf.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{{report_title}}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Performance Analysis">
+  <meta name="author" content="Samvit Kaul; Shreeniwas Sapre">
+
+  <!-- JQUERY -->
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+
+  <!-- BOOTSTRAP -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-SgOJa3DmI69IUzQ2PVdRZhwQ+dy64/BUtbMJw1MZ8t5HZApcHrRKUc4W0kG879m7" crossorigin="anonymous">
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/js/bootstrap.bundle.min.js" integrity="sha384-k6d4wzSIapyDyv1kpU366/PK5hCdSbCRGRCMv+eplOQJWyd1fbcAu9OCUj5zNLiq" crossorigin="anonymous"></script>
+
+  <!-- GOOGLE VISUALIZATION -->
+  <script type="text/javascript" src='{{cwd}}/tools/js/cmputil.js'></script>
+  <script type="text/javascript" src='https://www.gstatic.com/charts/loader.js'></script>
+  <script type="text/javascript">
+    var comparison_data = {{comparison_data}};
+    var attr_desc = {{attr_desc}};
+    var epsilon = {{epsilon}};
+    {% if linkdir is not defined %}
+    {% set linkdir = "" %}
+    {% endif %}
+    var linkdir = "{{linkdir}}";
+    gchart_setup({packages:["corechart","table","controls"]});
+  </script>
+</head>
+
+<body>
+  <div class="container-fluid"> <!-- toplevel container -->
+    <div class="row-fluid"> <!-- toplevel-1 -->
+    <h1 style="text-align: center">{{report_title}}</h1>
+
+    <table class="table table-striped table-bordered" style="width: fit-content;">
+        <tbody>
+            <tr><th>Run 1</th>                       <td><pre>{{run1_name}}</pre></td></tr>
+            <tr><th>Run 2</th>                       <td><pre>{{run2_name}}</pre></td></tr>
+            <tr><th>&epsilon; for numeric ratios</th><td>{{epsilon_str}}</td></tr>
+            <tr><th>Matches</th>                     <td>{{num_matches}} &#x2714; + {{num_mismatches}} &#x2718;
+                = {{num_rows}}</td></tr>
+            <tr><th>Result</th>
+                <td>
+                    {% if result_final == "match" %}
+                    &#x2714;
+                    {% else %}
+                    &#x2718;
+                    {% endif %}
+                </td></tr>
+        </tbody>
+    </table>
+
+    <hr style="width: 100%; height: 3px; background-color: #000000;">
+    <h2> Comparison Summary</h2>
+    <div id="comparison-summary-title-div"></div>
+    <div id="comparison-summary-dashboard-div">
+        <div id="comparison-summary-filter-div"></div>
+        <div id="comparison-summary-pagesize-div">
+            Page Size:
+            <select name="Pagesize" id="colpagesize-dropdown">
+                <option value="5">5</option>
+                <option value="10">10</option>
+                <option value="25">25</option>
+            </select>
+        </div>
+        <div id="comparison-summary-tbl-div"></div>
+    </div>
+
+<!--TODO BEGIN>
+    <HR>
+    <h2> Summary Grouped By({ {filtercolname} })</h2>
+    <div id="abs-stat-summary-title-div"></div>
+        <div id="abs-stat-summary-dashboard-div">
+        <div id="abs-stat-summary-tbl-div"></div>
+    </div>
+<TODO END-->
+
+
+    <hr style="width: 100%; height: 1px; background-color: #000000;">
+    <h2> Details </h2>
+    <div id="abs-stat-title-div"></div>
+    <br>
+    <div id="save-as-csv" class="row">
+        <div class="col-2">
+            <button onclick="savecsv1(abs_val_table, 'save.csv', 'saveproxy');">Export Data As CSV</button>
+            <a href="#" id="saveproxy" style="visibility: hidden"></a>
+        </div>
+        <div class="col-1">
+            <table id="filter-row-status-table">
+              <tbody>
+                <tr>
+                    <td></td>
+                    <td>/</td>
+                    <td></td>
+                    <td>selected</td>
+                </tr>
+              </tbody>
+            </table>
+        </div>
+        <div class="col-1">
+            <table id="filter-column-status-table">
+              <tbody>
+                <tr>
+                    <td></td>
+                    <td>/</td>
+                    <td></td>
+                    <td>columns</td>
+                </tr>
+              </tbody>
+            </table>
+        </div>
+        <div class="col-1">
+            <!-- Intentionally blank for spacing -->
+        </div>
+        <div class="col-7">
+            <table id="actionbuttons" width="75%">
+              <tbody>
+                <tr>
+                    <td><input type="checkbox" checked onclick="toggle_catg(this, 'same');" id="toggle_same_cb"><label id="toggle_same" for="toggle_same_cb">Identical Columns</label></td>
+                    <td><input type="checkbox" checked onclick="toggle_catg(this, 'comp');" id="toggle_comp_cb"><label id="toggle_comp" for="toggle_comp_cb">Compute Columns</label></td>
+                    <td><input type="checkbox" checked onclick="toggle_catg(this, 'mem');" id="toggle_mem_cb"><label id="toggle_mem"   for="toggle_mem_cb">Memory Columns</label></td>
+                    <td><button onclick="showall();">All Columns</button></td>
+                    <td></td>
+                </tr>
+              </tbody>
+            </table>
+        </div>
+    </div>
+    <hr style="width: 100%; height: 1px; background-color: #000000;">
+    <div id="abs-stat-dashboard-div">
+        <div id="abs-stat-filter-div"></div><br>
+        <div id="abs-stat-tbl-div"></div>
+    </div>
+
+    </div> <!-- toplevel-1 -->
+  </div> <!-- toplevel container -

--- a/tools/templates/template-jobsummary.html
+++ b/tools/templates/template-jobsummary.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Summary: Comparison of Performance Projections - Jobs</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Performance Comparison">
+    <meta name="author" content="Shreeniwas Sapre, Samvit Kaul">
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.js"></script>
+    <link href="https://nightly.datatables.net/css/dataTables.dataTables.css" rel="stylesheet" type="text/css" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-SgOJa3DmI69IUzQ2PVdRZhwQ+dy64/BUtbMJw1MZ8t5HZApcHrRKUc4W0kG879m7" crossorigin="anonymous">
+    <script type="text/javascript" src="https://cdn.datatables.net/2.2.2/js/dataTables.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js" integrity="sha384-I7E8VVD/ismYTF4hNIPjVp/Zjvgyol6VFvRkX/vR+Vc4jQkC+hVqc2pM8ODewa9r" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/js/bootstrap.min.js" integrity="sha384-VQqxDN0EQCkWoxt/0vsQvZswzTHUVOImccYmSyhJTp7kGtPed0Qcx8rK9h9YEgx+" crossorigin="anonymous"></script>  </body>
+</head>
+<body>
+  <div class="container-fluid"> <!-- toplevel container -->
+    <h1 style="text-align:center;">Comparison of Performance Projection Run: Jobs</h1>
+    <table id="jobheader" class="display" style="width:100%" border="1"></table>
+    <table id="jobsummary" class="display" style="width:100%" border="1"></table>
+
+  <script type="text/javascript">
+    var job_columns = {{ job_columns }};
+    var job_column_structure = job_columns.map(function(column) {
+        return { title: column };
+    });
+    var hdrtable = new DataTable('#jobheader', {
+        columns: [
+            { title: 'Projection Run1' },
+            { title: 'Projection Run2' },
+            { title: 'Study' },
+            { title: 'Job Comparison Result' },
+            { title: 'Exact Matches' },
+            { title: 'Matches Within Threshold' },
+            { title: 'Misatches' },
+            { title: 'Only in 1 or 2'},
+            { title: 'Total' }
+        ],
+        data: [
+            [ '{{ run1_name }}', '{{ run2_name }}', '{{ study_name }}', '{{ job_compare_result }}',
+             '{{ exact_matches }}', '{{ approx_matches }}', '{{ mismatches }}', '{{ only_in_1_or_2 }}',
+             '{{ total }}' ]
+        ],
+        paging: false,
+        searching: false,
+        ordering: false,
+        info: false,
+        lengthChange: false
+    });
+
+    var job_dataset = {{ job_dataset }};
+    var table = new DataTable('#jobsummary', {
+        columns: job_column_structure,
+        data: job_dataset,
+        lengthMenu: [
+            [10, 25, 50, -1],
+            [10, 25, 50, 'All']
+	]
+      }
+    );
+  </script>
+</body>
+</html>

--- a/tools/templates/template-projrun-summary.html
+++ b/tools/templates/template-projrun-summary.html
@@ -2,31 +2,94 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title> Comparison of Performance Projection Runs </title>
+  <title>Comparison of Performance Projection Runs</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Comparison of Performance Projection Runs">
   <meta name="author" content="Samvit Kaul; Shreeniwas Sapre">
 
   <!-- BOOTSTRAP -->
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css">
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-SgOJa3DmI69IUzQ2PVdRZhwQ+dy64/BUtbMJw1MZ8t5HZApcHrRKUc4W0kG879m7" crossorigin="anonymous">
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/js/bootstrap.bundle.min.js" integrity="sha384-k6d4wzSIapyDyv1kpU366/PK5hCdSbCRGRCMv+eplOQJWyd1fbcAu9OCUj5zNLiq" crossorigin="anonymous"></script>
+  <script type="text/javascript" src='https://www.gstatic.com/charts/loader.js'></script>
+  <script type="text/javascript">
+  let stats = {{stats}};
+    function drawtable()
+    {
+        let result_array = [
+            ['Run1', '{{run1_name}}'],
+            ['Run2', '{{run2_name}}'],
+            ['Result', '{{result_final}}'],
+            ['Configs', '<a href="{{config_comparison_html}}" target="_blank">Config Comparison</a>'],
+            ['Workload Projections', '<a href="{{workload_comparison_html}}" target="_blank">Workload Projection Comparison</a>']
+        ];
+        let stats_array = [];
+        if (stats.all_geomean != null || stats.all_stdev != null ||
+            stats.mismatch_geomean != null || stats.mismatch_stdev != null)
+        {
+            stats_array.push(['Workload-Category', 'Metric', 'Value']);
+        }
+        if (stats.all_geomean != null)
+        {
+            stats_array.push(['All workloads', 'Geomean', stats.all_geomean.toFixed(2)]);
+        }
+        if (stats.all_stdev != null)
+        {
+            stats_array.push(['All workloads', 'Stdev', stats.all_stdev.toFixed(2)]);
+        }
+        if (stats.mismatch_geomean != null)
+        {
+            stats_array.push(['Mismatching workloads', 'Geomean', stats.mismatch_geomean.toFixed(2)]);
+        }
+        if (stats.mismatch_stdev != null)
+        {
+            stats_array.push(['Mismatching workloads', 'Stdev', stats.mismatch_stdev.toFixed(2)]);
+        }
+        let table = google.visualization.arrayToDataTable(result_array, true);
+        let table_div = document.getElementById('summary');
+        let chart = new google.visualization.ChartWrapper({
+            'chartType'  : 'Table',
+            'containerId': 'summary',
+            'dataTable': table,
+            'options': {
+              'allowHtml'     : true,
+              'showRowNumber' : false,
+            }
+        });
+        chart.draw();
+        if (stats_array.length > 0)
+        {
+            let stats_table = google.visualization.arrayToDataTable(stats_array, false);
+            let stats_div = document.getElementById('ratios');
+            let stats_chart = new google.visualization.ChartWrapper({
+                'chartType'  : 'Table',
+                'containerId': 'ratios',
+                'dataTable': stats_table,
+                'options': {
+                  'allowHtml'     : true,
+                  'showRowNumber' : false,
+                }
+            });
+            stats_chart.draw();
+        }
+    }
+  google.charts.load('current', {packages:["corechart","table","controls"]});
+  google.charts.setOnLoadCallback(drawtable);
+  </script>
 
 </head>
 
 <body>
   <div class="container"> <!-- toplevel container -->
-    <h1><center>Comparison of Performance Projection Run: Summary</center></h1>
-
-    <table class="table table-striped table-bordered">
-        <thead>
-            {{header_rows}}
-        </thead>
-        <tbody>
-            {{status_rows}}
-        </tbody>
-    </table>
-
+    <h1>Comparison of Performance Projection Run: Summary</h1>
+    <br>
+      <div id="summary">
+      </div>
+    <br>
+    <h1>Ratio of run2 time / run1 time - summary</h1>
+    <br>
+      <div id="ratios">
+      </div>
   </div> <!-- toplevel container -->
 </body>
 </html>


### PR DESCRIPTION
* Add html output support for compare_projections.py
* Add pattern for ordinary files beginning with __ to .gitignore
* Add pattern for private/ directory to .gitignore
* Visualization logic is in javascript rather than python
* Change div by 0 to be 0 instead of inf. inf value causes issues in NumberRangeFilter
* Add linkdir to comparison output. Linkdir enables the JS model to auto-generate links to the stat html files from the summary html.
* Update Stat Attributes to ensure few columns (frozen) are marked as key
* Show # filtered / # total entries on HTML visualization
* Custom report title
* Summary in column sequence order
* The # matches/mismatches in top summary
* Ability to hide same, comp, mem columns
* --generate-html knob to enable / disable html generation
* Comparison html categories toggled by checkboxes
* Added unit tests for projection comparison
* Enabled collection of coverage data for subprocesses called from tests in checkin_tests as well CI coverage action (added "coverage combine")