### PR TITLE
Enable correlation for new workloads; Refactor workload config handling

### DIFF
--- a/config/all_workloads.yaml
+++ b/config/all_workloads.yaml
@@ -76,10 +76,11 @@ workloads:
     name: RESNET50
     basedir: workloads
     module : ResNet@basicresnet.py
-    params : {layers: [3,4,6,3], num_classes: 1000, num_channels: 3, use_adaptive_pool: true, init_stride: 4, bs: 1}
+    params : {layers: [3,4,6,3], num_classes: 1000, num_channels: 3, bs: 1}
     instances:
-      rn50_b1_hd : { img_height: 1024, img_width: 1024 }
-      rn50_b1_uhd: { img_height: 2828, img_width: 2828 }
+      rn50_224x224 : { img_height: 224, img_width: 224 }
+      rn50_b1_hd : { img_height: 1024, img_width: 1024, use_adaptive_pool: true, init_stride: 4 }
+      rn50_b1_uhd: { img_height: 2828, img_width: 2828, use_adaptive_pool: true, init_stride: 4 }
 
   - api: TTSIM
     name: BEVDepth
@@ -136,20 +137,21 @@ workloads:
     module : test_vgg_unet@ttnn_vgg_unet.py
     instances:
       vgg_unet_test: { bs: 1}
+      vgg_unet_256x256: { bs: 1, img_height: 256, img_width: 256}
 
   - api: TTNN
     name: llama3_decode
     basedir: workloads/ttnn/llama3
     module : run_llama3@test_llama3_decode.py
     instances:
-      llama3_8b: { bs: 1, model_name: llama3-8B }
+      llama3_8b_decode: { bs: 1, model_name: llama3-8B }
 
   - api: TTNN
     name: llama3_prefill
     basedir: workloads/ttnn/llama3
     module : run_llama3@test_llama3_prefill.py
     instances:
-      llama3_8b: { bs: 1, model_name: llama3-8B }
+      llama3_8b_prefill: { bs: 1, model_name: llama3-8B }
 
   - api: TTNN
     name: vit
@@ -157,3 +159,4 @@ workloads:
     module : run_vit@test_ttnn_functional_vit.py
     instances:
       vit_b16: { bs: 1, model_name: vit-b16 }
+      vit_base_224x224: { bs: 1, model_name: vit-b16 }

--- a/config/ttsi_correlation_workloads.yaml
+++ b/config/ttsi_correlation_workloads.yaml
@@ -99,3 +99,33 @@ workloads:
       LeViT_192: { img_height: 224, img_width: 224, img_channels: 3, bs: 1, patch_size: 16, dims: [192, 288, 384], depths: [4, 4, 4], heads: [3, 5, 6], key_dim: [32, 32, 32], attn_ratio: [2, 2, 2], mlp_ratio: [2, 2, 2], down_ops: [["Subsample", 32, 6, 4, 2, 2], ["Subsample", 32, 9, 4, 2, 2]], drop_path: 0, global_pool: avg, compute_pipe: matrix }
       LeViT_256: { img_height: 224, img_width: 224, img_channels: 3, bs: 1, patch_size: 16, dims: [256, 384, 512], depths: [4, 4, 4], heads: [4, 6, 8], key_dim: [32, 32, 32], attn_ratio: [2, 2, 2], mlp_ratio: [2, 2, 2], down_ops: [["Subsample", 32, 8, 4, 2, 2], ["Subsample", 32, 12, 4, 2, 2]], drop_path: 0, global_pool: avg, compute_pipe: matrix }
       LeViT_384: { img_height: 224, img_width: 224, img_channels: 3, bs: 1, patch_size: 16, dims: [384, 512, 768], depths: [6, 9, 12], heads: [6, 9, 12], key_dim: [32, 32, 32], attn_ratio: [2, 2, 2], mlp_ratio: [2, 2, 2], down_ops: [["Subsample", 32, 12, 4, 2, 2], ["Subsample", 32, 16, 4, 2, 2]], drop_path: 0.1, global_pool: avg, compute_pipe: matrix }
+
+  - api: TTNN
+    name: VGG_UNET
+    basedir: workloads/ttnn/vgg_unet
+    module : test_vgg_unet@ttnn_vgg_unet.py
+    instances:
+      vgg_unet_test: { bs: 1}
+      vgg_unet_256x256: { bs: 1, img_height: 256, img_width: 256}
+  - api: TTNN
+    name: llama3
+    basedir: workloads/ttnn/llama3
+    module : run_llama3@test_llama3.py
+    instances:
+      llama3_8b: { bs: 1, model_name: llama3-8B }
+
+  - api: TTNN
+    name: vit
+    basedir: workloads/ttnn/vit
+    module : run_vit@test_ttnn_functional_vit.py
+    instances:
+      vit_b16: { bs: 1, model_name: vit-b16 }
+      vit_base_224x224: { bs: 1, model_name: vit-b16 }
+
+  # TODO: Enable after SD full run works
+  # - api: TTSIM
+  #   name: StableDiffusion
+  #   basedir: workloads/diffusers
+  #   module : SDModel@stablediffusion.py
+  #   instances:
+  #     sd_b1 : {bs: 1}

--- a/tests/test_tools/test_ttsi_corr_utils.py
+++ b/tests/test_tools/test_ttsi_corr_utils.py
@@ -94,9 +94,22 @@ class TestGetWorkloadNameFromModel:
 
     def test_stable_diffusion(self):
         """Test Stable Diffusion / UNet."""
