### PR TITLE
Add LFC path support for operator lookup file in architecture configu…

### DIFF
--- a/config/tt_wh.yaml
+++ b/config/tt_wh.yaml
@@ -49,7 +49,8 @@ packages:
     -   name: Wormhole
         instances:
         -   name: n150
-            operator_lookup_file: __ext/perf_lookup/whb0_n150_lut.yaml
+            # operator_lookup_file can be a local path or LFC path starting with lfc://
+            operator_lookup_file: lfc://hlm-lut/whb0_n150_lut.yaml
             ipgroups:
             -   ipname: tensix
                 iptype: compute

--- a/doc/tools/perf_lookup/LOOKUP_TABLE_MASTER.md
+++ b/doc/tools/perf_lookup/LOOKUP_TABLE_MASTER.md
@@ -93,4 +93,6 @@ Analytical pipe/mem utilization **> 1.0** checks are skipped when `uses_perf_loo
 
 ## Example file
 
-Use the same path as `operator_lookup_file` in package YAML (e.g. [__ext/perf_lookup/whb0_n150_lut.yaml](../../../__ext/perf_lookup/whb0_n150_lut.yaml)): unary `single` rows, binary ops, and matmul as `hybrid` (`single` + `curve`) per the normative format. Those LUT YAML files are not in Git; fetch them from LFC with `lfc_downloader.sh` as described in [OPERATOR_LUT_LFC.md](OPERATOR_LUT_LFC.md).
+Package YAML specifies `operator_lookup_file` using LFC paths: `lfc://hlm-lut/whb0_n150_lut.yaml`, which are automatically downloaded and cached to `__ext/hlm-lut/whb0_n150_lut.yaml`.
+
+Example LUT files contain unary `single` rows, binary ops, and matmul as `hybrid` (`single` + `curve`) per the normative format. Those LUT YAML files are not in Git and download automatically with `lfc://` paths, or can be fetched manually as described in [OPERATOR_LUT_LFC.md](OPERATOR_LUT_LFC.md).

--- a/doc/tools/perf_lookup/OPERATOR_LUT_LFC.md
+++ b/doc/tools/perf_lookup/OPERATOR_LUT_LFC.md
@@ -1,51 +1,58 @@
 # Operator performance LUTs via Large File Cache (LFC)
 
-Package YAML under `config/` can point simulators at **tt-perf master** lookup tables, for example:
+Package YAML under `config/` specifies **tt-perf master** lookup tables using `lfc://` paths for automatic download and caching:
 
-| Architecture package | Config key | File (repo-relative) |
-|----------------------|------------|----------------------|
-| Wormhole `n150` (`config/tt_wh.yaml`) | `operator_lookup_file` | `__ext/perf_lookup/whb0_n150_lut.yaml` |
-| Blackhole `p100a` (`config/tt_bh.yaml`) | `operator_lookup_file` | `__ext/perf_lookup/bh_p100_lut.yaml` |
+| Architecture package | Config key | LFC Path |
+|----------------------|------------|----------|
+| Wormhole `n150` (`config/tt_wh.yaml`) | `operator_lookup_file` | `lfc://hlm-lut/whb0_n150_lut.yaml` |
+| Blackhole `p100a` (`config/tt_bh.yaml`) | `operator_lookup_file` | `lfc://hlm-lut/bh_p100_lut.yaml` |
 
-Those YAML files are **large, curated artifacts** and are **not checked into this repository**. Fetch them from LFC using `tools/ci/lfc_downloader.sh`.
+When using `lfc://` paths, files are **automatically downloaded** from LFC on first use and cached locally under `__ext/hlm-lut/`. The cache is checked for freshness (1 week) and re-downloaded if stale.
 
-## Prerequisites
+**Prerequisites for automatic download:**
+- (Developers outside CI) **Tailscale** VPN connection to reach the LFC server
+- (CI) Runs in cluster with direct LFC access
 
-- Same requirements as [lfc_downloader_user_guide.md](../ci/lfc_downloader_user_guide.md): `wget`, and (for developers outside CI) **Tailscale** to reach the external LFC host unless you have direct access.
-- Run commands from the **repository root** so paths match `config/*.yaml`.
+If LFC is unavailable and no cached file exists, the simulator will log a warning and continue without the performance lookup (maintaining backward compatibility).
 
-## Download (recommended)
+## Manual Download (Optional)
 
