### PR TITLE
Enhance spdx config file with allowed license and copyright

### DIFF
--- a/.github/actions/run-static-analysis/action.yml
+++ b/.github/actions/run-static-analysis/action.yml
@@ -17,18 +17,18 @@ inputs:
     description: 'Command to run for static tests'
     required: false
     default: 'python checkin_tests.py static'
-  spdx-ignore-file:
-    description: 'SPDX checker ignore file path'
+  spdx-config-file:
+    description: 'SPDX checker configuration file path'
     required: false
-    default: '.github/spdxchecker-ignore.yml'
+    default: '.github/spdxchecker-config.yml'
   allowed-licenses:
-    description: 'Allowed license types (comma-separated)'
+    description: 'Allowed license types (space-separated, overrides config file)'
     required: false
-    default: 'Apache-2.0'
-  allowed-copyright:
-    description: 'Allowed copyright holder'
+    default: ''
+  allowed-copyrights:
+    description: 'Allowed copyright holders (space-separated, overrides config file)'
     required: false
-    default: 'Tenstorrent AI ULC'
+    default: ''
 
 outputs:
   static-tests-outcome:
@@ -57,14 +57,23 @@ runs:
       shell: bash -el {0}
       run: |
         echo "Running license and copyright checks..."
-        echo "Ignore file: ${{ inputs.spdx-ignore-file }}"
-        echo "Allowed licenses: ${{ inputs.allowed-licenses }}"
-        echo "Allowed copyright: ${{ inputs.allowed-copyright }}"
+        echo "Config file: ${{ inputs.spdx-config-file }}"
         
-        python tools/spdxchecker.py \
-          --ignore ${{ inputs.spdx-ignore-file }} \
-          --allowed-licenses ${{ inputs.allowed-licenses }} \
-          --allowed-copyright "${{ inputs.allowed-copyright }}"
+        # Build command with optional overrides
+        CMD="python tools/spdxchecker.py --config ${{ inputs.spdx-config-file }}"
+        
+        if [ -n "${{ inputs.allowed-licenses }}" ]; then
+          echo "Overriding allowed licenses: ${{ inputs.allowed-licenses }}"
+          CMD="$CMD --allowed-licenses ${{ inputs.allowed-licenses }}"
+        fi
+        
+        if [ -n "${{ inputs.allowed-copyrights }}" ]; then
+          echo "Overriding allowed copyrights: ${{ inputs.allowed-copyrights }}"
+          CMD="$CMD --allowed-copyrights ${{ inputs.allowed-copyrights }}"
+        fi
+        
+        echo "Executing: $CMD"
+        bash -c "$CMD"
         
         echo "✅ License and copyright checks completed successfully"
     

--- a/.github/spdxchecker-config.yml
+++ b/.github/spdxchecker-config.yml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+# Files and patterns to completely ignore during SPDX checks
+ignore:
+  - '*.map'
+  - '*.json'
+  - '*.elf'
+  - '*.xlsx'
+  - '*.rst'
+  - '*.csv'
+  - '*.md'
+  - '*.mdc'
+  - '*.onnx'
+  - '*.png'
+  - '.gitignore'
+  - 'condarc'
+  - '*.txt'
+  - '*.toml'
+  - '*.tar.gz'
+  - 'CODEOWNERS'
+  - 'NOTICE'
+
+# Files that should generate warnings instead of errors
+warning:
+  - '*.html'
+  - '*.yaml'
+  - '*.yml'
+
+# Allowed SPDX license identifiers
+allowed_licenses:
+  - Apache-2.0
+
+# Allowed copyright holders
+allowed_copyrights:
+  - "Tenstorrent AI ULC"
+ 

--- a/doc/README_github_actions_architecture.md
+++ b/doc/README_github_actions_architecture.md
@@ -47,7 +47,7 @@ This document describes the project's architecture and best practices for struct
 │   │   └── action.yml
 │   └── setup_mamba/           # Mamba environment setup action
 │       └── action.yml
-├── spdxchecker-ignore.yml     # SPDX license checker ignore rules
+├── spdxchecker-config.yml     # SPDX license checker configuration
 └── workflows/                 # CI/CD workflows using actions
     ├── checkin_tests.yml      # Pre-merge validation with integrated RTL testing
     └── nightly_tests.yml      # Comprehensive nightly testing

--- a/tests/test_tools/test_spdxchecker.py
+++ b/tests/test_tools/test_spdxchecker.py
@@ -1,10 +1,12 @@
 # SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
