### PR TITLE
Add ONNX + Polaris support for pi0fast-base and pi05-base

### DIFF
--- a/config/ip_workloads.yaml
+++ b/config/ip_workloads.yaml
@@ -68,6 +68,31 @@ workloads:
                  img_width: 224 }
 
   - api: ONNX
+    name: PI0FAST_BASE
+    basedir: workloads/onnx
+    module: pi0fast_base_fixed-224.onnx
+    instances:
+      default: { path: pi0fast_base_fixed-224.onnx,
+                 bs: 1,
+                 img_height: 224,
+                 img_width: 224,
+                 seq_len: 200,
+                 fast_tokens: 256 }
+
+  - api: ONNX
+    name: PI05_BASE
+    basedir: workloads/onnx
+    module: pi05_base_fixed-224.onnx
+    instances:
+      default: { path: pi05_base_fixed-224.onnx,
+                 bs: 1,
+                 img_height: 224,
+                 img_width: 224,
+                 seq_len: 200,
+                 chunk_size: 50,
+                 max_action_dim: 32 }
+
+  - api: ONNX
     name: UNET-BASE
     basedir: workloads/onnx
     module: unet-fixed-256.onnx

--- a/config/wl2archmapping.yaml
+++ b/config/wl2archmapping.yaml
@@ -57,7 +57,7 @@ op_rsrc_spec:
              Pad, Permute, Pow,
              QuantizeLinear,
              Reciprocal, ReduceMax, ReduceMean, ReduceMin, ReduceProd, ReduceSum, Relu, Reshape, Resize,
-             ScatterND, ScatterElements, Shape, Sigmoid, Sin, Slice, Softmax, Softplus, Split, Sqrt, Squeeze, Sub, Sum,
+             ScatterND, ScatterElements, Shape, Sigmoid, Sin, Slice, Softmax, SoftmaxCrossEntropyLoss, Softplus, Split, Sqrt, Squeeze, Sub, Sum,
              Tanh, Tile, TopK, TorchGather, Transpose, Trilu,
              Unsqueeze, Upsample,
              VoxelPooling,