-On LFC, these LUTs live under a tree that **starts at `hlm-lut/`** (first segment after the downloader’s `simulators-ai-perf` base URL; see [lfc_downloader_user_guide.md](../ci/lfc_downloader_user_guide.md)). Pass that as the script’s **`server_path`**, e.g. `hlm-lut/` to sync the whole bundle.
+Manual download is only needed for offline access or troubleshooting.
 
-Sync that directory into `__ext/perf_lookup/` so the filenames match `operator_lookup_file`:
+**Prerequisites:**
+- Same requirements as [lfc_downloader_user_guide.md](../ci/lfc_downloader_user_guide.md): `wget`, and (for developers outside CI) **Tailscale** to reach the external LFC host
+- Run commands from the **repository root**
+
+On LFC, these LUTs live under a tree that **starts at `hlm-lut/`** (first segment after the downloader's `simulators-ai-perf` base URL; see [lfc_downloader_user_guide.md](../ci/lfc_downloader_user_guide.md)).
+
+Sync to `__ext/hlm-lut/` to match the automatic cache layout:
 
 ```bash
-./tools/ci/lfc_downloader.sh -v hlm-lut/ __ext/perf_lookup/
+./tools/ci/lfc_downloader.sh -v hlm-lut/ __ext/hlm-lut/
 ```
 
 After a successful sync you should have at least:
 
-- `__ext/perf_lookup/whb0_n150_lut.yaml`
-- `__ext/perf_lookup/bh_p100_lut.yaml`
+- `__ext/hlm-lut/whb0_n150_lut.yaml`
+- `__ext/hlm-lut/bh_p100_lut.yaml`
 
 (Additional files may appear if the `hlm-lut` bundle grows; the simulator only loads the path named in package YAML.)
 
 ### Dry run
 
 ```bash
-./tools/ci/lfc_downloader.sh -n -v hlm-lut/ __ext/perf_lookup/
+./tools/ci/lfc_downloader.sh -n -v hlm-lut/ __ext/hlm-lut/
 ```
 
 ### If LFC stores a single archive instead
 
-If `hlm-lut` is shipped as a `.tar.gz` on the server, download and extract from the repo root so contents land under `__ext/perf_lookup/` (adjust the archive name to match what LFC hosts):
+If `hlm-lut` is shipped as a `.tar.gz` on the server, download and extract from the repo root:
 
 ```bash
-./tools/ci/lfc_downloader.sh --type file --extract hlm-lut/<archive>.tar.gz
+./tools/ci/lfc_downloader.sh --type file --extract hlm-lut/<archive>.tar.gz __ext/hlm-lut/
 ```
 
-The archive layout must place `whb0_n150_lut.yaml` and `bh_p100_lut.yaml` under `__ext/perf_lookup/` after extraction, or you must move them to match `operator_lookup_file` in `config/tt_wh.yaml` and `config/tt_bh.yaml`.
+The archive layout must place `whb0_n150_lut.yaml` and `bh_p100_lut.yaml` under `__ext/hlm-lut/`.
 
 ## Wire format
 
@@ -53,7 +60,7 @@ The normative YAML shape is documented in [YAML_MASTER_FORMAT.md](../../YAML_MAS
 
 ## Tests
 
-Tests that need a LUT on disk (for example under `__ext/perf_lookup/`) assume you have already run the downloader; they skip or fail if the file is missing.
+Tests that need a LUT on disk assume an `lfc://` path is configured and can be automatically downloaded (cached under `__ext/hlm-lut/`), or you have manually downloaded files to `__ext/hlm-lut/`. They skip or fail if the file cannot be resolved.
 
 ## See also
 

--- a/tests/test_lfc.py
+++ b/tests/test_lfc.py
@@ -1,0 +1,287 @@
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import tempfile
+import time
+import urllib.error
+from pathlib import Path
+from unittest.mock import mock_open, patch
+
+import pytest
+
+from ttsim.utils.lfc import CACHE_AGE_SECONDS, resolve_lfc_path
+
+
+@pytest.mark.unit
+def test_resolve_lfc_path_invalid_prefix():
+    with pytest.raises(ValueError, match="Path must start with 'lfc://'"):
+        resolve_lfc_path("invalid/path.yaml")
+
+@pytest.mark.unit
+def test_resolve_lfc_path_cached():
+    original_cwd = os.getcwd()
+    try:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)
+            local_path = "__ext/test/file.yaml"
+            Path(local_path).parent.mkdir(parents=True)
+            Path(local_path).touch()
+            # Set mtime to now
+            os.utime(local_path, (time.time(), time.time()))
+
+            result = resolve_lfc_path("lfc://test/file.yaml")
+            assert result == local_path
+    finally:
+        os.chdir(original_cwd)
+
+@pytest.mark.unit
+def test_resolve_lfc_path_stale_download_success():
+    original_cwd = os.getcwd()
+    try:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)
+            local_path = "__ext/test/file.yaml"
+            Path(local_path).parent.mkdir(parents=True)
+            Path(local_path).touch()
+            # Set mtime to old
+            old_time = time.time() - CACHE_AGE_SECONDS - 1
+            os.utime(local_path, (old_time, old_time))
+            with patch('urllib.request.urlopen') as mock_urlopen:
+                mock_response = mock_open(read_data=b"content").return_value
+                mock_response.status = 200
+                mock_urlopen.return_value.__enter__.return_value = mock_response
+                result = resolve_lfc_path("lfc://test/file.yaml")
+                assert result == local_path
+                mock_urlopen.assert_called_once()
+                # Check content was written
+                with open(local_path, 'rb') as f:
+                    assert f.read() == b"content"
+    finally:
+        os.chdir(original_cwd)
+
+@pytest.mark.unit
+def test_resolve_lfc_path_download_fail_fallback():
+    original_cwd = os.getcwd()
+    try:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)
+            local_path = "__ext/test/file.yaml"
+            Path(local_path).parent.mkdir(parents=True)
+            Path(local_path).write_text("old content")
+            # Set mtime to be stale (older than CACHE_AGE_SECONDS)
+            old_time = time.time() - CACHE_AGE_SECONDS - 1
+            os.utime(local_path, (old_time, old_time))
+            with patch('urllib.request.urlopen', side_effect=Exception("Network error")) as mock_urlopen:
+                result = resolve_lfc_path("lfc://test/file.yaml")
+                assert result == local_path
+                # Verify download was attempted
+                mock_urlopen.assert_called()
+                # Content should remain old (preserved after failed download)
+                assert Path(local_path).read_text() == "old content"
+    finally:
+        os.chdir(original_cwd)
+
+@pytest.mark.unit
+def test_resolve_lfc_path_download_fail_no_local():
+    original_cwd = os.getcwd()
+    try:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)
+            with patch('urllib.request.urlopen', side_effect=Exception("Network error")):
+                with pytest.raises(RuntimeError, match="Download failed and no local file exists"):
+                    resolve_lfc_path("lfc://test/file.yaml")
+    finally:
+        os.chdir(original_cwd)
+
+@pytest.mark.unit
+def test_resolve_lfc_path_auth_required():
+    original_cwd = os.getcwd()
+    try:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)
+            with patch('urllib.request.urlopen') as mock_urlopen:
+                mock_response = mock_open().return_value
+                mock_response.status = 401
+                mock_urlopen.return_value.__enter__.return_value = mock_response
+                with pytest.raises(RuntimeError, match="Authentication required"):
+                    resolve_lfc_path("lfc://test/file.yaml")
+    finally:
+        os.chdir(original_cwd)
+
+
+# Security validation tests
+
+@pytest.mark.unit
+def test_resolve_lfc_path_rejects_empty_path():
+    with pytest.raises(ValueError, match="Server path cannot be empty"):
+        resolve_lfc_path("lfc://")
+
+
+@pytest.mark.unit
+def test_resolve_lfc_path_rejects_absolute_path():
+    with pytest.raises(ValueError, match="Absolute paths not allowed"):
+        resolve_lfc_path("lfc:///etc/passwd")
+
+
+@pytest.mark.unit
+def test_resolve_lfc_path_rejects_path_traversal():
+    with pytest.raises(ValueError, match="Path traversal.*not allowed"):
+        resolve_lfc_path("lfc://../../../etc/passwd")
+
+
+@pytest.mark.unit
+def test_resolve_lfc_path_rejects_path_traversal_midpath():
+    with pytest.raises(ValueError, match="Path traversal.*not allowed"):
+        resolve_lfc_path("lfc://test/../../../etc/passwd")
+
+
+@pytest.mark.unit
+def test_resolve_lfc_path_rejects_backslashes():
+    with pytest.raises(ValueError, match="Backslashes not allowed"):
+        resolve_lfc_path("lfc://test\\file.yaml")
+
+
+@pytest.mark.unit
+def test_resolve_lfc_path_rejects_windows_drive_letter():
+    with pytest.raises(ValueError, match="Windows drive letters not allowed"):
+        resolve_lfc_path("lfc://C:/Windows/System32/file.txt")
+
+
+@pytest.mark.unit
+def test_resolve_lfc_path_rejects_unc_path():
+    with pytest.raises(ValueError, match="UNC paths not allowed"):
+        resolve_lfc_path("lfc://\\\\server\\share\\file.txt")
+
+
+@pytest.mark.unit
+def test_resolve_lfc_path_allows_valid_nested_path():
+    """Test that valid nested paths are allowed"""
+    original_cwd = os.getcwd()
+    try:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)
+            local_path = "__ext/deep/nested/path/file.yaml"
+            Path(local_path).parent.mkdir(parents=True)
+            Path(local_path).touch()
+            os.utime(local_path, (time.time(), time.time()))
+            
+            result = resolve_lfc_path("lfc://deep/nested/path/file.yaml")
+            assert result == local_path
+    finally:
+        os.chdir(original_cwd)
+
+
+@pytest.mark.unit
+def test_resolve_lfc_path_http_404_with_local_fallback():
+    """Test that 404 errors fall back to stale local cache"""
+    original_cwd = os.getcwd()
+    try:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)
+            local_path = "__ext/test/file.yaml"
+            Path(local_path).parent.mkdir(parents=True)
+            Path(local_path).write_text("cached content")
+            # Set mtime to be stale
+            old_time = time.time() - CACHE_AGE_SECONDS - 1
+            os.utime(local_path, (old_time, old_time))
+            
+            http_error = urllib.error.HTTPError(
+                url="http://test.com/file.yaml",
+                code=404,
+                msg="Not Found",
+                hdrs={},
+                fp=None
+            )
+            with patch('urllib.request.urlopen', side_effect=http_error) as mock_urlopen:
+                result = resolve_lfc_path("lfc://test/file.yaml")
+                assert result == local_path
+                # Verify download was attempted
+                mock_urlopen.assert_called()
+                # Content should be preserved
+                assert Path(local_path).read_text() == "cached content"
+    finally:
+        os.chdir(original_cwd)
+
+
+@pytest.mark.unit
+def test_resolve_lfc_path_http_500_with_local_fallback():
+    """Test that 500 errors fall back to stale local cache"""
+    original_cwd = os.getcwd()
+    try:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)
+            local_path = "__ext/test/file.yaml"
+            Path(local_path).parent.mkdir(parents=True)
+            Path(local_path).write_text("cached content")
+            # Set mtime to be stale
+            old_time = time.time() - CACHE_AGE_SECONDS - 1
+            os.utime(local_path, (old_time, old_time))
+            
+            http_error = urllib.error.HTTPError(
+                url="http://test.com/file.yaml",
+                code=500,
+                msg="Internal Server Error",
+                hdrs={},
+                fp=None
+            )
+            with patch('urllib.request.urlopen', side_effect=http_error) as mock_urlopen:
+                result = resolve_lfc_path("lfc://test/file.yaml")
+                assert result == local_path
+                # Verify download was attempted
+                mock_urlopen.assert_called()
+                # Content should be preserved
+                assert Path(local_path).read_text() == "cached content"
+    finally:
+        os.chdir(original_cwd)
+
+
+@pytest.mark.unit
+def test_resolve_lfc_path_http_404_without_local_fallback():
+    """Test that 404 errors raise when no local cache exists"""
+    original_cwd = os.getcwd()
+    try:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)
+            
+            http_error = urllib.error.HTTPError(
+                url="http://test.com/file.yaml",
+                code=404,
+                msg="Not Found",
+                hdrs={},
+                fp=None
+            )
+            with patch('urllib.request.urlopen', side_effect=http_error):
+                with pytest.raises(RuntimeError, match="Download failed.*HTTP 404.*no local file exists"):
+                    resolve_lfc_path("lfc://test/file.yaml")
+    finally:
+        os.chdir(original_cwd)
+
+
+@pytest.mark.unit
+def test_resolve_lfc_path_http_401_no_fallback():
+    """Test that 401 errors are raised immediately without fallback"""
+    original_cwd = os.getcwd()
+    try:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)
+            local_path = "__ext/test/file.yaml"
+            Path(local_path).parent.mkdir(parents=True)
+            Path(local_path).write_text("cached content")
+            # Set mtime to be stale
+            old_time = time.time() - CACHE_AGE_SECONDS - 1
+            os.utime(local_path, (old_time, old_time))
+            
+            http_error = urllib.error.HTTPError(
+                url="http://test.com/file.yaml",
+                code=401,
+                msg="Unauthorized",
+                hdrs={},
+                fp=None
+            )
+            with patch('urllib.request.urlopen', side_effect=http_error):
+                # 401 should raise immediately, not fall back to cache
+                with pytest.raises(RuntimeError, match="Authentication required"):
+                    resolve_lfc_path("lfc://test/file.yaml")
+    finally:
+        os.chdir(original_cwd)