-import os
-import pytest
 from contextlib import chdir
-from tools.spdxchecker import ext_2_lang, classify_file, analyze_file, collect_all_files, collect_git_status_files, SPDXHeaderStatus, create_args, \
-    IgnoreFileModel, get_active_files
+
+import pytest
+
+from tools.spdxchecker import (ConfigFileModel, SPDXHeaderStatus, analyze_file, classify_file, collect_all_files,
+                               collect_git_status_files, create_args, ext_2_lang, get_active_files, load_config,
+                               validate_config)
 
 
 @pytest.mark.parametrize("extension,expected_language", [
@@ -31,16 +33,16 @@ lic_header = '# SPDX-License-Identifier: Apache-2.0'
 copyright_header = '# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC'
 
 
-@pytest.mark.parametrize("filename,allowed_licenses,allowed_copyright,content,expected_status", [
-    ("valid_file.py", ["Apache-2.0"], "Tenstorrent AI ULC", '\n'.join([lic_header, copyright_header]), (SPDXHeaderStatus.ST_OK, SPDXHeaderStatus.ST_OK)),
-    ("missing_license.py", ["Apache-2.0"], "Tenstorrent AI ULC", copyright_header, (SPDXHeaderStatus.ST_MISSING, SPDXHeaderStatus.ST_OK)),
-    ("missing_copyright.py", ["Apache-2.0"], "Tenstorrent AI ULC", lic_header, (SPDXHeaderStatus.ST_OK, SPDXHeaderStatus.ST_MISSING)),
-    ("incorrect_license.py", ["Apache-2.0"], "Tenstorrent AI ULC", '\n'.join([lic_header + 'force-diff', copyright_header]), (SPDXHeaderStatus.ST_INCORRECT, SPDXHeaderStatus.ST_OK)),
-    ("incorrect_copyright.py", ["Apache-2.0"], "Tenstorrent AI ULC", '\n'.join([lic_header, copyright_header+'force-diff']), (SPDXHeaderStatus.ST_OK, SPDXHeaderStatus.ST_INCORRECT)),
+@pytest.mark.parametrize("filename,allowed_licenses,allowed_copyrights,content,expected_status", [
+    ("valid_file.py", ["Apache-2.0"], ["Tenstorrent AI ULC"], '\n'.join([lic_header, copyright_header]), (SPDXHeaderStatus.ST_OK, SPDXHeaderStatus.ST_OK)),
+    ("missing_license.py", ["Apache-2.0"], ["Tenstorrent AI ULC"], copyright_header, (SPDXHeaderStatus.ST_MISSING, SPDXHeaderStatus.ST_OK)),
+    ("missing_copyright.py", ["Apache-2.0"], ["Tenstorrent AI ULC"], lic_header, (SPDXHeaderStatus.ST_OK, SPDXHeaderStatus.ST_MISSING)),
+    ("incorrect_license.py", ["Apache-2.0"], ["Tenstorrent AI ULC"], '\n'.join([lic_header + 'force-diff', copyright_header]), (SPDXHeaderStatus.ST_INCORRECT, SPDXHeaderStatus.ST_OK)),
+    ("incorrect_copyright.py", ["Apache-2.0"], ["Tenstorrent AI ULC"], '\n'.join([lic_header, copyright_header+'force-diff']), (SPDXHeaderStatus.ST_OK, SPDXHeaderStatus.ST_INCORRECT)),
 ])
-def test_analyzes_file_for_spdx_headers(filename, allowed_licenses, allowed_copyright, expected_status, content, mocker):
+def test_analyzes_file_for_spdx_headers(filename, allowed_licenses, allowed_copyrights, expected_status, content, mocker):
     mocker.patch("builtins.open", mocker.mock_open(read_data=content))
-    assert analyze_file(filename, allowed_licenses, allowed_copyright) == expected_status
+    assert analyze_file(filename, allowed_licenses, allowed_copyrights) == expected_status
 
 
 def test_collects_all_files_in_directory(tmp_path):
@@ -51,7 +53,7 @@ def test_collects_all_files_in_directory(tmp_path):
     assert collect_all_files(str(tmp_path)) == ["file1.py", "file2.js"]
 
 def test_collects_git_status_files(tmp_path):
-    res = get_active_files(True, IgnoreFileModel()) # collect_git_status_files(True) != []
+    res = get_active_files(True, ConfigFileModel()) # collect_git_status_files(True) != []
     assert isinstance(res, list)
     with chdir(tmp_path):
         with pytest.raises(FileNotFoundError, match=".git directory not found"):
@@ -61,4 +63,217 @@ def test_create_args():
     args = create_args().parse_args([])
     assert args is not None
     assert hasattr(args, 'allowed_licenses')
-    assert hasattr(args, 'allowed_copyright')
+    assert hasattr(args, 'allowed_copyrights')
+    assert hasattr(args, 'config')
+
+
+# New tests for enhanced configuration support
+
+def test_config_model_with_all_fields():
+    """Test ConfigFileModel with all fields populated."""
+    config = ConfigFileModel(
+        ignore=['*.json', '*.md'],
+        warning=['*.html'],
+        allowed_licenses=['Apache-2.0'],
+        allowed_copyrights=['Tenstorrent AI ULC', '(C) 2025 Tenstorrent AI ULC']
+    )
+    assert len(config.ignore) == 2
+    assert len(config.allowed_licenses) == 1
+    assert len(config.allowed_copyrights) == 2
+
+
+def test_config_model_with_empty_fields():
+    """Test ConfigFileModel with empty optional fields."""
+    config = ConfigFileModel()
+    assert config.ignore == []
+    assert config.warning == []
+    assert config.allowed_licenses == []
+    assert config.allowed_copyrights == []
+
+
+def test_validate_config_with_valid_licenses():
+    """Test configuration validation with valid SPDX licenses."""
+    config = ConfigFileModel(
+        allowed_licenses=['Apache-2.0'],
+        allowed_copyrights=['Tenstorrent AI ULC']
+    )
+    # Should not raise any exceptions
+    validate_config(config)
+
+
+def test_validate_config_errors_on_invalid_licenses():
+    """Test configuration validation raises error for invalid SPDX licenses."""
+    config = ConfigFileModel(
+        allowed_licenses=['Apache-2.0', 'InvalidLicense'],
+        allowed_copyrights=['Tenstorrent AI ULC']
+    )
+    with pytest.raises(ValueError, match='Invalid SPDX license identifiers'):
+        validate_config(config)
+
+
+def test_validate_config_warns_no_licenses():
+    """Test configuration validation warns when no licenses specified."""
+    config = ConfigFileModel(
+        allowed_copyrights=['Tenstorrent AI ULC']
+    )
+    # Should not raise an exception, just warn
+    validate_config(config)
+    # Test passes if no exception is raised
+
+
+def test_validate_config_warns_no_copyrights():
+    """Test configuration validation warns when no copyrights specified."""
+    config = ConfigFileModel(
+        allowed_licenses=['Apache-2.0']
+    )
+    # Should not raise an exception, just warn
+    validate_config(config)
+    # Test passes if no exception is raised
+
+
+def test_validate_config_with_validation_disabled():
+    """Test that validation can be disabled for invalid SPDX licenses."""
+    config = ConfigFileModel(
+        allowed_licenses=['Apache-2.0', 'MIT', 'BSD-3-Clause', 'CustomLicense'],
+        allowed_copyrights=['Tenstorrent AI ULC']
+    )
+    # Should not raise an exception when validation is disabled
+    validate_config(config, validate_spdx=False)
+    # Test passes if no exception is raised
+
+
+def test_validate_config_with_validation_enabled():
+    """Test that validation rejects invalid licenses when enabled."""
+    config = ConfigFileModel(
+        allowed_licenses=['Apache-2.0', 'MIT'],
+        allowed_copyrights=['Tenstorrent AI ULC']
+    )
+    # Should raise an exception when validation is enabled (default)
+    with pytest.raises(ValueError, match='Invalid SPDX license identifiers'):
+        validate_config(config, validate_spdx=True)
+
+
+def test_load_config_file_not_found():
+    """Test load_config raises FileNotFoundError for missing file."""
+    with pytest.raises(FileNotFoundError, match='Configuration file not found'):
+        load_config('/nonexistent/path/config.yml')
+
+
+def test_load_config_valid_file(tmp_path):
+    """Test load_config successfully loads a valid configuration file."""
+    config_file = tmp_path / "test_config.yml"
+    config_file.write_text("""
+ignore:
+  - '*.json'
+  - '*.md'
+warning:
+  - '*.html'
+allowed_licenses:
+  - Apache-2.0
+allowed_copyrights:
+  - Tenstorrent AI ULC
+  - (C) 2025 Tenstorrent AI ULC
+""")
+    config = load_config(str(config_file))
+    assert len(config.ignore) == 2
+    assert len(config.allowed_licenses) == 1
+    assert len(config.allowed_copyrights) == 2
+
+
+def test_load_config_empty_file(tmp_path):
+    """Test load_config handles empty YAML file."""
+    config_file = tmp_path / "empty_config.yml"
+    config_file.write_text("")
+    config = load_config(str(config_file))
+    assert config.ignore == []
+    assert config.allowed_licenses == []
+
+
+def test_load_config_invalid_yaml(tmp_path):
+    """Test load_config handles invalid YAML syntax."""
+    config_file = tmp_path / "invalid_config.yml"
+    config_file.write_text("invalid: yaml: syntax: [")
+    with pytest.raises(Exception):  # YAMLError
+        load_config(str(config_file))
+
+
+def test_load_config_with_validation_disabled(tmp_path):
+    """Test load_config with SPDX validation disabled allows any license."""
+    config_file = tmp_path / "config_with_custom_license.yml"
+    config_file.write_text("""
+allowed_licenses:
+  - MIT
+  - BSD-3-Clause
+  - CustomLicense
+allowed_copyrights:
+  - Tenstorrent AI ULC
+""")
+    # Should not raise an exception when validation is disabled
+    config = load_config(str(config_file), validate_spdx=False)
+    assert len(config.allowed_licenses) == 3
+    assert 'MIT' in config.allowed_licenses
+    assert 'CustomLicense' in config.allowed_licenses
+
+
+def test_load_config_with_validation_enabled_rejects_invalid(tmp_path):
+    """Test load_config with SPDX validation enabled rejects invalid licenses."""
+    config_file = tmp_path / "config_with_invalid_license.yml"
+    config_file.write_text("""
+allowed_licenses:
+  - MIT
+  - InvalidLicense
+allowed_copyrights:
+  - Tenstorrent AI ULC
+""")
+    # Should raise an exception when validation is enabled
+    with pytest.raises(ValueError, match='Invalid SPDX license identifiers'):
+        load_config(str(config_file), validate_spdx=True)
+
+
+def test_multiple_copyright_holders():
+    """Test that multiple copyright holders are supported."""
+    content = '\n'.join([lic_header, copyright_header])
+
+    # Mock the file reading
+    import unittest.mock as mock
+    with mock.patch("builtins.open", mock.mock_open(read_data=content)):
+        license_status, copyright_status = analyze_file(
+            "test.py",
+            ["Apache-2.0"],
+            ["Tenstorrent AI ULC", "Another Company"]
+        )
+        assert license_status == SPDXHeaderStatus.ST_OK
+        assert copyright_status == SPDXHeaderStatus.ST_OK
+
+
+def test_cli_config_parameter():
+    """Test that CLI includes --config parameter."""
+    args = create_args().parse_args(['--config', 'custom_config.yml'])
+    assert args.config == 'custom_config.yml'
+
+
+def test_cli_validate_spdx_licenses_flag():
+    """Test that CLI includes --validate-spdx-licenses flag."""
+    # Test default value (enabled)
+    args_default = create_args().parse_args([])
+    assert args_default.validate_spdx_licenses is True
+    
+    # Test explicit enable
+    args_enabled = create_args().parse_args(['--validate-spdx-licenses'])
+    assert args_enabled.validate_spdx_licenses is True
+    
+    # Test explicit disable
+    args_disabled = create_args().parse_args(['--no-validate-spdx-licenses'])
+    assert args_disabled.validate_spdx_licenses is False
+
+
+def test_cli_override_licenses():
+    """Test that CLI can override allowed licenses."""
+    args = create_args().parse_args(['--allowed-licenses', 'Apache-2.0', 'MIT'])
+    assert args.allowed_licenses == ['Apache-2.0', 'MIT']
+
+
+def test_cli_override_copyrights():
+    """Test that CLI can override allowed copyrights."""
+    args = create_args().parse_args(['--allowed-copyrights', 'Company A', 'Company B'])
+    assert args.allowed_copyrights == ['Company A', 'Company B']


### PR DESCRIPTION
- Move spdx ignore file to a more comprehensive configuration file (.github/spdxchecker-config.yml) adding  allowed licenses, and copyright holders.
- Enhanced documentation and tests