### PR TITLE
Set generation length to 1 in Llama3

### DIFF
--- a/workloads/ttnn/llama3/test_llama3.py
+++ b/workloads/ttnn/llama3/test_llama3.py
@@ -42,7 +42,7 @@ def test_model_inference(model_name: str = "llama3-8B"):
         max_seq_len=max_seq_len,
         max_batch_size=batch_size,
     )
-    iterations = 4 # llama3.2 3B or 8B
+    iterations = 1
 
     if layers is not None:
         model_args.n_layers = layers


### PR DESCRIPTION
The generation length is set to `1` for decode to generate only `1` token instead of `4`.