--- a/tests/test_ops/test_softmax_cross_entropy_loss.py
+++ b/tests/test_ops/test_softmax_cross_entropy_loss.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for TTSim SoftmaxCrossEntropyLoss shape/perf inference.
+"""
+
+import numpy as np
+import pytest
+
+from ttsim.ops.tensor import SimTensor
+from ttsim.ops.desc.math import softmax_cross_entropy_loss_sinf
+
+SEED = 42
+
+def _seed():
+    np.random.seed(SEED)
+
+def make_sim_tensor(data, name="t"):
+    return SimTensor(
+        {
+            "name": name,
+            "shape": list(data.shape),
+            "data": data.copy(),
+            "dtype": np.dtype(np.float32),
+        }
+    )
+
+class _FakeOp:
+    def __init__(self, **attrs):
+        self.attrs = attrs
+        self.precision = np.dtype(np.float32)
+        self.perf_stats = None
+
+@pytest.mark.unit
+@pytest.mark.opunit
+def test_softmax_ce_reduction_none_shapes_and_perf():
+    _seed()
+    B, C = 4, 7
+    scores_data = np.random.randn(B, C).astype(np.float32)
+    # Use probabilities / soft labels; shape must match scores
+    labels_data = np.random.rand(B, C).astype(np.float32)
+    labels_data /= labels_data.sum(axis=-1, keepdims=True)
+
+    scores = make_sim_tensor(scores_data, "sce_scores")
+    labels = make_sim_tensor(labels_data, "sce_labels")
+    loss_out = make_sim_tensor(np.zeros_like(labels_data), "sce_loss")
+
+    op = _FakeOp(reduction="none")
+
+    softmax_cross_entropy_loss_sinf([scores, labels], [loss_out], op)
+
+    assert list(loss_out.shape) == [B, C]
+    assert loss_out.dtype == scores.dtype
+
+    assert op.perf_stats is not None
+    for key in ("inElems", "outElems", "inBytes", "outBytes"):
+        assert key in op.perf_stats
+        assert op.perf_stats[key] >= 0
+
+@pytest.mark.unit
+@pytest.mark.opunit
+@pytest.mark.parametrize("reduction", ["mean", "sum"])
+def test_softmax_ce_scalar_reduction(reduction):
+    _seed()
+    B, C = 2, 5
+    scores_data = np.random.randn(B, C).astype(np.float32)
+    labels_data = np.random.rand(B, C).astype(np.float32)
+    labels_data /= labels_data.sum(axis=-1, keepdims=True)
+
+    scores = make_sim_tensor(scores_data, f"sce_scores_{reduction}")
+    labels = make_sim_tensor(labels_data, f"sce_labels_{reduction}")
+    loss_out = make_sim_tensor(np.array(0.0, dtype=np.float32), f"sce_loss_{reduction}")
+
+    op = _FakeOp(reduction=reduction)
+
+    softmax_cross_entropy_loss_sinf([scores, labels], [loss_out], op)
+
+    assert loss_out.shape == []
+    assert loss_out.dtype == scores.dtype
+
+@pytest.mark.unit
+@pytest.mark.opunit
+def test_softmax_ce_optional_log_prob_output_shape():
+    _seed()
+    B, C = 3, 6
+    scores_data = np.random.randn(B, C).astype(np.float32)
+    labels_data = np.random.rand(B, C).astype(np.float32)
+    labels_data /= labels_data.sum(axis=-1, keepdims=True)
+
+    scores = make_sim_tensor(scores_data, "sce_scores_logp")
+    labels = make_sim_tensor(labels_data, "sce_labels_logp")
+    loss_out = make_sim_tensor(np.array(0.0, dtype=np.float32), "sce_loss_logp")
+    log_prob_out = make_sim_tensor(np.zeros_like(scores_data), "sce_log_prob")
+
+    op = _FakeOp(reduction="mean")
+
+    softmax_cross_entropy_loss_sinf(
+        [scores, labels],
+        [loss_out, log_prob_out],
+        op,
+    )
+
+    assert list(log_prob_out.shape) == [B, C]
+    assert log_prob_out.dtype == scores.dtype

--- a/tests/test_ops/test_trilu.py
+++ b/tests/test_ops/test_trilu.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for TTSim Trilu — DLRM 1-input path + ONNX 2-input path.
+
+- 1-input: legacy DLRM behavior (flattened upper triangle without diagonal).
+- 2-input: ONNX behavior (output shape == input shape), k is ignored for shape.
+"""
+
+import numpy as np
+import pytest
+
+from ttsim.ops.tensor import SimTensor
+import ttsim.front.functional.op as F
+from ttsim.ops.desc.tensor import trilu_sinf
+from tests.test_ops.utils import generate_test_data
+
+RTOL = 1e-4
+ATOL = 1e-5
+SEED = 42
+
+def _seed():
+    np.random.seed(SEED)
+
+def make_sim_tensor(data, name="t"):
+    return SimTensor(
+        {
+            "name": name,
+            "shape": list(data.shape),
+            "data": data.copy(),
+            "dtype": np.dtype(np.float32),
+        }
+    )
+
+class _FakeOp:
+    def __init__(self, **attrs):
+        self.attrs = attrs
+        self.precision = np.dtype(np.float32)
+        self.perf_stats = None
+
+@pytest.mark.unit
+@pytest.mark.opunit
+def test_trilu_dlrm_flatten_upper():
+    """
+    1-input Trilu — DLRM legacy path via F.TriluX.
+
+    Input:  [B, N, N]
+    Output: [B, N*(N-1)/2] upper-triangle (i<j) flattened.
+    """
+    _seed()
+    B, N = 2, 4
+    x_data = generate_test_data((B, N, N), "mixed").astype(np.float32)
+    x = make_sim_tensor(x_data, "trilu_dlrm_in")
+
+    trilu = F.TriluX("trilu_dlrm")
+    out = trilu(x)
+
+    expected_cols = N * (N - 1) // 2
+    assert list(out.shape) == [B, expected_cols]
+
+    ref = []
+    for b in range(B):
+        upper_vals = []
+        for i in range(N):
+            for j in range(i + 1, N):
+                upper_vals.append(x_data[b, i, j])
+        ref.append(upper_vals)
+    ref = np.asarray(ref, dtype=np.float32)
+
+    assert out.data is not None
+    assert np.allclose(out.data, ref, rtol=RTOL, atol=ATOL)
+
+@pytest.mark.unit
+@pytest.mark.opunit
+def test_trilu_onnx_two_input_shape():
+    """
+    2-input Trilu — ONNX path via trilu_sinf directly.
+
+    Input:  data [B, H, W], k scalar
+    Output: same shape as data.
+    """
+    _seed()
+    B, H, W = 3, 5, 5
+    x_data = generate_test_data((B, H, W), "mixed").astype(np.float32)
+    x = make_sim_tensor(x_data, "trilu_onnx_in")
+
+    k_data = np.array(0, dtype=np.int64)
+    k = SimTensor(
+        {
+            "name": "trilu_k",
+            "shape": [],
+            "data": k_data.copy(),
+            "dtype": k_data.dtype,
+        }
+    )
+
+    y_data = np.zeros_like(x_data, dtype=np.float32)
+    y = make_sim_tensor(y_data, "trilu_onnx_out")
+
+    op = _FakeOp(upper=1)
+
+    trilu_sinf([x, k], [y], op)
+
+    assert list(y.shape) == [B, H, W]
+    assert y.dtype == x.dtype

