### PR TITLE
ci(348): exclude reference/ dirs from Ruff, isort, and SPDX checks

### DIFF
--- a/.github/spdxchecker-config.yml
+++ b/.github/spdxchecker-config.yml
@@ -21,6 +21,7 @@ ignore:
   - '*.ipynb'
   - 'CODEOWNERS'
   - 'NOTICE'
+  - '**/reference/*'
 
 # Files that should generate warnings instead of errors
 warning:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,10 +87,12 @@ directory = "__htmlcov"
 force_to_top = ["sys" , "os"]
 honor_noqa = true
 line_length = 120
+skip_glob = ["**/reference/*"]
 
 [tool.ruff]
 line-length = 120
 indent-width = 4
+extend-exclude = ["**/reference/*"]
 
 [tool.ruff.format]
 quote-style = "single"


### PR DESCRIPTION
## Summary

- `reference/` directories under `workloads/` hold third-party / example implementations that mypy already excludes (via the `/reference/` pattern in `pyproject.toml`). Ruff, isort, and the SPDX checker were not, producing false-positive findings on those files. This PR plugs the three remaining gaps with a single `**/reference/*` glob per tool — matching `reference/` at any nesting depth.
- For Ruff, `extend-exclude` is used (not `exclude`) so the tool's default exclude list (`.venv`, `__pycache__`, build artifacts, etc.) is preserved while adding `**/reference/*`.
- Bundles a one-line type annotation in `ttsim/front/onnx/onnx2nx.py` (`nodeinfo: dict[str, Any]`) to unblock the pre-commit mypy hook — same pre-existing main bug also bundled in PR #434 and PR #459. Whichever merges first wins; others get a trivial rebase.

Closes #348.

## Test plan

- [x] `python ./checkin_tests.py static` (SPDX + mypy) passes locally on squashed HEAD
- [x] `pre-commit run --all-files` clean on squashed HEAD
- [x] `checkin-tests` + `userenv-tests` green in CI on squashed commit (`c9e7ceb`)