### PR TITLE
UNet fixes for generating Polaris projections

### DIFF
--- a/config/ip_workloads.yaml
+++ b/config/ip_workloads.yaml
@@ -49,6 +49,13 @@ workloads:
       bevdepth_l : { img_height: 1024, img_width: 1024, img_channels: 3, bs: 1 }
 
   - api: TTSIM
+    name: UNet
+    basedir: workloads/UNet
+    module : UNet@unet_model.py
+    instances:
+      unet_b1 : {'n_channels': 3, 'n_classes': 2, 'img_size': 256, 'bilinear': False, 'bs': 1}
+
+  - api: TTSIM
     name: llama2
     basedir: workloads/llama2
     module : Transformer@model.py

--- a/config/wl2archmapping.yaml
+++ b/config/wl2archmapping.yaml
@@ -39,10 +39,10 @@ op_fusion_spec:
 
 op_rsrc_spec:
   compute:
-    matrix: [Matmul, Conv]
+    matrix: [Matmul, Conv, ConvTranspose]
     vector: [Gather, Reshape, Transpose, Gelu, Relu, LeakyRelu, Resize, Sigmoid, Slice,
              Flatten, ReduceMax, ArgMax, Cast, NonMaxSuppression, Add, Sub, Mul, Div,
              Dropout, Split, Softmax, LayerNormalization, Identity, Constant, Where,
              Pow, Tanh, MaxPool, BatchNormalization, Concat, Unsqueeze, Squeeze, Trilu,
-             AveragePool, Tile, VoxelPooling, Mean, Sqrt, Reciprocal
+             AveragePool, Tile, VoxelPooling, Mean, Sqrt, Reciprocal, Pad,
             ]

--- a/ttsim/ops/op.py
+++ b/ttsim/ops/op.py
@@ -2895,7 +2895,7 @@ class PadOp(SimOp):
         nElem_out = np.prod(output_shape)
         instr_count = {'mov': nElem_in}
         if mode == 'constant':
-            instr_count['fill'] = nElem_out - nElem_in
+            instr_count['mov'] = nElem_out - nElem_in
         else:
             instr_count['mov'] = nElem_out
 

--- a/workloads/UNet/test_unet.py
+++ b/workloads/UNet/test_unet.py
@@ -8,18 +8,19 @@ import ttsim.front.functional.op as F
 from workloads.UNet.unet_model import UNet
 
 def test_unet_forward_random():
-    n_channels = 3
-    n_classes = 2
-    img_size = 256
-    bilinear = False
+    cfg = {'n_channels': 3, 'n_classes': 2, 'img_size': 256, 'bilinear': False}
+    n_channels = cfg['n_channels']
+    n_classes = cfg['n_classes']
+    img_size = cfg['img_size']
+    bilinear = cfg['bilinear']
 
-    x = F._from_shape(name='input_tensor', shape=[2, n_channels, img_size, img_size])
+    x = F._from_shape(name='input_tensor', shape=[n_classes, n_channels, img_size, img_size])
     print(f'bilinear is {bilinear}')
-    model = UNet('unet', n_channels, n_classes, bilinear=bilinear)
+    model = UNet('unet', cfg)
     model.create_input_tensors()
-    out = model(x)
+    out = model()
     print(f'output shape is {out.shape}')
-    assert out.shape[0] == 2
+    assert out.shape[0] == n_classes
     assert out.shape[1] == n_classes
     assert out.shape[2] == img_size and out.shape[3] == img_size
     print('UNet test passed!')

--- a/workloads/UNet/unet_model.py
+++ b/workloads/UNet/unet_model.py
@@ -11,29 +11,30 @@ import ttsim.front.functional.sim_nn as SimNN
 from workloads.UNet.unet_parts import *
 
 class UNet(SimNN.Module):
-    def __init__(self, objname, n_channels, n_classes, bilinear=False):
+    def __init__(self, objname, cfg):
         super().__init__()
         self.name = objname
-        self.n_channels = n_channels
-        self.n_classes = n_classes
-        self.bilinear = bilinear
+        self.n_channels = cfg['n_channels']
+        self.n_classes = cfg['n_classes']
+        self.bilinear = cfg['bilinear']
+        self.img_size = cfg['img_size']
 
-        self.inc = (DoubleConv(f'{self.name}_DoubleConv', n_channels, 64))
+        self.inc = (DoubleConv(f'{self.name}_DoubleConv', self.n_channels, 64))
         self.down1 = (Down(f'{self.name}_Down1', 64, 128))
         self.down2 = (Down(f'{self.name}_Down2', 128, 256))
         self.down3 = (Down(f'{self.name}_Down3', 256, 512))
-        factor = 2 if bilinear else 1
+        factor = 2 if self.bilinear else 1
         self.down4 = (Down(f'{self.name}_Down4', 512, 1024 // factor))
-        self.up1 = (Up(f'{self.name}_Up1', 1024, 512 // factor, bilinear))
-        self.up2 = (Up(f'{self.name}_Up2', 512, 256 // factor, bilinear))
-        self.up3 = (Up(f'{self.name}_Up3', 256, 128 // factor, bilinear))
-        self.up4 = (Up(f'{self.name}_Up4', 128, 64, bilinear))
-        self.outc = (OutConv(f'{self.name}_OutConv', 64, n_classes))
+        self.up1 = (Up(f'{self.name}_Up1', 1024, 512 // factor, self.bilinear))
+        self.up2 = (Up(f'{self.name}_Up2', 512, 256 // factor, self.bilinear))
+        self.up3 = (Up(f'{self.name}_Up3', 256, 128 // factor, self.bilinear))
+        self.up4 = (Up(f'{self.name}_Up4', 128, 64, self.bilinear))
+        self.outc = (OutConv(f'{self.name}_OutConv', 64, self.n_classes))
         super().link_op2module()
 
     def create_input_tensors(self):
         self.input_tensors = {
-                'x_in': F._from_shape('input_tensor', shape=[2, 3, 128, 128]),
+                'x_in': F._from_shape('input_tensor', shape=[self.n_classes, self.n_channels, self.img_size, self.img_size]),
                 }
         return
 


### PR DESCRIPTION
This PR fixes UNet code to generate perf projections using Polaris flow. Command:

```
$  python polaris.py -w config/ip_workloads.yaml -a config/all_archs.yaml -m config/wl2archmapping.yaml --filterarch Q1_A1 --filterwlg TTSIM  --filterwl UNet -o ODDIR_UNet -s SIMPLE_RUN --outputformat json    
```