--- a/tests/test_tools/test_master_operator_perf_lookup.py
+++ b/tests/test_tools/test_master_operator_perf_lookup.py
@@ -687,7 +687,7 @@ def test_operator_perf_map_loads_repo_sample():
     from tools.perf_lookup.lookup_operator_perf import OperatorPerfMap
 
     root = Path(__file__).resolve().parents[2]
-    yml = root / "__ext" / "perf_lookup" / "whb0_n150_lut.yaml"
+    yml = root / "__ext" / "hlm-lut" / "whb0_n150_lut.yaml"
     if not yml.is_file():
         pytest.skip(f"repo LUT not present: {yml}")
     m = OperatorPerfMap(yml)

--- a/ttsim/back/device.py
+++ b/ttsim/back/device.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from loguru import logger
 
 from ttsim.utils.types import get_bpe, get_sim_dtype
+from ttsim.utils.lfc import resolve_lfc_path
 from tools.perf_lookup.lookup_operator_perf import resolve_operator_lookup_core_count
 
 LOG     = logger
@@ -134,30 +135,43 @@ class Device:
         else:
             _hybrid_curve = bool(operator_lookup_hybrid_curve)
         if hasattr(simcfg_obj, 'operator_lookup_file') and simcfg_obj.operator_lookup_file:
