### PR TITLE
Update mypy exclude patterns in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ addopts = "--durations=0"
 [tool.mypy]
 check_untyped_defs = true
 explicit_package_bases = true
-exclude = "^__.*/|^tests/|ttsim/back/tensix_neo|ttsim/front/llk"
+exclude = "^__.*/|^tests/|ttsim/back/tensix_neo|ttsim/front/llk|/reference/"
 # disallow_untyped_calls = true
 # disallow_untyped_defs = true
 warn_unreachable = true


### PR DESCRIPTION
Any non-polaris reference code that we wish to add to the repository can break regressions, particularly about the static checks such as mypy. To enable such reference code to be added without breaking regressions, we add `/reference/` as an exclude pattern for mypy, so any files in directories (anywhere in the repo) named `reference` will be excluded from mypy checks. 

@ramamalladiTT 