-        assert get_workload_name_from_model('Stable Diffusion') == 'unet'
-        assert get_workload_name_from_model('stable diffusion') == 'unet'
+        assert get_workload_name_from_model('Stable Diffusion') == 'stablediffusion'
+        assert get_workload_name_from_model('stable diffusion') == 'stablediffusion'
         assert get_workload_name_from_model('UNet') == 'unet'
+
+    def test_vgg_unet(self):
+        """Test VGG UNet workload name detection."""
+        assert get_workload_name_from_model('UNet - VGG19 (256x256)') == 'vgg_unet'
+        assert get_workload_name_from_model('VGG UNet') == 'vgg_unet'
+        assert get_workload_name_from_model('vgg unet') == 'vgg_unet'
+
+    def test_vit(self):
+        """Test ViT workload name detection."""
+        assert get_workload_name_from_model('ViT-Base (224x224)') == 'vit'
+        assert get_workload_name_from_model('VIt-Base') == 'vit'
+        assert get_workload_name_from_model('vit-base') == 'vit'
+        assert get_workload_name_from_model('VIT') == 'vit'
 
     def test_unknown_model(self):
         """Test unknown model defaults to first word."""
@@ -140,8 +153,20 @@ class TestGetBenchmarkFromModel:
 
     def test_unet_benchmark(self):
         """Test UNet/Stable Diffusion benchmark mapping."""
-        assert get_benchmark_from_model('Stable Diffusion') == 'Benchmark.UNet'
+        assert get_benchmark_from_model('Stable Diffusion') == 'Benchmark.StableDiffusion'
         assert get_benchmark_from_model('UNet') == 'Benchmark.UNet'
+
+    def test_vgg_unet_benchmark(self):
+        """Test VGG UNet benchmark mapping."""
+        assert get_benchmark_from_model('UNet - VGG19 (256x256)') == 'Benchmark.VggUnet'
+        assert get_benchmark_from_model('VGG UNet') == 'Benchmark.VggUnet'
+        assert get_benchmark_from_model('vgg unet') == 'Benchmark.VggUnet'
+
+    def test_vit_benchmark(self):
+        """Test ViT benchmark mapping."""
+        assert get_benchmark_from_model('ViT-Base (224x224)') == 'Benchmark.ViT'
+        assert get_benchmark_from_model('VIt-Base') == 'Benchmark.ViT'
+        assert get_benchmark_from_model('vit-base') == 'Benchmark.ViT'
 
     def test_unknown_benchmark(self):
         """Test unknown model benchmark mapping."""
@@ -165,12 +190,12 @@ class TestIntegration:
         # Simulate extracting info from a table row
         model_name = 'Llama 3.1 8B'
         hardware = 'n150 (Wormhole)'
-        
+
         # Parse components
         device = parse_hardware_to_device(hardware)
         workload_name = get_workload_name_from_model(model_name)
         benchmark = get_benchmark_from_model(model_name)
-        
+
         # Verify results
         assert device == 'n150'
         assert workload_name == 'llama3'
@@ -182,7 +207,7 @@ class TestIntegration:
             'Llama 3.1 8B',
             'Llama 3.2 1B',
         ]
-        
+
         for model in models:
             assert get_workload_name_from_model(model) == 'llama3'
             assert get_benchmark_from_model(model) == 'Benchmark.Llama'
@@ -195,10 +220,9 @@ class TestIntegration:
             ('Llama 3.1 8B', 'llama3', 'Benchmark.Llama'),
             ('Mamba-2.8B', 'mamba', 'Benchmark.Mamba'),
             ('YOLOv8', 'yolov8', 'Benchmark.YOLO'),
-            ('Stable Diffusion', 'unet', 'Benchmark.UNet'),
+            ('Stable Diffusion', 'stablediffusion', 'Benchmark.StableDiffusion'),
         ]
-        
+
         for model, expected_workload, expected_benchmark in test_cases:
             assert get_workload_name_from_model(model) == expected_workload
             assert get_benchmark_from_model(model) == expected_benchmark
-

--- a/tools/ttsi_corr/ttsi_corr_utils.py
+++ b/tools/ttsi_corr/ttsi_corr_utils.py
@@ -79,9 +79,19 @@ def get_workload_name_from_model(model: str) -> str:
             return 'yolov7'
         return 'yolo'
 
-    # Stable Diffusion / UNet
-    if 'stable diffusion' in model_lower or 'unet' in model_lower:
+    # Stable Diffusion
+    if 'stable diffusion' in model_lower:
+        return 'stablediffusion'
+
+    # UNet
+    if 'unet' in model_lower:
+        if 'vgg' in model_lower:
+            return 'vgg_unet'
         return 'unet'
+
+    # VIT
+    if 'vit' in model_lower:
+        return 'vit'
 
     # Default: use first word of model name
     return model.split()[0].lower()
@@ -109,8 +119,14 @@ def get_benchmark_from_model(model: str) -> str:
         return 'Benchmark.Mamba'
     elif 'yolo' in model_lower:
         return 'Benchmark.YOLO'
-    elif 'stable diffusion' in model_lower or 'unet' in model_lower:
+    elif 'stable diffusion' in model_lower:
+        return 'Benchmark.StableDiffusion'
+    elif 'unet' in model_lower:
+        if 'vgg' in model_lower:
+            return 'Benchmark.VggUnet'
         return 'Benchmark.UNet'
+    elif 'vit' in model_lower:
+        return 'Benchmark.ViT'
     else:
         # Default: use model name as benchmark
         return f'Benchmark.{model.split()[0]}'


### PR DESCRIPTION
- Enable correlation run for newly added TTNN workloads
- Change default workloads config path in run_ttsi_corr.py
- Update workload configurations for RESNET50 and TTNN models
- Add --workload-group command line argument to filter on workload API (e.g. TTSIM, TTNN)