--- a/ttsim/ops/desc/math.py
+++ b/ttsim/ops/desc/math.py
@@ -71,6 +71,67 @@ def binary_cross_entropy_with_logits_sinf(iTList, oTList, op, **kwargs):
 
     return output_t
 
+def softmax_cross_entropy_loss_sinf(iTList, oTList, op, **kwargs):
+    """
+    SoftmaxCrossEntropyLoss shape/perf inference.
+    """
+    scores = iTList[0]
+    labels = iTList[1]
+
+    loss_out = oTList[0]
+    log_prob_out = oTList[1] if len(oTList) > 1 else None
+
+    reduction = op.attrs.get("reduction", "mean")
+
+    assert scores.check_shape(), f"Scores shape not defined: {scores}"
+    assert labels.check_shape(), f"Labels shape not defined: {labels}"
+
+    axis = op.attrs.get("axis", 1)
+    scores_shape = list(scores.shape)
+    labels_shape = list(labels.shape)
+
+    if axis < 0:
+        axis += len(scores_shape)
+    assert 0 <= axis < len(scores_shape), (
+        f"Invalid axis={axis} for scores shape {scores_shape}"
+    )
+
+    index_label_shape = scores_shape[:axis] + scores_shape[axis + 1 :]
+
+    assert (
+        labels_shape == scores_shape
+        or labels_shape == index_label_shape
+    ), (
+        f"Incompatible scores/labels shapes for SoftmaxCrossEntropyLoss: "
+        f"scores={scores_shape}, labels={labels_shape}, axis={axis}"
+    )
+
+    if reduction == "none":
+        loss_out.shape = list(labels.shape)
+    else:
+        loss_out.shape = []
+    loss_out.dtype = scores.dtype
+
+    if log_prob_out is not None:
+        log_prob_out.shape = list(scores.shape)
+        log_prob_out.dtype = scores.dtype
+
+    inBytes = sum(t.nbytes(op.precision) for t in iTList)
+    inElems = sum(t.nelems() for t in iTList)
+    outBytes = sum(
+        t.nbytes(op.precision) for t in oTList if t.check_shape()
+    )
+    outElems = sum(t.nelems() for t in oTList if t.check_shape())
+
+    op.perf_stats = {
+        "inElems": int(inElems),
+        "inBytes": int(inBytes),
+        "outElems": int(outElems),
+        "outBytes": int(outBytes),
+        "instrs": {"mov": int(outElems)},
+    }
+
+    return loss_out
 
 def einsum_sinf(iTList, oTList, op, **kwargs):
     """
@@ -800,6 +861,24 @@ def register_math_ops():
             1,
             1,
             binary_cross_entropy_with_logits_sinf,
+            True,
+            True,
+            True,
+            True,
+            True,
+        ],
+        [
+            "SoftmaxCrossEntropyLoss",
+            "ARITY_VARIADIC[2-3]->VARIADIC[1-2]",
+            "ai.onnx",
+            "COMMON",
+            13,
+            13,
+            3,
+            2,
+            2,
+            1,
+            softmax_cross_entropy_loss_sinf,
             True,
             True,
             True,

--- a/ttsim/ops/desc/tensor.py
+++ b/ttsim/ops/desc/tensor.py
@@ -11,35 +11,67 @@ from ttsim.utils.common import prod_ints
 
 def trilu_sinf(iTList, oTList, op, **kwargs):
     """
