### PR TITLE
correlations: choose workload instances by mapping full workload names

### DIFF
--- a/config/ttsi_correlation_workloads.yaml
+++ b/config/ttsi_correlation_workloads.yaml
@@ -29,6 +29,7 @@ workloads:
     module : ResNet@basicresnet.py
     params : {layers: [3,4,6,3], num_classes: 1000, num_channels: 3, bs: 1}
     instances:
+      rn50_224x224 : { img_height: 224, img_width: 224, }
       rn50_b1_hd : { img_height: 1024, img_width: 1024, }
       rn50_b1_uhd: { img_height: 2828, img_width: 2828, }
       corr: { }
@@ -87,4 +88,3 @@ workloads:
       bert_base : { nL: 12, nH: 12, dE:  768, nW:  512}
       bert_large: { nL: 24, nH: 16, dE: 1024, nW:  512}
       corr:    { nL: 24, nH: 16, dE: 1024, nW:  384}
-

--- a/envdev.yaml
+++ b/envdev.yaml
@@ -43,4 +43,5 @@ dependencies:
     - types-PYYAML==6.0.12.20241230
     - types-networkx==3.4.2.20241227
     - types-requests
+    - types-openpyxl
     - lxml-stubs

--- a/tests/test_tools/test_ttsi_corr_utils.py
+++ b/tests/test_tools/test_ttsi_corr_utils.py
@@ -76,8 +76,8 @@ class TestGetWorkloadNameFromModel:
 
     def test_llama_variants(self):
         """Test Llama model variants."""
-        assert get_workload_name_from_model('Llama 3.1 8B') == 'llama'
-        assert get_workload_name_from_model('Llama 3.2 1B') == 'llama'
+        assert get_workload_name_from_model('Llama 3.1 8B') == 'llama3'
+        assert get_workload_name_from_model('Llama 3.2 1B') == 'llama3'
         assert get_workload_name_from_model('llama-7b') == 'llama'
 
     def test_mamba(self):
@@ -173,7 +173,7 @@ class TestIntegration:
         
         # Verify results
         assert device == 'n150'
-        assert workload_name == 'llama'
+        assert workload_name == 'llama3'
         assert benchmark == 'Benchmark.Llama'
 
     def test_multiple_models_consistent(self):
@@ -181,11 +181,10 @@ class TestIntegration:
         models = [
             'Llama 3.1 8B',
             'Llama 3.2 1B',
-            'Llama 2 7B',
         ]
         
         for model in models:
-            assert get_workload_name_from_model(model) == 'llama'
+            assert get_workload_name_from_model(model) == 'llama3'
             assert get_benchmark_from_model(model) == 'Benchmark.Llama'
 
     def test_all_supported_models(self):
