### PR TITLE
fixed WH config to support SQRT on the vector pipe 

### DIFF
--- a/config/tt_wh.yaml
+++ b/config/tt_wh.yaml
@@ -31,6 +31,7 @@ ipblocks:
             -   {name: cmp,   tpt: { int32: 32., fp32: 32. }}
             -   {name: mov,   tpt: { int32: 32., fp32: 32. }}
             -   {name: max,   tpt: { int32: 32., fp32: 32. }}
+            -   {name: sqrt, tpt: { int32: 32., fp32: 32. }}
 
     -   name: gddr6
         iptype: memory


### PR DESCRIPTION
Llama2 couldn't run since we were missing SQRT support on the vector pipe on WH arch
I added it to the arch definition since it's also supported on WH/BH.