### PR TITLE
llama2 changes for generating Polaris projections

### DIFF
--- a/config/all_archs.yaml
+++ b/config/all_archs.yaml
@@ -27,6 +27,7 @@ ipblocks:
             -   {name: tanh,  tpt: {int8: 128.,  int32: 32., fp32: 32. }}
             -   {name: log,   tpt: {int8: 128.,  int32: 32., fp32: 32. }}
             -   {name: exp,   tpt: {int8: 128.,  int32: 32., fp32: 32. }}
+            -   {name: sqrt,  tpt: {int8: 128.,  int32: 32., fp32: 32. }}
             -   {name: rsqrt, tpt: {int8: 128.,  int32: 32., fp32: 32. }}
             -   {name: cmp,   tpt: {int8: 128.,  int32: 32., fp32: 32. }}
             -   {name: mov,   tpt: {int8: 128.,  int32: 32., fp32: 32. }}

--- a/config/ip_workloads.yaml
+++ b/config/ip_workloads.yaml
@@ -47,3 +47,11 @@ workloads:
       bevdepth_s : { img_height:   32, img_width:   32, img_channels: 3, bs: 1 }
       bevdepth_m : { img_height:  256, img_width:  256, img_channels: 3, bs: 1 }
       bevdepth_l : { img_height: 1024, img_width: 1024, img_channels: 3, bs: 1 }
+
+  - api: TTSIM
+    name: llama2
+    basedir: workloads/llama2
+    module : Transformer@model.py
+    instances:
+      input_small: {'dim': 32, 'n_layers': 2, 'n_heads': 2, 'vocab_size': 256, 'max_batch_size': 2, 'max_seq_len': 8, 'seq_len': 1, 'bs': 1}
+      input_standard: {'dim': 4096, 'n_layers': 32, 'n_heads': 32, 'vocab_size': 32000, 'max_batch_size': 2, 'max_seq_len': 8, 'seq_len': 1, 'bs': 1}

--- a/config/wl2archmapping.yaml
+++ b/config/wl2archmapping.yaml
@@ -44,5 +44,5 @@ op_rsrc_spec:
              Flatten, ReduceMax, ArgMax, Cast, NonMaxSuppression, Add, Sub, Mul, Div,
              Dropout, Split, Softmax, LayerNormalization, Identity, Constant, Where,
              Pow, Tanh, MaxPool, BatchNormalization, Concat, Unsqueeze, Squeeze, Trilu,
-             AveragePool, Tile, VoxelPooling
+             AveragePool, Tile, VoxelPooling, Mean, Sqrt, Reciprocal
             ]

--- a/ttsim/front/functional/op.py
+++ b/ttsim/front/functional/op.py
@@ -557,7 +557,6 @@ LeakyReLU     = partial(UnaryOperator, optype='LeakyRelu')
 Sigmoid       = partial(UnaryOperator, optype='Sigmoid')
 AveragePool2d = partial(UnaryOperator, optype='AveragePool')
 Sum           = partial(UnaryOperator, optype='Sum')
-Rsqrt         = partial(UnaryOperator, optype='Rsqrt')
 Mean          = partial(UnaryOperator, optype='Mean')
 Reciprocal    = partial(UnaryOperator, optype='Reciprocal')
 

--- a/workloads/llama2/test_model.py
+++ b/workloads/llama2/test_model.py
@@ -7,27 +7,21 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '../..'))
 import ttsim.front.functional.op as F
 import ttsim.front.functional.sim_nn as SimNN
 import ttsim.front.functional.tensor_op as T
-from workloads.llama2.llama.model import Transformer, ModelArgs
+from workloads.llama2.model import Transformer
 
 def test_llama2_forward():
-    # Minimal model args for a quick test
-    args = ModelArgs(
-        dim=32,           # small dimension for test
-        n_layers=2,       # fewer layers for speed
-        n_heads=2,        # fewer heads
-        vocab_size=256,    # small vocab
-        max_batch_size=2,
-        max_seq_len=8,
-    )
-    model = Transformer('transformer_model', args)
-    batch_size = 1
-    seqlen = 1
+    cfg = {'dim': 32, 'n_layers': 2, 'n_heads': 2,
+            'vocab_size': 256, 'max_batch_size': 2,
+            'max_seq_len': 8, 'bs': 1, 'seq_len': 1}
+    model = Transformer('transformer_model', cfg)
+    batch_size = cfg['bs']
+    seqlen = cfg['seq_len']
      # Create random token indices in vocab range
     # tokens = F._from_shape('input_tokens', [batch_size, seqlen])
     model.create_input_tensors()
     out = model() #tokens, start_pos=0)
     print('Output shape:', out.shape)
-    assert out.shape == [batch_size, seqlen, args.vocab_size], 'Mismatched output shape'
+    assert out.shape == [batch_size, seqlen, cfg['vocab_size']], 'Mismatched output shape'
     print('Test passed!')
     gg = model.get_forward_graph()
     print('Dumping ONNX...')


### PR DESCRIPTION
This PR fixes `llama2` for generating Polaris perf projections.

```
$ python polaris.py -w config/ip_workloads.yaml -a config/all_archs.yaml -m config/wl2archmapping.yaml --filterarch Q1_A1 --filterwlg TTSIM  --filterwl llama2 -o ODDIR_llama2 -s SIMPLE_RUN --outputformat json        
```