### PR TITLE
Fix: Correct argument naming and description

### DIFF
--- a/polaris.py
+++ b/polaris.py
@@ -291,7 +291,7 @@ def setup_cmdline_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument('--batchsize', nargs=3, metavar=('start', 'end', 'step'), type=int,
                         action='append', help='batchsize range specification (geom-seq)')
     parser.add_argument('--outputformat', choices=['none', 'yaml', 'json', 'pickle'], default='json', type=str.lower)
-    parser.add_argument('--dumpstatscsv', dest='dump_stats_csv', action='store_true', 
+    parser.add_argument('--dump_stats_csv', dest='dump_stats_csv', action='store_true', 
                         default=False, help='Dump stats in CSV format')
 
     #cmdline args processing

--- a/ttsim/config/runcfgmodel.py
+++ b/ttsim/config/runcfgmodel.py
@@ -14,7 +14,7 @@ type TYPE_batchsize = Tuple[int, int, int]
 
 class PolarisRunConfig(BaseModel, extra='forbid'):
     # Title is used only in the run config, it is not a command line attribute of polaris
-    title: str = Field(description='Human readable itle for the run')
+    title: str = Field(description='Human readable title for the run')
 
     # Attributes corresponding to polaris command line options
     odir: str = Field(


### PR DESCRIPTION
* Update command line argument from '--dumpstatscsv' to '--dump_stats_csv' for consistency.
* Fix typo in the description of the 'title' field in PolarisRunConfig from 'itle' to 'title'.

This pull request contains minor corrections to improve code clarity and usability. The changes address a typo in a field description and update a command-line argument name for consistency.

Documentation and naming improvements:

* Fixed a typo in the `title` field description in `ttsim/config/runcfgmodel.py` ("itle" → "title").
* Renamed the `--dumpstatscsv` command-line argument to `--dump_stats_csv` in the `setup_cmdline_args` function in `polaris.py` for consistency with naming conventions.