### PR TITLE
Add LPDDR5X ipblock to all_archs.yaml, and transfer_rate_GTs field to MemoryBlocks

### DIFF
--- a/config/all_archs.yaml
+++ b/config/all_archs.yaml
@@ -49,6 +49,7 @@ ipblocks:
         data_rate : 8
         freq_MHz  : 1250
         size_GB   : 4
+        transfer_rate_GTs : 20.0
     -   name: gddr7
         iptype: memory
         technology: GDDR
@@ -56,6 +57,7 @@ ipblocks:
         data_rate : 16
         freq_MHz  : 1250
         size_GB   : 2
+        transfer_rate_GTs : 40.0
     -   name: hbm1
         iptype: memory
         technology: HBM
@@ -63,6 +65,7 @@ ipblocks:
         stacks    : 8
         data_bits : 128
         size_GB   : 4
+        transfer_rate_GTs : 8.0
     -   name: hbm2
         iptype: memory
         technology: HBM
@@ -70,6 +73,7 @@ ipblocks:
         stacks    : 8
         data_bits : 128
         size_GB   : 8
+        transfer_rate_GTs : 19.2
     -   name: hbm2e
         iptype: memory
         technology: HBM
@@ -77,6 +81,7 @@ ipblocks:
         stacks    : 8
         data_bits : 128
         size_GB   : 16
+        transfer_rate_GTs : 28.8
     -   name: hbm3
         iptype: memory
         technology: HBM
@@ -84,6 +89,7 @@ ipblocks:
         stacks    : 16
         data_bits : 64
         size_GB   : 16
+        transfer_rate_GTs : 102.4
     -   name: hbm3e
         iptype: memory
         technology: HBM
@@ -91,6 +97,7 @@ ipblocks:
         stacks    : 16
         data_bits : 64
         size_GB   : 48
+        transfer_rate_GTs : 156.8
     -   name: hbm4
         iptype: memory
         technology: HBM
@@ -98,6 +105,15 @@ ipblocks:
         stacks    : 32
         data_bits : 64
         size_GB   : 64
+        transfer_rate_GTs : 204.8
+    -   name: lpddr5x
+        iptype: memory
+        technology: LPDDR
+        data_bits : 16
+        data_rate : 4
+        freq_MHz  : 1200
+        size_GB   : 4
+        transfer_rate_GTs : 9.6
 
 packages:
     -   name: Grendel

--- a/config/tt_wh.yaml
+++ b/config/tt_wh.yaml
@@ -43,6 +43,7 @@ ipblocks:
         data_rate : 8
         freq_MHz  : 750
         size_GB   : 2
+        transfer_rate_GTs : 12.0
 
 packages:
     -   name: Wormhole

--- a/tests/test_back/test_memory_bandwidth.py
+++ b/tests/test_back/test_memory_bandwidth.py
@@ -25,7 +25,8 @@ def test_peak_bandwidth_per_cycle():
         freq_MHz=1000,
         size_GB=2,
         stacks=1,
-        data_rate=1
+        data_rate=1,
+        transfer_rate_GTs=2
     )
     # Expected: 2 * 1 * 1 * 32 / 8 = 8 bytes per cycle
     assert mem1.peak_bandwidth_per_cycle() == 8.0
@@ -39,7 +40,8 @@ def test_peak_bandwidth_per_cycle():
         freq_MHz=1000,
         size_GB=2,
         stacks=1,
-        data_rate=2
+        data_rate=2,
+        transfer_rate_GTs=4
     )
     # Expected: 2 * 1 * 2 * 32 / 8 = 16 bytes per cycle
     assert mem2.peak_bandwidth_per_cycle() == 16.0
@@ -53,7 +55,8 @@ def test_peak_bandwidth_per_cycle():
         freq_MHz=1000,
         size_GB=2,
         stacks=4,
-        data_rate=2
+        data_rate=2,
+        transfer_rate_GTs=16
     )
     # Expected: 2 * 4 * 2 * 32 / 8 = 64 bytes per cycle
     assert mem3.peak_bandwidth_per_cycle() == 64.0
@@ -67,7 +70,8 @@ def test_peak_bandwidth_per_cycle():
         freq_MHz=1000,
         size_GB=2,
         stacks=1,
-        data_rate=2
+        data_rate=2,
+        transfer_rate_GTs=4
     )
     # Expected: 2 * 1 * 2 * 64 / 8 = 32 bytes per cycle
     assert mem4.peak_bandwidth_per_cycle() == 32.0
@@ -84,7 +88,8 @@ def test_peak_bandwidth_per_cycle_package():
         freq_MHz=1000,
         size_GB=2,
         stacks=1,
-        data_rate=2
+        data_rate=2,
+        transfer_rate_GTs=4
     )
 
     # Create IP group with 4 memory units


### PR DESCRIPTION
This pull request enhances the memory configuration system by introducing an explicit `transfer_rate_GTs` (giga transfers per second) field for memory IP blocks, enforcing consistency between this value and other memory parameters. It also adds validation logic and comprehensive unit tests to ensure correctness. Additionally, new memory types and updated configurations are included.

**Memory configuration and validation improvements:**

* Added a required `transfer_rate_GTs` field to the `MemoryBlockModel` in `simconfig.py`, and implemented a model validator to ensure this value matches the calculated transfer rate based on `freq_MHz`, `stacks`, and `data_rate` (using the formula: `2 * freq_GHz * stacks * data_rate`). This enforces consistency and prevents configuration mismatches.
* Updated memory IP block entries in `config/all_archs.yaml` and `config/tt_wh.yaml` to include the `transfer_rate_GTs` field for all relevant memory types, and added a new LPDDR5x memory configuration. [[1]](diffhunk://#diff-279c94f6884b7383d909f175f07846c4f2e873c21f72a9ecacc6ea3e2bc6d1a3R52-R116) [[2]](diffhunk://#diff-654c302f86288899b83045de7bf6fe23bb9d13ffd8f5c3c1bc335ef0e7cdd537R46)

**Testing enhancements:**

* Added a new unit test `test_memory_transfer_rate_validation` in `tests/test_config.py` to verify that the validator correctly accepts valid configurations and rejects mismatches for `transfer_rate_GTs`.
* Updated all relevant memory bandwidth tests in `tests/test_back/test_memory_bandwidth.py` to include the new `transfer_rate_GTs` parameter in memory block instantiations, ensuring the tests align with the new validation requirements. [[1]](diffhunk://#diff-07a759cd4a1d1cfade04a7c3f96351ca26470bfc0cd3616a2b81cce2b56c215bL28-R29) [[2]](diffhunk://#diff-07a759cd4a1d1cfade04a7c3f96351ca26470bfc0cd3616a2b81cce2b56c215bL42-R44) [[3]](diffhunk://#diff-07a759cd4a1d1cfade04a7c3f96351ca26470bfc0cd3616a2b81cce2b56c215bL56-R59) [[4]](diffhunk://#diff-07a759cd4a1d1cfade04a7c3f96351ca26470bfc0cd3616a2b81cce2b56c215bL70-R74) [[5]](diffhunk://#diff-07a759cd4a1d1cfade04a7c3f96351ca26470bfc0cd3616a2b81cce2b56c215bL87-R92)

**Internal code updates:**

* Imported `isclose` from `math` in `simconfig.py` to support floating-point comparison in the new validator.