-            lookup_file_path = Path(os.getcwd()) / simcfg_obj.operator_lookup_file
-            if lookup_file_path.exists():
+            lookup_file = simcfg_obj.operator_lookup_file
+            if lookup_file.startswith('lfc://'):
                 try:
-                    from tools.perf_lookup.lookup_operator_perf import OperatorPerfMap
-
-                    self.operator_perf_map = OperatorPerfMap(
-                        lookup_file_path,
-                        use_hybrid_curve=_hybrid_curve,
-                    )
-                    logger.info(
-                        "Loaded operator performance master lookup from {} (core_count={}, hybrid_curve={})",
-                        lookup_file_path,
-                        self._operator_lookup_core_count,
-                        _hybrid_curve,
-                    )
-                except Exception as e:
+                    lookup_file = resolve_lfc_path(lookup_file)
+                except (RuntimeError, ValueError) as e:
                     logger.warning(
-                        "Failed to load operator performance lookup from {}: {}",
-                        lookup_file_path,
+                        "Failed to resolve LFC path {}: {}. Continuing without operator performance lookup.",
+                        simcfg_obj.operator_lookup_file,
                         e,
                     )
-                    self.operator_perf_map = None
-            else:
-                logger.warning(f"Operator lookup file specified but not found: {lookup_file_path}")
+                    lookup_file = None
+            
+            if lookup_file:
+                lookup_file_path = Path(os.getcwd()) / lookup_file
+                if lookup_file_path.exists():
+                    try:
+                        from tools.perf_lookup.lookup_operator_perf import OperatorPerfMap
+
+                        self.operator_perf_map = OperatorPerfMap(
+                            lookup_file_path,
+                            use_hybrid_curve=_hybrid_curve,
+                        )
+                        logger.info(
+                            "Loaded operator performance master lookup from {} (core_count={}, hybrid_curve={})",
+                            lookup_file_path,
+                            self._operator_lookup_core_count,
+                            _hybrid_curve,
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "Failed to load operator performance lookup from {}: {}",
+                            lookup_file_path,
+                            e,
+                        )
+                        self.operator_perf_map = None
+                else:
+                    logger.warning(f"Operator lookup file specified but not found: {lookup_file_path}")
 
         return
 