-    TODO: this is very specific to DLRM usage right now
-     need to generalize this as specified in ONNX opset!!
+    Shape/perf inference for Trilu with dual behavior:
+
+    - len(iTList) == 1: DLRM legacy path that flattens the strict upper
+      triangle (i < j) into a feature vector (output shape != input shape).
+    - len(iTList) == 2: generic ONNX Trilu(A, k) where the output tensor
+      has the same shape and dtype as the input tensor A; k is ignored
+      for shape/perf purposes.
     """
-    upper = op.attrs.get('upper', 1)
-    assert len(iTList) == 1, f"More than 1 inputs not supported for Trilu for now!!"
 
-    X = iTList[0].clone_by_shape()
+    if len(iTList) == 1:
+        X = iTList[0].clone_by_shape()
 
-    # Get the upper triangular indices manually (excluding diagonal)
-    # This Code is DLRM specific
-    row_indices, col_indices = [], []
-    batch_size, num_features1, num_features2 = X.shape
-    assert num_features1 == num_features2, f"Input should be an batch of square matrices: {X.shape}"
-    num_features = num_features1
-    for i in range(num_features):
-        for j in range(i + 1, num_features):
-            row_indices.append(i)
-            col_indices.append(j)
-    tmp_data = X.data[:, row_indices, col_indices]
-    tmp_outT = build_tmp_data_tensor(tmp_data, op.name + '__tmp_out__')
-    update_output_tensor(op, tmp_outT, oTList[0])
+        row_indices, col_indices = [], []
+        batch_size, num_features1, num_features2 = X.shape
+        assert (
+            num_features1 == num_features2
+        ), f"Input should be an batch of square matrices: {X.shape}"
+        num_features = num_features1
+        for i in range(num_features):
+            for j in range(i + 1, num_features):
+                row_indices.append(i)
+                col_indices.append(j)
+        tmp_data = X.data[:, row_indices, col_indices]
+        tmp_outT = build_tmp_data_tensor(tmp_data, op.name + "__tmp_out__")
+        update_output_tensor(op, tmp_outT, oTList[0])
+
+        op.perf_stats = {
+            "inElems": X.nelems(),
+            "inBytes": X.nbytes(op.precision),
+            "outElems": oTList[0].nelems(),
+            "outBytes": oTList[0].nbytes(op.precision),
+            "instrs": {"mov": int(oTList[0].nelems())},
+        }
+        return op.perf_stats
+
+    X = iTList[0]
+    Y = oTList[0]
+
+    if not Y.check_shape():
+        assert X.check_shape(), f"Input tensor shape not defined: {X}"
+        Y.shape = list(X.shape)
+    else:
+        assert list(Y.shape) == list(X.shape), (
+            f"Preallocated output shape mismatch in Trilu: "
+            f"expected {X.shape}, got {Y.shape}"
+        )
+
+    Y.dtype = X.dtype
+
+    inBytes = sum(t.nbytes(op.precision) for t in iTList)
+    inElems = sum(t.nelems() for t in iTList)
+    outBytes = Y.nbytes(op.precision)
+    outElems = Y.nelems()
 
     op.perf_stats = {
-            'inElems' : X.nelems(),
-            'inBytes' : X.nbytes(op.precision),
-            'outElems': oTList[0].nelems(),
-            'outBytes': oTList[0].nbytes(op.precision),
-            'instrs'  : {'mov': 100} #dummy - TODO get the real cost involved!!
-            }
+        "inElems": int(inElems),
+        "inBytes": int(inBytes),
+        "outElems": int(outElems),
+        "outBytes": int(outBytes),
+        "instrs": {"mov": int(outElems)},
+    }
     return op.perf_stats
 
 def where_sinf(iTList, oTList, op, **kwargs):

--- a/workloads/onnx/examples/pi05_base_onnx_dump.py
+++ b/workloads/onnx/examples/pi05_base_onnx_dump.py
@@ -1,0 +1,193 @@
+# #!/usr/bin/env python
+# # SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# # SPDX-License-Identifier: Apache-2.0
+
+# """
+# Export the full Pi0.5 (pi05_base) model to a fixed-shape ONNX graph
+# for Polaris perf projection.
+
+# """
+
+# from pathlib import Path
+
+# import torch
+# from torch import Tensor, nn
+
+# try:
+#     from lerobot.configs.policies import PreTrainedConfig
+#     from lerobot.policies.pi05.configuration_pi05 import PI05Config
+#     from lerobot.policies.pi05.modeling_pi05 import PI05Pytorch
+# except ModuleNotFoundError as e: 
+#     raise SystemExit(
+#         "LeRobot with pi05 is not installed.\n"
+#         'Install it with:\n'
+#         '  pip install "lerobot[pi]@git+https://github.com/huggingface/lerobot.git"\n'
+#     ) from e
+
+# MODEL_ID = "lerobot/pi05_base"
+# DEFAULT_OUT_PATH = "workloads/onnx/pi05_base_fixed-224.onnx"
+
+# class PI05PytorchExport(PI05Pytorch):
+
+#     def sample_noise(self, shape, device):
+#         return torch.zeros(shape, dtype=torch.float32, device=device)
+
+#     def sample_time(self, bsize: int, device):
+#         return torch.full(
+#             (bsize,),
+#             0.5,
+#             dtype=torch.float32,
+#             device=device,
+#         )
+
+# class Pi05ForwardWrapper(nn.Module):
+#     """
+#     Wrapper around the full PI05Pytorch model so ONNX sees only tensor
+#     inputs. Calls the real training forward(), so the entire model graph
+#     (PaliGemma + flow-matching head) is exported.
+
+#     Inputs:
+#       image:                   [B, 3, H, W]        float32 in [0, 1]
+#       image_mask:              [B]                 bool
+#       language_tokens:         [B, L]              int64
+#       language_attention_mask: [B, L]              bool
+#       actions:                 [B, T, D]           float32
+
+#     Output:
+#       loss:                    [B, T, D]           float32 (per-step, per-dim loss)
+#     """
+
+#     def __init__(self, core_model: nn.Module):
+#         super().__init__()
+#         self.core = core_model
+
+#     def forward(
+#         self,
+#         image: Tensor,
+#         image_mask: Tensor,
+#         language_tokens: Tensor,
+#         language_attention_mask: Tensor,
+#         actions: Tensor,
+#     ) -> Tensor:
+#         images = [image]
+#         img_masks = [image_mask]
+
+#         losses = self.core(
+#             images=images,
+#             img_masks=img_masks,
+#             tokens=language_tokens,
+#             masks=language_attention_mask,
+#             actions=actions,
+#         )
+#         return losses
+
+# def export_pi05_onnx(
+#     output_path: str = DEFAULT_OUT_PATH,
+#     batch_size: int = 1,
+# ) -> None:
+#     print(f"[pi05] Loading PI05Config from {MODEL_ID} ...")
+#     cfg_any = PreTrainedConfig.from_pretrained(MODEL_ID)
+#     if not isinstance(cfg_any, PI05Config):
+#         raise TypeError(f"Expected PI05Config, got {type(cfg_any)}")
+#     cfg: PI05Config = cfg_any
+
+#     cfg.device = "cpu"
+#     cfg.gradient_checkpointing = False
+#     cfg.compile_model = False
+
+#     print("[pi05] Constructing full PI05PytorchExport model (random weights) ...")
+#     core = PI05PytorchExport(
+#         config=cfg,
+#         rtc_processor=None,
+#     )
+#     core.eval()
+
+#     wrapper = Pi05ForwardWrapper(core)
+#     wrapper.eval()
+
+#     img_h, img_w = cfg.image_resolution
+#     lang_len = cfg.tokenizer_max_length
+#     chunk_size = cfg.chunk_size
+#     max_action_dim = cfg.max_action_dim
+
+#     print(
+#         "[pi05] Using fixed shapes:\n"
+#         f"  image                  = ({batch_size}, 3, {img_h}, {img_w})\n"
+#         f"  image_mask             = ({batch_size},)\n"
+#         f"  language_tokens        = ({batch_size}, {lang_len})\n"
+#         f"  language_attention_mask= ({batch_size}, {lang_len})\n"
+#         f"  actions                = ({batch_size}, {chunk_size}, {max_action_dim})"
+#     )
+
+#     device = torch.device("cpu")
+
+#     dummy_image = torch.zeros(
+#         batch_size,
+#         3,
+#         img_h,
+#         img_w,
+#         dtype=torch.float32,
+#         device=device,
+#     )
+
+#     dummy_image_mask = torch.ones(
+#         batch_size,
+#         dtype=torch.bool,
+#         device=device,
+#     )
+
+#     dummy_lang_tokens = torch.zeros(
+#         batch_size,
+#         lang_len,
+#         dtype=torch.long,
+#         device=device,
+#     )
+
+#     dummy_lang_attn = torch.ones(
+#         batch_size,
+#         lang_len,
+#         dtype=torch.bool,
+#         device=device,
+#     )
+
+#     dummy_actions = torch.zeros(
+#         batch_size,
+#         chunk_size,
+#         max_action_dim,
+#         dtype=torch.float32,
+#         device=device,
+#     )
+
+#     out_path = Path(output_path)
+#     out_path.parent.mkdir(parents=True, exist_ok=True)
+
+#     print(f"[pi05] Exporting ONNX to {out_path} ...")
+#     torch.onnx.export(
+#         wrapper,
+#         (
+#             dummy_image,
+#             dummy_image_mask,
+#             dummy_lang_tokens,
+#             dummy_lang_attn,
+#             dummy_actions,
+#         ),
+#         out_path.as_posix(),
+#         input_names=[
+#             "image",
+#             "image_mask",
+#             "language_tokens",
+#             "language_attention_mask",
+#             "actions",
+#         ],
+#         output_names=["loss"],
+#         opset_version=18,
+#         dynamic_axes=None,
+#         do_constant_folding=True,
+#     )
+#     print(f"[pi05] Saved fixed-shape ONNX: {out_path}")
+
+# def main() -> None:
+#     export_pi05_onnx()
+
+# if __name__ == "__main__":
+#     main()