@@ -193,7 +192,7 @@ class TestIntegration:
         test_cases = [
             ('BERT-Base', 'bert', 'Benchmark.BERT'),
             ('ResNet-50', 'resnet50', 'Benchmark.ResNet50'),
-            ('Llama 3.1 8B', 'llama', 'Benchmark.Llama'),
+            ('Llama 3.1 8B', 'llama3', 'Benchmark.Llama'),
             ('Mamba-2.8B', 'mamba', 'Benchmark.Mamba'),
             ('YOLOv8', 'yolov8', 'Benchmark.YOLO'),
             ('Stable Diffusion', 'unet', 'Benchmark.UNet'),

--- a/tests/test_ttsi_corr/test_chart_builder.py
+++ b/tests/test_ttsi_corr/test_chart_builder.py
@@ -9,7 +9,7 @@ proper S-curve chart generation functionality.
 
 import math
 import pytest
-from openpyxl import Workbook  # type: ignore[import-untyped]
+from openpyxl import Workbook
 
 from tools.ttsi_corr.chart_builder import ScurveChartBuilder, add_scurve_chart
 

--- a/tests/test_ttsi_corr/test_excel_writer.py
+++ b/tests/test_ttsi_corr/test_excel_writer.py
@@ -9,8 +9,8 @@ Excel formatting utilities functionality.
 
 import pytest
 from pathlib import Path
-from openpyxl import Workbook  # type: ignore[import-untyped]
-from openpyxl.worksheet.worksheet import Worksheet  # type: ignore[import-untyped]
+from openpyxl import Workbook
+from openpyxl.worksheet.worksheet import Worksheet
 
 from tools.ttsi_corr.excel_writer import ExcelFormatter, write_csv
 

--- a/tools/run_ttsi_corr.py
+++ b/tools/run_ttsi_corr.py
@@ -3,34 +3,25 @@
 # SPDX-License-Identifier: Apache-2.0
 import os
 import sys
-import csv
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import argparse
-import json
-import math
-import subprocess
 from pathlib import Path
 from typing import Any
 
-import yaml
 from loguru import logger
-from openpyxl import Workbook  # type: ignore[import-untyped]
-from openpyxl.styles import Border, Font, PatternFill, Side, Alignment  # type: ignore[import-untyped]
-from openpyxl.chart import LineChart, Reference  # type: ignore[import-untyped]
+from openpyxl import Workbook
 
-from tools.ttsi_corr.ttsi_corr_utils import TTSI_REF_VALID_TAGS, get_benchmark_from_model, get_workload_name_from_model, parse_hardware_to_device
-from tools.parsers.md_parser import TensixMdPerfMetricModel
-from tools.workloads import WorkloadConfig, WorkloadsFile, load_workloads_file
-from tools.ttsi_corr.excel_writer import ExcelFormatter, write_csv
 from tools.ttsi_corr.chart_builder import add_scurve_chart
-from tools.ttsi_corr.data_loader import load_metrics_from_sources, read_metadata, normalize_md_metric
-from tools.ttsi_corr.workload_processor import process_workload_configs, find_workload_config, get_workload_module_config
-from tools.ttsi_corr.correlation import compare_scores, read_scores, calculate_and_save_geomean
-from tools.ttsi_corr.simulator import validate_and_filter_configs, run_polaris_simulation
-from ttsim.utils.common import parse_yaml, print_yaml, setup_logger
+from tools.ttsi_corr.correlation import calculate_and_save_geomean, compare_scores, read_scores
+from tools.ttsi_corr.data_loader import load_metrics_from_sources, read_metadata
+from tools.ttsi_corr.excel_writer import ExcelFormatter, write_csv
+from tools.ttsi_corr.simulator import run_polaris_simulation, validate_and_filter_configs
+from tools.ttsi_corr.ttsi_corr_utils import TTSI_REF_VALID_TAGS
+from tools.ttsi_corr.workload_processor import process_workload_configs
+from tools.workloads import WorkloadsFile, load_workloads_file
 from ttsim.config import get_arspec_from_yaml
-
+from ttsim.utils.common import setup_logger
 
 type ScoreTuple = tuple[str, str, str, str]
 type ScoreDict = dict[ScoreTuple, dict[str, float]]
@@ -52,7 +43,7 @@ DEVICE_TABLE: dict[str, str] = {}
 def write_correlation_xlsx(comparison: list[dict[str, Any]], output_path: Path) -> None:
     """
     Write correlation results to an Excel file with formulas and formatting.
-    
+
     Creates an XLSX file with:
     - Excel formulas for calculated fields (ratios)
     - Comma number formatting for float values
@@ -60,58 +51,60 @@ def write_correlation_xlsx(comparison: list[dict[str, Any]], output_path: Path) 
     - Borders around all cells
     - Auto-filter on header row
     - Frozen panes for easier navigation
-    
+
     Args:
         comparison: List of dictionaries containing correlation data.
                    Each dict should have keys matching the expected columns.
         output_path: Path where the XLSX file will be saved.
-    
+
     Returns:
         None
-    
+
     Side Effects:
         - Creates an XLSX file at output_path
         - Logs progress and completion
-        
+
     Note:
         Uses ExcelFormatter utility class from ttsi_corr.excel_writer for
         formatting operations (Phase 2 refactoring).
     """
     logger.debug('Writing XLSX file to: {}', output_path)
-    
+
     # Create Excel formatter instance
     formatter = ExcelFormatter()
-    
+
     wb = Workbook()
     ws = wb.active
+    if ws is None:
+        raise RuntimeError('Failed to create worksheet')
     ws.title = 'Correlation Results'
-    
+
     # Write header row
     headers = list(comparison[0].keys())
     ws.append(headers)
-    
+
     # Create column index map for formula generation
     col_map = {header: idx + 1 for idx, header in enumerate(headers)}
-    
+
     # Define which columns should use formulas
     formula_columns = {
         'Ratio-HLM-to-Si',
         'Ratio-HLM-to-SiTarget',
     }
-    
+
     # Write data rows with formulas for calculated fields
     for row_idx, row in enumerate(comparison, start=2):  # Start at row 2 (after header)
         row_data = []
         for col_idx, header in enumerate(headers, start=1):
             value = row[header]
-            
+
             # Generate formulas for calculated columns
             if header in formula_columns:
                 # Get column letters for source values using ExcelFormatter
                 ref_score_col = formatter.col_letter(col_map['Si-Score'])
                 target_score_col = formatter.col_letter(col_map['Si-Target-Score'])
                 projected_score_col = formatter.col_letter(col_map['HLM-Score'])
-                
+
                 # Generate appropriate formula based on column name
                 if header == 'Ratio-HLM-to-Si':
                     formula = f'=IF({ref_score_col}{row_idx}=0, "", {projected_score_col}{row_idx}/{ref_score_col}{row_idx})'
@@ -119,22 +112,22 @@ def write_correlation_xlsx(comparison: list[dict[str, Any]], output_path: Path) 
                     formula = f'=IF({target_score_col}{row_idx}=0, "", {projected_score_col}{row_idx}/{target_score_col}{row_idx})'
                 else:
                     formula = value
-                
+
                 row_data.append(formula)
             else:
                 row_data.append(value)
-        
+
         ws.append(row_data)
-    
+
     # Apply number formatting using ExcelFormatter
     formatter.apply_number_formats(ws, headers, comparison)
-    
+
     # Apply borders using ExcelFormatter
     formatter.apply_borders(ws, num_rows=len(comparison) + 1, num_cols=len(headers))
-    
+
     # Enable auto-filter on the header row
     ws.auto_filter.ref = ws.dimensions
-    
+
     # Freeze panes: freeze after row 1 (header) and after HLM-Ideal-Score column
     if 'HLM-Ideal-Score' in col_map:
         projected_ideal_score_col_idx = col_map['HLM-Ideal-Score']
@@ -145,10 +138,10 @@ def write_correlation_xlsx(comparison: list[dict[str, Any]], output_path: Path) 
         # Fallback: just freeze after row 1 if column not found
         ws.freeze_panes = 'A2'
         logger.warning('HLM-Ideal-Score column not found, freezing at A2')
-    
+
     # Add S-curve analysis sheet
     add_scurve_chart(wb, comparison)
-    
+
     # Save workbook
     wb.save(output_path)
     logger.info('XLSX file written to: {}', output_path)
@@ -172,24 +165,24 @@ def write_correlation_xlsx(comparison: list[dict[str, Any]], output_path: Path) 
 def setup_environment(args: argparse.Namespace) -> tuple[Path, bool]:
     """
     Set up the execution environment and output directory.
-    
+
     Args:
         args: Parsed command-line arguments
-        
+
     Returns:
         tuple: (output_path, dry_run_flag)
     """
     setup_logger(level=args.loglevel)
-    
+
     opath = Path(args.output_dir)
     dry_run = args.dry_run
-    
+
     if dry_run:
         logger.info('[DRY-RUN] Would create output directory: {}', opath)
     else:
         os.makedirs(opath, exist_ok=True)
         logger.debug('Created output directory: {}', opath)
-    
+
     return opath, dry_run
 
 
@@ -203,23 +196,23 @@ def get_data_source_from_metadata(
 ) -> str:
     """
     Get the data source from metadata file.
-    
+
     Args:
         data_dir: Directory containing the metadata
         dry_run: Whether to run in dry-run mode
-        
+
     Returns:
         str: Data source ('html' or 'md'), defaults to 'md' if no metadata found
-        
+
     Raises:
         RuntimeError: If metadata file exists but data_source field is missing
     """
     if dry_run:
         logger.debug('[DRY-RUN] Would read data source from metadata')
         return 'md'  # Default for dry-run
-    
+
     metadata = read_metadata(data_dir)
-    
+
     if metadata is None:
         logger.warning(
             'No metadata found in {}. Defaulting to data_source=md. '
@@ -227,23 +220,23 @@ def get_data_source_from_metadata(
             data_dir
         )
         return 'md'
-    
+
     data_source = metadata.get('data_source')
-    
+
     if data_source is None:
         raise RuntimeError(
             f'Metadata file exists in {data_dir} but does not contain "data_source" field. '
             f'Please re-parse the data with parse_ttsi_perf_results.py.'
         )
-    
+
     if data_source not in ['html', 'md']:
         raise RuntimeError(
             f'Invalid data_source in metadata: "{data_source}". Must be "html" or "md".'
         )
-    
+
     logger.info('Data source from metadata: {} (tag={}, parsed={})',
                 data_source, metadata.get('tag'), metadata.get('parsed_date'))
-    
+
     return data_source
 
 
@@ -254,30 +247,30 @@ def get_data_directory(
 ) -> Path:
     """
     Get and validate the data directory containing Tensix metrics.
-    
+
     Constructs the full path as input_dir / tag.
-    
+
     Args:
         input_dir: Base directory containing tagged metric subdirectories
         tag: Tag subdirectory name (e.g., '15oct25')
         dry_run: Whether to run in dry-run mode
-        
+
     Returns:
         Path: Directory containing Tensix metrics (input_dir / tag)
-        
+
     Raises:
         RuntimeError: If directory doesn't exist (in non-dry-run mode)
     """
     tensix_perf_data_dir = Path(input_dir) / tag
-    
+
     if dry_run:
         logger.info('[DRY-RUN] Would use data directory: {}', tensix_perf_data_dir)
         return tensix_perf_data_dir
-    
+
     if not tensix_perf_data_dir.exists():
         raise RuntimeError(f'Data directory does not exist: {tensix_perf_data_dir}')
-    
-    logger.info('Using data directory: {} (from input-dir={}, tag={})', 
+
+    logger.info('Using data directory: {} (from input-dir={}, tag={})',
                 tensix_perf_data_dir, input_dir, tag)
     return tensix_perf_data_dir
 
@@ -288,26 +281,26 @@ def load_workload_configs(
 ) -> tuple[WorkloadsFile, set[str] | None]:
     """
     Load workload configurations and parse filter if provided.
-    
+
     Args:
         workloads_config_path: Path to workloads configuration file
         workload_filter_str: Comma-separated workload names to filter
-        
+
     Returns:
         tuple: (workloads_file, workload_filter_set)
-        
+
     Raises:
         Exception: If workloads configuration cannot be loaded
     """
     logger.debug('Loading workloads configuration from: {}', workloads_config_path)
     workloads_file = load_workloads_file(workloads_config_path)
     logger.debug('Loaded {} workload configurations', len(workloads_file.workloads))
-    
+
     workload_filter = None
     if workload_filter_str:
         workload_filter = set(wl.strip() for wl in workload_filter_str.split(','))
         logger.debug('Filtering workloads: {}', workload_filter)
-    
+
     return workloads_file, workload_filter
 
 
@@ -325,13 +318,13 @@ def generate_correlation_outputs(
 ) -> int:
     """
     Compare scores and generate correlation output files.
-    
+
     Args:
         metal_ref_scores: Reference scores from Tensix
         opath: Output path
         default_precision: Default precision setting
         dry_run: Whether in dry-run mode
-        
+
     Returns:
         int: 0 on success, non-zero on failure
     """
@@ -341,33 +334,33 @@ def generate_correlation_outputs(
         logger.info('[DRY-RUN] Would write correlation results to: {}', opath / 'correlation_result.xlsx')
         logger.info('[DRY-RUN] Dry-run completed successfully')
         return 0
-    
+
     # Read simulation scores
     actual_scores = read_scores(
         opath / POLPROJ_STUDY_NAME / 'SUMMARY' / 'study-summary.json',
         default_precision
     )
-    
+
     # Compare scores (include Override-Precision column only if precision was specified on CLI)
     comparison = compare_scores(metal_ref_scores, actual_scores, include_override_precision=(default_precision is not None))
-    
+
     if not comparison:
         logger.warning('No valid comparisons generated (all workloads may have been skipped)')
         logger.info('Correlation completed with no results')
         return 0
-    
+
     # Write CSV
     correlation_csv_path = opath / 'correlation_result.csv'
     write_csv(comparison, correlation_csv_path)
-    
+
     # Write XLSX
     correlation_xlsx_path = opath / 'correlation_result.xlsx'
     write_correlation_xlsx(comparison, correlation_xlsx_path)
-    
+
     # Calculate and save geometric mean
     geomean_json_path = opath / 'correlation_geomean.json'
     calculate_and_save_geomean(comparison, geomean_json_path)
-    
+
     logger.info('Correlation completed successfully with {} results', len(comparison))
     return 0
 
@@ -378,14 +371,14 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         description='Run Tensix Metal correlation',
         formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    
+
     # Reference data group
     ref_data_group = parser.add_argument_group('Reference Data')
     ref_data_group.add_argument('--input-dir', type=str, default='data/metal/inf',
                                 help='Base directory containing tagged metric subdirectories (default: %(default)s)')
     ref_data_group.add_argument('--tag', '-t', type=str, choices=TTSI_REF_VALID_TAGS, default=TTSI_REF_VALID_TAGS[0],
                                 help=f'Tag subdirectory name (required). Valid values: {TTSI_REF_VALID_TAGS}. (default: %(default)s)')
-    
+
     # WL/Arch configurations group
     wl_arch_group = parser.add_argument_group('WL/Arch configurations')
     wl_arch_group.add_argument('--workloads-config', type=str, default='config/ttsi_correlation_workloads.yaml',
@@ -402,7 +395,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     wl_arch_group.add_argument('--precision', type=str,
                                help='Override precision for all workloads (e.g., bf8, bf16, fp32). '
                                     'If not specified, uses precision from parsed metrics data')
-    
+
     # Other arguments
     parser.add_argument('--output-dir', type=str, default=OUTPUT_DIR.as_posix(),
                         help='Output directory for results (default: %(default)s)')
@@ -411,16 +404,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument('--loglevel', '--log-level', type=str.upper, default='INFO',
                         choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
                         help='Set logging level (default: %(default)s)')
-    
+
     args = parser.parse_args(argv)
-    
+
     return args
 
 
 def main(argv: list[str]) -> int:
     """
     Main entry point for Metal-Tensix correlation analysis.
-    
+
     Orchestrates the complete correlation workflow:
     1. Setup environment and parse arguments
     2. Construct data directory from input-dir and tag
@@ -431,10 +424,10 @@ def main(argv: list[str]) -> int:
     7. Process workloads and create specs
     8. Run Polaris simulation
     9. Generate correlation outputs (CSV, XLSX, JSON)
-    
+
     Required Arguments:
         --tag: Tag identifying the parsed metrics dataset
-    
+
     Optional Arguments:
         --input-dir: Base directory containing tagged metrics (default: data/metal/inf)
         --workloads-config: Workload configuration file
@@ -443,78 +436,77 @@ def main(argv: list[str]) -> int:
         --precision: Override precision for all workloads
         --output-dir: Output directory for results
         --dry-run: Preview actions without executing
-    
+
     Note:
         Requires that metrics have been pre-parsed using parse_ttsi_perf_results.py
         which creates the metadata file containing data source information.
-    
+
     Args:
         argv: Command-line arguments
-        
+
     Returns:
         int: 0 on success, non-zero on failure
     """
     # Parse arguments and setup
     args = parse_args(argv[1:])
     opath, dry_run = setup_environment(args)
-    
+
     try:
         # Get data directory (constructed from input_dir / tag)
         arch_specs = get_arspec_from_yaml(args.arch_config)
         arch_specs_packages = arch_specs[1]
-        
+
         # Build device table from arch config based on requested arch name
         arch_name_lower = args.arch_name.lower()
         device_names = [
             pkgname for pkgname in arch_specs_packages
             if arch_specs_packages[pkgname].devname.lower() == arch_name_lower
         ]
-        
+
         if not device_names:
-            logger.error('Architecture name "{}" not found in arch config: {}', 
+            logger.error('Architecture name "{}" not found in arch config: {}',
                         args.arch_name, args.arch_config)
-            logger.error('Available architectures: {}', 
+            logger.error('Available architectures: {}',
                         sorted(set(pkg.devname for pkg in arch_specs_packages.values())))
             return 1
-        
+
         # Populate device table
         for devname in device_names:
             DEVICE_TABLE[devname] = devname
-        
+
         logger.debug('Device table populated for arch "{}": {}', args.arch_name, device_names)
-        
+
         tensix_perf_data_dir = get_data_directory(args.input_dir, args.tag, dry_run)
-        
+
         # Get data source from metadata
         data_source = get_data_source_from_metadata(tensix_perf_data_dir, dry_run)
-        
+
         # Load workload configurations
         workloads_file, workload_filter = load_workload_configs(
             args.workloads_config,
             args.workload_filter
         )
-        
+
         # Load metrics from data source specified in metadata
         all_configs = load_metrics_from_sources(tensix_perf_data_dir, data_source)
-        
+
         # Validate and filter configurations
         valid_configs = validate_and_filter_configs(all_configs, workload_filter)
-        
+
         # Process workload configurations
         ttsim_wlspec, metal_ref_scores, uniq_devs = process_workload_configs(
             valid_configs,
             workloads_file,
             workload_filter,
             args.precision,
-            DEVICE_TABLE,
-            CORRELATION_INSTANCE_NAME
+            DEVICE_TABLE
         )
-        
+
         # Run Polaris simulation
         ret = run_polaris_simulation(ttsim_wlspec, uniq_devs, opath, args, dry_run)
         if ret != 0:
             return ret
-        
+
         # Generate correlation outputs
         return generate_correlation_outputs(
             metal_ref_scores,
@@ -522,7 +514,7 @@ def main(argv: list[str]) -> int:
             args.precision,
             dry_run
         )
-        
+
     except Exception as e:
         logger.error('Correlation failed: {}', e)
         return 1

--- a/tools/ttsi_corr/chart_builder.py
+++ b/tools/ttsi_corr/chart_builder.py
@@ -55,10 +55,10 @@ import math
 from typing import Any, Optional
 
 from loguru import logger
-from openpyxl import Workbook  # type: ignore[import-untyped]
-from openpyxl.styles import Font, Alignment  # type: ignore[import-untyped]
-from openpyxl.chart import LineChart, Reference  # type: ignore[import-untyped]
-from openpyxl.worksheet.worksheet import Worksheet  # type: ignore[import-untyped]
+from openpyxl import Workbook
+from openpyxl.chart import LineChart, Reference
+from openpyxl.styles import Alignment, Font
+from openpyxl.worksheet.worksheet import Worksheet
 
 
 class ScurveChartBuilder:
@@ -287,8 +287,8 @@ class ScurveChartBuilder:
         
         # Calculate appropriate X-axis tick interval (~10 ticks)
         x_tick_interval = max(1, len(self.ratio_data) // 10)
-        chart.x_axis.majorUnit = x_tick_interval
-        chart.x_axis.minorUnit = x_tick_interval
+        chart.x_axis.majorUnit = x_tick_interval  # type: ignore[attr-defined]
+        chart.x_axis.minorUnit = x_tick_interval  # type: ignore[attr-defined]
         
         # Configure Y-axis (Ratio values)
         chart.y_axis.delete = False

--- a/tools/ttsi_corr/data_loader.py
+++ b/tools/ttsi_corr/data_loader.py
@@ -47,12 +47,13 @@ See Also:
 
 from pathlib import Path
 from typing import Any
-import yaml
 
+import yaml
 from loguru import logger
 
 from tools.parsers.md_parser import TensixMdPerfMetricModel
-from tools.ttsi_corr.ttsi_corr_utils import get_benchmark_from_model, get_workload_name_from_model, parse_hardware_to_device
+from tools.ttsi_corr.ttsi_corr_utils import (get_benchmark_from_model, get_workload_name_from_model,
+                                             parse_hardware_to_device)
 from ttsim.utils.common import parse_yaml
 
 

--- a/tools/ttsi_corr/excel_writer.py
+++ b/tools/ttsi_corr/excel_writer.py
@@ -61,8 +61,8 @@ from pathlib import Path
 from typing import Any
 
 from loguru import logger
-from openpyxl.styles import Border, Side  # type: ignore[import-untyped]
-from openpyxl.worksheet.worksheet import Worksheet  # type: ignore[import-untyped]
+from openpyxl.styles import Border, Side
+from openpyxl.worksheet.worksheet import Worksheet
 
 
 class ExcelFormatter:

--- a/tools/ttsi_corr/ttsi_corr_utils.py
+++ b/tools/ttsi_corr/ttsi_corr_utils.py
@@ -61,6 +61,8 @@ def get_workload_name_from_model(model: str) -> str:
     
     # Llama variants
     if 'llama' in model_lower:
+        if 'llama 3' in model_lower:
+            return 'llama3'
         return 'llama'
     
     # Mamba
@@ -69,9 +71,9 @@ def get_workload_name_from_model(model: str) -> str:
     
     # YOLO variants
     if 'yolo' in model_lower:
-        if 'v8' in model_lower:
+        if 'v8' in model_lower or 'yolov8' in model_lower or 'yolo8' in model_lower:
             return 'yolov8'
-        elif 'v7' in model_lower:
+        elif 'v7' in model_lower or 'yolov7' in model_lower or 'yolo7' in model_lower:
             return 'yolov7'
         return 'yolo'
     
@@ -110,4 +112,3 @@ def get_benchmark_from_model(model: str) -> str:
     else:
         # Default: use model name as benchmark
         return f'Benchmark.{model.split()[0]}'
-

--- a/tools/workloads.py
+++ b/tools/workloads.py
@@ -21,45 +21,45 @@ from ttsim.utils.common import parse_yaml
 class WorkloadConfig(BaseModel):
     """
     Pydantic model for a single workload configuration.
-    
+
     Represents an individual workload entry from a workloads YAML file.
     """
-    
+
     api: str = Field(..., description='API type (e.g., TTSIM)')
     name: str = Field(..., description='Workload name')
     basedir: str = Field(..., description='Base directory for the workload')
     module: str = Field(..., description='Module specification (format: ClassName@file.ext or file.ext)')
     params: Optional[Dict[str, Any]] = Field(None, description='Optional workload parameters')
     instances: Dict[str, Dict[str, Any]] = Field(..., description='Workload instances with their configurations')
-    
+
     class Config:
         extra = 'forbid'
         populate_by_name = True
-    
+
     @field_validator('module')
     @classmethod
     def validate_module_format(cls, v: str) -> str:
         """
         Validate the module attribute format based on file extension.
-        
+
         Rules:
         - .py files: can be 'ClassName@file.py' or 'file.py'
         - .html files: must be 'file.html' (no @ separator)
         - .onnx files: must be 'file.onnx' (no @ separator)
         - Other extensions: error and terminate
-        
+
         Args:
             v (str): Module string to validate.
-            
+
         Returns:
             str: Validated module string.
-            
+
         Raises:
             ValueError: If the module format is invalid.
         """
         # Check if module contains @ separator
         has_separator = '@' in v
-        
+
         if has_separator:
             # Format: ClassName@filename
             parts = v.split('@')
@@ -73,13 +73,13 @@ class WorkloadConfig(BaseModel):
         else:
             # Format: filename only
             filename = v
-        
+
         # Extract file extension
         if '.' not in filename:
             raise ValueError(f'Module filename must have an extension: {filename}')
-        
+
         extension = filename.rsplit('.', 1)[-1].lower()
-        
+
         # Validate extension and format
         valid_extensions = {'py', 'html', 'onnx'}
         if extension not in valid_extensions:
@@ -88,7 +88,7 @@ class WorkloadConfig(BaseModel):
                 f'Only .py, .html, and .onnx files are supported. '
                 f'Terminating due to invalid extension.'
             )
-        
+
         # Validate format rules by extension
         if extension == 'py':
             # .py files can have either format
@@ -100,27 +100,27 @@ class WorkloadConfig(BaseModel):
                     f'Module with .{extension} extension must use "file.{extension}" format, '
                     f'not "ClassName@file.{extension}" format: {v}'
                 )
-        
+
         return v
-    
+
     @field_validator('instances')
     @classmethod
     def validate_instances_is_dict(cls, v: Any) -> Dict[str, Dict[str, Any]]:
         """
         Validate that instances field is a dictionary.
-        
+
         Args:
             v: Value to validate.
-            
+
         Returns:
             Dict[str, Dict[str, Any]]: Validated instances dictionary.
-            
+
         Raises:
             ValueError: If instances is not a dictionary.
         """
         if not isinstance(v, dict):
             raise ValueError(f'Instances must be a dictionary, got {type(v).__name__}')
-        
+
         # Validate that each instance value is also a dictionary
         for instance_name, instance_config in v.items():
             if not isinstance(instance_config, dict):
@@ -128,32 +128,32 @@ class WorkloadConfig(BaseModel):
                     f'Instance "{instance_name}" configuration must be a dictionary, '
                     f'got {type(instance_config).__name__}'
                 )
-        
+
         return v
-    
+
     @field_validator('params')
     @classmethod
     def validate_params_is_dict(cls, v: Optional[Any]) -> Optional[Dict[str, Any]]:
         """
         Validate that params field is a dictionary if provided.
-        
+
         Args:
             v: Value to validate.
-            
+
         Returns:
             Optional[Dict[str, Any]]: Validated params dictionary or None.
-            
+
         Raises:
             ValueError: If params is provided but not a dictionary.
         """
         if v is not None and not isinstance(v, dict):
             raise ValueError(f'Params must be a dictionary, got {type(v).__name__}')
         return v
-    
+
     def get_model_extension(self) -> str:
         """
         Get the file extension of the model file (without the dot).
-        
+
         Returns:
             str: File extension without dot (e.g., 'py', 'html', 'onnx').
         """
@@ -162,26 +162,26 @@ class WorkloadConfig(BaseModel):
             filename = self.module.split('@')[1]
         else:
             filename = self.module
-        
+
         # Extract and return extension without dot
         extension = filename.rsplit('.', 1)[-1].lower()
         return extension
-    
+
     def get_module_class(self) -> Optional[str]:
         """
         Get the class name from the module attribute if present.
-        
+
         Returns:
             Optional[str]: Class name if module uses 'ClassName@file' format, None otherwise.
         """
         if '@' in self.module:
             return self.module.split('@')[0]
         return None
-    
+
     def get_module_filename(self) -> str:
         """
         Get the filename from the module attribute.
-        
+
         Returns:
             str: Filename (e.g., 'BasicLLM.py', 'model.onnx').
         """
@@ -193,66 +193,65 @@ class WorkloadConfig(BaseModel):
 class WorkloadsFile(BaseModel):
     """
     Pydantic model for a workloads file containing multiple workload configurations.
-    
+
     Represents the top-level structure of a workloads YAML file.
     """
-    
+
     workloads: List[WorkloadConfig] = Field(..., description='List of workload configurations')
-    
+
     class Config:
         extra = 'forbid'
         populate_by_name = True
-    
+
     @field_validator('workloads')
     @classmethod
     def validate_workloads(cls, v: List[WorkloadConfig]) -> List[WorkloadConfig]:
         """
         Validate workloads list for common issues.
-        
+
         Args:
             v: List of workload configurations to validate.
-            
+
         Returns:
             List[WorkloadConfig]: Validated workloads list.
-            
+
         Raises:
             ValueError: If workloads list is empty or contains duplicate names.
         """
         if not v:
             raise ValueError('workloads must contain at least one workload')
-        
+
         # Check for duplicate workload names
-        names = [w.name for w in v]
-        duplicates = [n for n in names if names.count(n) > 1]
+        names_lower = [w.name.lower() for w in v]
+        duplicates = [n for n in names_lower if names_lower.count(n) > 1]
         if duplicates:
-            # Get first duplicate
-            first_dup = duplicates[0]
-            raise ValueError(f'Duplicate workload name: {first_dup}')
-        
+            raise ValueError(f'Duplicate workload names: {duplicates}')
+
         return v
     
     def get_workload_by_name(self, name: str) -> Optional[WorkloadConfig]:
         """
-        Get a workload configuration by name.
-        
+        Get a workload configuration by name (case-insensitive).
+
         Args:
             name (str): Workload name to search for.
-            
+
         Returns:
             Optional[WorkloadConfig]: Workload configuration if found, None otherwise.
         """
+        name_lower = name.lower()
         for workload in self.workloads:
-            if workload.name == name:
+            if workload.name.lower() == name_lower:
                 return workload
         return None
-    
+
     def get_workloads_by_extension(self, extension: str) -> List[WorkloadConfig]:
         """
         Get all workloads with a specific model file extension.
-        
+
         Args:
             extension (str): File extension to filter by (without dot, e.g., 'py', 'html').
-            
+
         Returns:
             List[WorkloadConfig]: List of workloads matching the extension.
         """
@@ -262,19 +261,19 @@ class WorkloadsFile(BaseModel):
 def load_workloads_file(filepath: str | Path, use_cache: bool = True) -> WorkloadsFile:
     """
     Load and validate a workloads YAML file from local path or URL.
-    
+
     This function uses the existing ttsim.utils.common.parse_yaml utility which
     supports both local files and URLs through locator_handle.
-    
+
     Args:
         filepath (str | Path): Path or URL to the workloads YAML file.
         use_cache (bool): Whether to use cache for URL fetching (default: True).
                          Note: Currently parse_yaml doesn't expose cache control,
                          so this parameter is for future compatibility.
-        
+
     Returns:
         WorkloadsFile: Validated workloads file model.
-        
+
     Raises:
         ValueError: If the file format is invalid or validation fails.
         FileNotFoundError: If the local file doesn't exist.
@@ -283,22 +282,22 @@ def load_workloads_file(filepath: str | Path, use_cache: bool = True) -> Workloa
     try:
         logger.debug('Loading workloads file from: {}', filepath)
         data = parse_yaml(filepath)
-        
+
         if data is None:
             raise ValueError(f'Failed to parse YAML from {filepath}: file is empty or invalid')
-        
+
         if not isinstance(data, dict):
             raise ValueError(f'Expected dictionary at top level, got {type(data).__name__}')
-        
+
         if 'workloads' not in data:
             raise ValueError('Missing required "workloads" key in YAML file')
-        
+
         workloads_file = WorkloadsFile(**data)
-        logger.info('Successfully loaded and validated {} workloads from {}', 
+        logger.info('Successfully loaded and validated {} workloads from {}',
                    len(workloads_file.workloads), filepath)
-        
+
         return workloads_file
-        
+
     except Exception as e:
         logger.error('Failed to load workloads file from {}: {}', filepath, e)
         raise
@@ -307,19 +306,19 @@ def load_workloads_file(filepath: str | Path, use_cache: bool = True) -> Workloa
 def load_workload_config(filepath: str | Path, workload_name: str) -> WorkloadConfig:
     """
     Load a specific workload configuration by name from a workloads file.
-    
+
     Args:
         filepath (str | Path): Path or URL to the workloads YAML file.
         workload_name (str): Name of the workload to load.
-        
+
     Returns:
         WorkloadConfig: Validated workload configuration.
-        
+
     Raises:
         ValueError: If the workload name is not found or validation fails.
     """
     workloads_file = load_workloads_file(filepath)
-    
+
     workload = workloads_file.get_workload_by_name(workload_name)
     if workload is None:
         available_names = [wl.name for wl in workloads_file.workloads]
@@ -327,6 +326,6 @@ def load_workload_config(filepath: str | Path, workload_name: str) -> WorkloadCo
             f'Workload "{workload_name}" not found in {filepath}. '
             f'Available workloads: {available_names}'
         )
-    
+
     logger.info('Loaded workload configuration: {}', workload_name)
     return workload


### PR DESCRIPTION
- Workload instances are chosen by a map from workload-type (bert, resnet50 etc) x workload-name to the instance name. e.g. bertxBert-Large -> bert-large instance
- Introduced a new instance 'rn50_224x224' in the ResNet workload configuration.
- Workload name matching made case-insensitive.
- Removing trailing spaces