--- a/ttsim/utils/lfc.py
+++ b/ttsim/utils/lfc.py
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+try:
+    import fcntl
+    HAS_FCNTL = True
+except ImportError:
+    HAS_FCNTL = False
+
+CACHE_AGE_SECONDS = 604800  # 1 week
+
+def _validate_server_path(server_path: str) -> None:
+    """
+    Validate server path to prevent path traversal attacks.
+
+    Args:
+        server_path: Path after 'lfc://' prefix
+
+    Raises:
+        ValueError: If path contains security risks (absolute paths, .., or backslashes)
+    """
+    if not server_path:
+        raise ValueError("Server path cannot be empty")
+    
+    # Reject absolute paths
+    if server_path.startswith('/'):
+        raise ValueError(f"Absolute paths not allowed in LFC paths: {server_path}")
+    
+    # Reject Windows absolute paths (e.g., C:/, \\server\share)
+    if len(server_path) >= 2 and server_path[1] == ':':
+        raise ValueError(f"Windows drive letters not allowed in LFC paths: {server_path}")
+    
+    if server_path.startswith('\\\\'):
+        raise ValueError(f"UNC paths not allowed in LFC paths: {server_path}")
+    
+    # Reject backslashes (potential path separator confusion)
+    if '\\' in server_path:
+        raise ValueError(f"Backslashes not allowed in LFC paths: {server_path}")
+    
+    # Reject path traversal attempts
+    path_parts = server_path.split('/')
+    for part in path_parts:
+        if part == '..':
+            raise ValueError(f"Path traversal (..) not allowed in LFC paths: {server_path}")
+    
+    # Additional safety: normalize and verify the resolved path stays within __ext
+    try:
+        # Construct the full local path and resolve it
+        local_path = Path('__ext') / server_path
+        resolved = local_path.resolve()
+        expected_base = Path('__ext').resolve()
+        
+        # Check that resolved path is under __ext
+        try:
+            resolved.relative_to(expected_base)
+        except ValueError:
+            raise ValueError(f"Path would escape __ext directory: {server_path}")
+    except Exception as e:
+        if isinstance(e, ValueError):
+            raise
+        raise ValueError(f"Invalid path format: {server_path}") from e
+
+def resolve_lfc_path(lfc_path: str) -> str:
+    """
+    Resolve an LFC path to a local file path, downloading if necessary.
+
+    Args:
+        lfc_path: Path starting with 'lfc://', e.g., 'lfc://hlm-lut/whb0_n150_lut.yaml'
+
+    Returns:
+        Local file path relative to workspace, e.g., '__ext/hlm-lut/whb0_n150_lut.yaml'
+
+    Raises:
+        ValueError: If path does not start with 'lfc://' or contains invalid/unsafe components
+        RuntimeError: If download fails and no local file exists
+    """
+    if not lfc_path.startswith('lfc://'):
+        raise ValueError(f"Path must start with 'lfc://': {lfc_path}")
+
+    # Translate to local path
+    server_path = lfc_path[6:]  # Remove 'lfc://'
+    
+    # Validate server path for security (prevent path traversal)
+    _validate_server_path(server_path)
+    
+    local_path = f"__ext/{server_path}"
+
+    local_file = Path(local_path)
+    if local_file.exists():
+        mtime = os.path.getmtime(local_path)
+        if time.time() - mtime < CACHE_AGE_SECONDS:
+            return local_path  # Fresh, use it
+
+    # Need to download
+    download_lfc_file(server_path, local_path)
+    return local_path
+
+def download_lfc_file(server_path: str, local_path: str):
+    """
+    Download a file from LFC server to local path.
+
+    Args:
+        server_path: Path relative to simulators-ai-perf, e.g., 'hlm-lut/whb0_n150_lut.yaml'
+        local_path: Local path, e.g., '__ext/hlm-lut/whb0_n150_lut.yaml'
+    """
+    # Determine server base URL
+    is_ci = os.getenv('GITHUB_ACTIONS') == 'true'
+    if is_ci:
+        base_url = 'http://large-file-cache.large-file-cache.svc.cluster.local/simulators-ai-perf/'
+    else:
+        base_url = 'http://aus2-lfcache.aus2.tenstorrent.com/simulators-ai-perf/'
+
+    url = base_url + server_path
+
+    # Create local directory
+    local_file = Path(local_path)
+    local_file.parent.mkdir(parents=True, exist_ok=True)
+
+    # Use a lock file to prevent concurrent downloads
+    lock_path = f"{local_path}.lock"
+    lock_file = None
+    try:
+        if HAS_FCNTL:
+            lock_file = open(lock_path, 'w')
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        
+        # Check again if file exists and is fresh (another process may have downloaded it)
+        if local_file.exists():
+            mtime = os.path.getmtime(local_path)
+            if time.time() - mtime < CACHE_AGE_SECONDS:
+                return  # Fresh file exists, no need to download
+
+        # Try download with retries
+        for attempt in range(3):
+            try:
+                with urllib.request.urlopen(url, timeout=30) as response:
+                    if response.status == 401:
+                        raise RuntimeError(f"Authentication required for {url}")
+                    
+                    # Download to temporary file in same directory (ensures atomic rename)
+                    with tempfile.NamedTemporaryFile(
+                        mode='wb',
+                        dir=local_file.parent,
+                        prefix=f'.{local_file.name}.',
+                        suffix='.tmp',
+                        delete=False
+                    ) as tmp_file:
+                        tmp_path = tmp_file.name
+                        tmp_file.write(response.read())
+                    
+                    # Atomically replace the target file
+                    os.replace(tmp_path, local_path)
+                return  # Success
+            except urllib.error.HTTPError as e:
+                if e.code == 401:
+                    raise RuntimeError(f"Authentication required for {url}")
+                if attempt == 2:
+                    # On final attempt, check for local fallback (except 401)
+                    if local_file.exists():
+                        print(f"Download failed after 3 attempts (HTTP {e.code}), using existing local file: {local_path}", file=sys.stderr)
+                        return
+                    else:
+                        # Provide Tailscale diagnostic for non-CI environments
+                        if not is_ci:
+                            print("Direct access failed. Ensure Tailscale VPN is connected.", file=sys.stderr)
+                        raise RuntimeError(f"Download failed (HTTP {e.code}) and no local file exists: {local_path}") from e
+            except Exception as e:
+                # Clean up temp file if it exists
+                if 'tmp_path' in locals():
+                    try:
+                        os.unlink(tmp_path)
+                    except FileNotFoundError:
+                        pass
+                
+                if isinstance(e, RuntimeError) and "Authentication required" in str(e):
+                    raise  # Re-raise auth errors immediately
+                if attempt == 2:
+                    # Check if local exists
+                    if local_file.exists():
+                        print(f"Download failed after 3 attempts, using existing local file: {local_path}", file=sys.stderr)
+                        return
+                    else:
+                        # Provide Tailscale diagnostic for non-CI environments
+                        if not is_ci:
+                            print("Direct access failed. Ensure Tailscale VPN is connected.", file=sys.stderr)
+                        raise RuntimeError(f"Download failed and no local file exists: {local_path}") from e
+    finally:
+        # Release lock and clean up lock file
+        if lock_file:
+            try:
+                if HAS_FCNTL:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+                lock_file.close()
+                os.unlink(lock_path)
+            except Exception:
+                pass  # Best effort cleanup


### PR DESCRIPTION
…rations

- Implemented `resolve_lfc_path` function in `lfc.py` for resolving LFC paths.
- Added unit tests for LFC path resolution in `test_lfc.py`.
- Adjusted related tests to use new LFC path structure.
- Updated `operator_lookup_file` in `tt_wh.yaml` to support LFC paths.


# Summary of the issue:

Currently, file paths can be specified using local path or html path syntax. However, some files are resident on LFC (large file cache) as well. An example is  operator_lookup_file in architecture YAML files (e.g., config/tt_wh.yaml). Currently this attribute only supports local file paths. This requires manual file management and distribution for teams working with shared operator performance lookup tables.

# Solution:

Implement support for LFC (Large File Cache) paths using the lfc:// protocol prefix. When an LFC path is specified, the system should:

- Download the file from the appropriate LFC server
- Cache locally for 1 week to avoid repeated downloads
- Fall back to existing local files if download fails

Example Usage:

```
packages:
  - name: Wormhole
    instances:
      - name: n150
        operator_lookup_file: lfc://hlm-lut/whb0_n150_lut.yaml
```