--- a/workloads/onnx/examples/pi0fast_base_onnx_dump.py
+++ b/workloads/onnx/examples/pi0fast_base_onnx_dump.py
@@ -1,0 +1,194 @@
+# #!/usr/bin/env python
+# # SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# # SPDX-License-Identifier: Apache-2.0
+
+# """
+# Export the full PI0-FAST (pi0fast-base) model to a fixed-shape ONNX graph
+# for Polaris perf projection.
+
+# """
+
+# from pathlib import Path
+
+# import torch
+# from torch import Tensor, nn
+
+# try:
+#     from lerobot.configs.policies import PreTrainedConfig
+#     from lerobot.policies.pi0_fast.configuration_pi0_fast import PI0FastConfig
+#     from lerobot.policies.pi0_fast.modeling_pi0_fast import PI0FastPytorch
+# except ModuleNotFoundError as e:
+#     raise SystemExit(
+#         "LeRobot with pi0-fast is not installed.\n"
+#         'Install it with:\n'
+#         '  pip install "lerobot[pi]@git+https://github.com/huggingface/lerobot.git"\n'
+#     ) from e
+
+# MODEL_ID = "lerobot/pi0fast-base"
+# DEFAULT_OUT_PATH = "workloads/onnx/pi0fast_base_fixed-224.onnx"
+
+# class Pi0FastForwardWrapper(nn.Module):
+#     """
+#     Wrapper around the full PI0FastPytorch model so ONNX sees only tensor
+#     inputs. Calls the real training forward(), so the entire model graph
+#     (PaliGemma + FAST head) is exported.
+
+#     Inputs:
+#       image:                   [B, 3, H, W]        float32 in [0, 1]
+#       image_mask:              [B]                 bool
+#       language_tokens:         [B, L]              int64
+#       language_attention_mask: [B, L]              bool
+#       fast_action_tokens:      [B, T]              int64
+#       fast_action_masks:       [B, T]              bool
+
+#     Output:
+#       loss:                    [B]                 float32
+#     """
+
+#     def __init__(self, core_model: nn.Module):
+#         super().__init__()
+#         self.core = core_model
+
+#     def forward(
+#         self,
+#         image: Tensor,
+#         image_mask: Tensor,
+#         language_tokens: Tensor,
+#         language_attention_mask: Tensor,
+#         fast_action_tokens: Tensor,
+#         fast_action_masks: Tensor,
+#     ) -> Tensor:
+#         images = [image]
+#         img_masks = [image_mask]
+
+#         loss_dict = self.core(
+#             images=images,
+#             img_masks=img_masks,
+#             tokens=language_tokens,
+#             masks=language_attention_mask,
+#             fast_action_tokens=fast_action_tokens,
+#             fast_action_masks=fast_action_masks,
+#         )
+#         return loss_dict["loss"]
+
+# def export_pi0fast_onnx(
+#     output_path: str = DEFAULT_OUT_PATH,
+#     batch_size: int = 1,
+# ) -> None:
+#     print(f"[pi0fast] Loading PI0FastConfig from {MODEL_ID} ...")
+#     cfg_any = PreTrainedConfig.from_pretrained(MODEL_ID)
+#     if not isinstance(cfg_any, PI0FastConfig):
+#         raise TypeError(f"Expected PI0FastConfig, got {type(cfg_any)}")
+#     cfg: PI0FastConfig = cfg_any
+
+#     # Make export deterministic / CPU-friendly
+#     cfg.device = "cpu"
+#     cfg.gradient_checkpointing = False
+#     cfg.compile_model = False
+#     cfg.use_kv_cache = False
+
+#     print("[pi0fast] Constructing full PI0FastPytorch model (random weights) ...")
+#     core = PI0FastPytorch(
+#         config=cfg,
+#         rtc_processor=None,
+#         paligemma_tokenizer=None,
+#     )
+#     core.eval()
+
+#     wrapper = Pi0FastForwardWrapper(core)
+#     wrapper.eval()
+
+#     img_h, img_w = cfg.image_resolution
+#     lang_len = cfg.tokenizer_max_length
+#     max_fast_tokens = cfg.max_action_tokens
+
+#     print(
+#         "[pi0fast] Using fixed shapes:\n"
+#         f"  image                  = ({batch_size}, 3, {img_h}, {img_w})\n"
+#         f"  image_mask             = ({batch_size},)\n"
+#         f"  language_tokens        = ({batch_size}, {lang_len})\n"
+#         f"  language_attention_mask= ({batch_size}, {lang_len})\n"
+#         f"  fast_action_tokens     = ({batch_size}, {max_fast_tokens})\n"
+#         f"  fast_action_masks      = ({batch_size}, {max_fast_tokens})"
+#     )
+
+#     device = torch.device("cpu")
+
+#     dummy_image = torch.zeros(
+#         batch_size,
+#         3,
+#         img_h,
+#         img_w,
+#         dtype=torch.float32,
+#         device=device,
+#     )
+
+#     dummy_image_mask = torch.ones(
+#         batch_size,
+#         dtype=torch.bool,
+#         device=device,
+#     )
+
+#     dummy_lang_tokens = torch.zeros(
+#         batch_size,
+#         lang_len,
+#         dtype=torch.long,
+#         device=device,
+#     )
+
+#     dummy_lang_attn = torch.ones(
+#         batch_size,
+#         lang_len,
+#         dtype=torch.bool,
+#         device=device,
+#     )
+
+#     dummy_fast_tokens = torch.zeros(
+#         batch_size,
+#         max_fast_tokens,
+#         dtype=torch.long,
+#         device=device,
+#     )
+
+#     dummy_fast_masks = torch.ones(
+#         batch_size,
+#         max_fast_tokens,
+#         dtype=torch.bool,
+#         device=device,
+#     )
+
+#     out_path = Path(output_path)
+#     out_path.parent.mkdir(parents=True, exist_ok=True)
+
+#     print(f"[pi0fast] Exporting ONNX to {out_path} ...")
+#     torch.onnx.export(
+#         wrapper,
+#         (
+#             dummy_image,
+#             dummy_image_mask,
+#             dummy_lang_tokens,
+#             dummy_lang_attn,
+#             dummy_fast_tokens,
+#             dummy_fast_masks,
+#         ),
+#         out_path.as_posix(),
+#         input_names=[
+#             "image",
+#             "image_mask",
+#             "language_tokens",
+#             "language_attention_mask",
+#             "fast_action_tokens",
+#             "fast_action_masks",
+#         ],
+#         output_names=["loss"],
+#         opset_version=18,
+#         dynamic_axes=None,
+#         do_constant_folding=True,
+#     )
+#     print(f"[pi0fast] Saved fixed-shape ONNX: {out_path}")
+
+# def main() -> None:
+#     export_pi0fast_onnx()
+
+# if __name__ == "__main__":
+#     main()


### PR DESCRIPTION
Add ONNX export scripts and Polaris support for `lerobot/pi0fast-base` and `lerobot/pi05_base`. 

- New example dump scripts generate fixed-shape ONNX graphs for both models from full LeRobot architectures .
- Register `PI0FAST_BASE` and `PI05_BASE` as `api: ONNX` workloads in `ip_workloads.yaml`.
