### PR TITLE
406 fold improvements   pr3 for vit reference command

### DIFF
--- a/tests/test_ttnn/test_fold_simop.py
+++ b/tests/test_ttnn/test_fold_simop.py
@@ -1,20 +1,34 @@
 # SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
-"""Regression: default ``ttnn.fold`` emits a ``Fold`` SimOp (ViT patch path)."""
+"""Fold SimOp shape-inference tests covering the flatten_nd design decision.
+
+The three tests validate flatten_nd selection logic (in ttsim/front/ttnn/op.py)
+and the resulting output shapes from fold_sinf (in ttsim/ops/desc/tensor.py):
+
+1. L1-sharded / ROW_MAJOR (no explicit memory config) → flatten_nd=True
+   → output [1, 1, N*Hs*Ws, Cs]  (HW prim::fold kernel behaviour)
+2. DRAM-interleaved → flatten_nd=False
+   → output [N, Hs, Ws, Cs]       (HW compute_output_specs override)
+3. TILE_LAYOUT → flatten_nd=False
+   → output [N, Hs, Ws, Cs]       (HW reshape-back-to-4D path)
+
+fold_sinf itself has two behaviors (flatten_nd True/False); the three test
+cases exercise the different conditions that select flatten_nd in op.py.
+"""
 
 import pytest
 
 import ttsim.front.ttnn as ttnn
 from ttsim.front.ttnn.device import Device
+from ttsim.front.ttnn.memory import MemoryConfig
 from ttsim.front.ttnn.tensor import DataType, Layout, Tensor
 
 
 @pytest.mark.unit
 def test_fold_default_path_emits_fold_simop_vit_like_shapes() -> None:
-    """Reshape + default ``fold`` (same pattern as ViT patch: prep reshape then ``Fold`` SimOp)."""
+    """L1/ROW_MAJOR fold flattens batch*spatial (ViT patch path)."""
     device = Device(device_id=0)
-    # Element count preserved: 2*32*8*16 == 2*32*4*32
     pixel_values = Tensor(
         shape=[2, 32, 8, 16],
         dtype=DataType.BFLOAT16,
@@ -24,9 +38,48 @@ def test_fold_default_path_emits_fold_simop_vit_like_shapes() -> None:
     x = ttnn.reshape(pixel_values, (2, 32, 4, 32))
     y = ttnn.fold(x, stride_h=8, stride_w=2, use_transpose_as_fold=False)
 
-    assert y.shape.as_list() == [2, 4, 2, 512]
+    # HW Fold kernel flattens batch*spatial: 2*4*2 = 16 rows, 512 channels
+    assert y.shape.as_list() == [1, 1, 16, 512]
 
     optypes = [op.optype for op in device.ops.values()]
     assert optypes[0] == 'Reshape'
     assert optypes[1] == 'Fold'
-    assert 'Fold' in optypes
+
+
+@pytest.mark.unit
+def test_fold_dram_preserves_4d_shape() -> None:
+    """DRAM-interleaved fold preserves logical 4D shape [N, Hs, Ws, Cs]."""
+    device = Device(device_id=0)
+    pixel_values = Tensor(
+        shape=[2, 32, 4, 32],
+        dtype=DataType.BFLOAT16,
+        layout=Layout.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=MemoryConfig.DRAM,
+    )
+    y = ttnn.fold(pixel_values, stride_h=8, stride_w=2, use_transpose_as_fold=False)
+
+    assert y.shape.as_list() == [2, 4, 2, 512]
+
+    fold_ops = [op for op in device.ops.values() if op.optype == 'Fold']
+    assert len(fold_ops) == 1
+    assert fold_ops[0].attrs['flatten_nd'] is False
+
+
+@pytest.mark.unit
+def test_fold_tiled_preserves_4d_shape() -> None:
+    """Tiled-layout fold preserves logical 4D shape [N, Hs, Ws, Cs]."""
+    device = Device(device_id=0)
+    pixel_values = Tensor(
+        shape=[2, 32, 4, 32],
+        dtype=DataType.BFLOAT16,
+        layout=Layout.TILE_LAYOUT,
+        device=device,
+    )
+    y = ttnn.fold(pixel_values, stride_h=8, stride_w=2, use_transpose_as_fold=False)
+
+    assert y.shape.as_list() == [2, 4, 2, 512]
+
+    fold_ops = [op for op in device.ops.values() if op.optype == 'Fold']
+    assert len(fold_ops) == 1
+    assert fold_ops[0].attrs['flatten_nd'] is False

--- a/ttsim/front/ttnn/op.py
+++ b/ttsim/front/ttnn/op.py
@@ -865,39 +865,67 @@ def linear(*args, **kwargs):
     return C
 
 
-# fold:
-# takes an input tensor with shape (N, H, W, C) and transforms it to shape
-# (N, H//stride_h, W//stride_w, C*stride_h*stride_w) by reshaping and permuting
-# the spatial dimensions. This operation is commonly used as a preprocessing step
-# for convolution operations, similar to the im2col operation in other deep learning
-# frameworks, to reorganize input data in a format suitable for efficient matrix
-# multiplication on Tenstorrent hardware.
 def fold(
     ttnn_tensor_like,
     stride_h: int,
     stride_w: int,
     *,
     use_transpose_as_fold=False,
-    output_shape=None,  # ttnn.Shape
+    output_shape=None,  # ttnn.Shape  -- accepted for ttnn API compat, unused
     pad_c: int = 0,
     pad_h: int = 0,
     pad_w: int = 0,
-    grid_size=None,  # ttnn.CoreRangeSet
-    override_memory_config: MemoryConfig = None,  # type: ignore
+    grid_size=None,  # ttnn.CoreRangeSet  -- accepted for ttnn API compat, unused
+    override_memory_config: MemoryConfig | None = None,  # accepted for ttnn API compat, unused
 ):
+    """Fold: (N,H,W,C) → (N, Hs, Ws, Cs) or (1, 1, N*Hs*Ws, Cs).
 
+    Reorganises spatial dimensions similarly to im2col, commonly used as a
+    preprocessing step for convolution on Tenstorrent hardware.
+
+    Where Hs = H//stride_h, Ws = W//stride_w, Cs = C*stride_h*stride_w.
+
+    Output shape depends on execution path:
+      - ``use_transpose_as_fold=True``: decomposed into reshape/transpose ops,
+        always produces 4D logical output [N, Hs, Ws, Cs].
+      - ``use_transpose_as_fold=False`` (default): creates a first-class Fold
+        SimOp whose output shape depends on the input tensor's memory config:
+
+        * L1-sharded ROW_MAJOR (typical): flatten_nd=True → [1, 1, N*Hs*Ws, Cs]
+        * DRAM-interleaved or TILE_LAYOUT: flatten_nd=False → [N, Hs, Ws, Cs]
+
+        (See ``flatten_nd`` design comment below for rationale.)
+    """
     ttnn_tensor_like = require_ttnn_tensor(ttnn_tensor_like, "ttnn.fold input")
     assert (
         ttnn_tensor_like.rank() == 4
-    ), f"fold input should be a rank-4 [N, H, W, C] tensor!!\n{ttnn_tensor_like}"
+    ), f"fold input should be a rank-4 [N, H, W, C] tensor: {ttnn_tensor_like}"
     N, H, W, C = ttnn_tensor_like.shape
 
     assert (
         isinstance(stride_h, int) and stride_h > 0 and stride_h <= H
-    ), f"stride_h({stride_h}) should be in [0, {H}]"
+    ), f"stride_h({stride_h}) should be in (0, {H}]"
     assert (
-        isinstance(stride_w, int) and stride_w > 0 and stride_w <= H
-    ), f"stride_w({stride_w}) should be in [0, {W}]"
+        isinstance(stride_w, int) and stride_w > 0 and stride_w <= W
+    ), f"stride_w({stride_w}) should be in (0, {W}]"
+
+    # Validate unused parameters to prevent silent divergence from real ttnn.fold behavior
+    # These parameters are unused in both execution paths
+    if output_shape is not None:
+        raise ValueError(
+            "ttnn.fold: output_shape is not supported by this implementation. "
+            "It is accepted only for API compatibility but ignored. Remove it to avoid confusion."
+        )
+    if grid_size is not None:
+        raise ValueError(
+            "ttnn.fold: grid_size is not supported by this implementation. "
+            "It is accepted only for API compatibility but ignored. Remove it to avoid confusion."
+        )
+    if override_memory_config is not None:
+        raise ValueError(
+            "ttnn.fold: override_memory_config is not supported by this implementation. "
+            "It is accepted only for API compatibility but ignored. Remove it to avoid confusion."
+        )
 
     if pad_h > 0:
         H += pad_h
@@ -937,6 +965,11 @@ def fold(
         # Tensor.memory_config() returns None when no config has been set
         # (the common L1-sharded path); hasattr guards against non-Tensor inputs.
         mc = ttnn_tensor_like.memory_config() if hasattr(ttnn_tensor_like, 'memory_config') else None
+        # Detect DRAM via the underlying buffer_type rather than identity/equality
+        # against a specific singleton.  This correctly recognises both the local
+        # MemoryConfig.DRAM and any shim-side MemoryConfig instance (e.g.
+        # ttnn_shim.DRAM_MEMORY_CONFIG), since both share buffer_type=BufferType.DRAM,
+        # without needing to import ttnn_shim here.
         is_dram = (getattr(mc, 'buffer_type', None) is BufferType.DRAM) if mc is not None else False
         fold_attrs = {
             'stride_h': stride_h,
@@ -944,6 +977,7 @@ def fold(
             'pad_h': pad_h,
             'pad_w': pad_w,
             'pad_c': pad_c,
+            'flatten_nd': not (is_tiled or is_dram),
         }
         out_tensor = Tensor(
             name=op_name + '.out',

--- a/ttsim/front/ttnn/tensor.py
+++ b/ttsim/front/ttnn/tensor.py
@@ -7,6 +7,7 @@ from typing import Optional, Tuple, Union
 from ttsim.ops.op import SimOp
 from ttsim.ops.tensor import SimTensor, Shape
 from .device import Device, USE_DEFAULT_DEVICE, resolve_device
+from .memory import MemoryConfig as MemoryConfigEnum
 from .types import TILE_HEIGHT, TILE_WIDTH
 
 from enum import Enum, auto
@@ -166,6 +167,11 @@ class Tensor(SimTensor):
             raise TypeError(f"Error: Tensor Creation -- attribute layout={kwargs['layout']} should be of type Layout")
         if kwargs['device'] is not None and not isinstance(kwargs['device'], Device):
             raise TypeError(f"Error: Tensor Creation -- attribute device={kwargs['device']} should be of type Device or None")
+        if 'memory_config' in kwargs and kwargs['memory_config'] is not None:
+            # Avoid circular import by importing ttnn_shim.MemoryConfig here
+            from .ttnn_shim import MemoryConfig as MemoryConfigClass
+            if not isinstance(kwargs['memory_config'], (MemoryConfigEnum, MemoryConfigClass)):
+                raise TypeError(f"Error: Tensor Creation -- attribute memory_config={kwargs['memory_config']} should be of type MemoryConfig or None")
 
         # NumPy has no native bfloat8/bfloat4 types, so DataType.BFLOAT8_B and
         # BFLOAT4_B both map to np.float32 via to_numpy -- making them
@@ -766,7 +772,19 @@ def to_device(tt_tensor_like, device, memory_config=None):
             del old_device.tensors[tt_tensor_like.name]
 
     tt_tensor_like.device = device
-    device.add_tensor(tt_tensor_like)
+    if memory_config is not None:
+        # Validate memory_config type (mirror constructor validation)
+        from .ttnn_shim import MemoryConfig as MemoryConfigClass
+        if not isinstance(memory_config, (MemoryConfigEnum, MemoryConfigClass)):
+            raise TypeError(f"Error: to_device -- memory_config={memory_config} should be of type MemoryConfig or None")
+        tt_tensor_like._memory_config = memory_config
+    buffer = device.add_tensor(tt_tensor_like)
+
+    # Update storage_type and buffer to maintain consistency when moving to device
+    if hasattr(tt_tensor_like, "_storage_type"):
+        tt_tensor_like._storage_type = "DEVICE"
+    if hasattr(tt_tensor_like, "_buffer"):
+        tt_tensor_like._buffer = buffer if buffer is not None else "buffer_placeholder"
 
     if memory_config is not None:
         tt_tensor_like._memory_config = memory_config

--- a/ttsim/ops/desc/tensor.py
+++ b/ttsim/ops/desc/tensor.py
@@ -843,7 +843,24 @@ def permute_op_inf_func(iTList, oTList, op, **kwargs):
 
 
 def fold_sinf(iTList, oTList, op, **kwargs):
-    """Shape inference for Fold: 4D [N,H,W,C] -> [N,H//sh,W//sw,C*sh*sw]; attrs stride_h, stride_w; optional pad_*."""
+    """Shape inference for Fold.
+
+    Default output shape is the standard mathematical form
+    ``[N, Hs, Ws, Cs]`` where ``Hs = H // stride_h``, ``Ws = W // stride_w``,
+    ``Cs = C * stride_h * stride_w``.
+
+    When ``flatten_nd`` is set in the op attrs, the output uses the
+    HW ``prim::fold`` representation ``[1, 1, N*Hs*Ws, Cs]`` instead,
+    which flattens batch and spatial dims into a single row dimension.
+    This matches L1-sharded / ROW_MAJOR inputs on Tenstorrent hardware
+    (the common case for ViT and similar TTNN models).  DRAM-interleaved
+    or originally-tiled inputs keep the 4D form (``flatten_nd=False``),
+    matching the ``compute_output_specs`` override in
+    ``fold_device_op.cpp``.
+
+    The ``use_transpose_as_fold=True`` reference path in ``op.py`` bypasses
+    this function entirely and always produces ``[N, Hs, Ws, Cs]``.
+    """
     assert len(iTList) == 1 and len(oTList) == 1
     X = iTList[0]
     assert X.check_shape(), f"Fold: input shape not defined: {X}"
@@ -865,7 +882,21 @@ def fold_sinf(iTList, oTList, op, **kwargs):
     )
     Hs = H // stride_h
     Ws = W // stride_w
-    out_shape = [N, Hs, Ws, C * stride_h * stride_w]
+    Cs = C * stride_h * stride_w
+    # Design decision: the default (flatten_nd absent or False) produces the
+    # standard mathematical 4D shape [N, Hs, Ws, Cs].  This keeps fold_sinf
+    # frontend-agnostic -- any non-TTNN caller (e.g. ONNX, future frontends)
+    # gets correct behaviour without needing to know about Tenstorrent HW
+    # layout semantics.  Only the TTNN frontend explicitly opts into the
+    # flattened [1,1,rows,channels] form by setting flatten_nd=True, which
+    # mirrors the conditional logic in tt-metal's fold_device_op.cpp
+    # (prim::fold flattens for L1-sharded ROW_MAJOR; compute_output_specs
+    # preserves 4D for DRAM-interleaved or tiled inputs).
+    flatten_nd = bool(op.attrs.get('flatten_nd', False))
+    if flatten_nd:
+        out_shape = [1, 1, N * Hs * Ws, Cs]
+    else:
+        out_shape = [N, Hs, Ws, Cs]
     oTList[0].shape = out_shape
     oTList[0].dtype = X.dtype
     in_elems = X.nelems()


### PR DESCRIPTION
Closes #406

Restore correct fold output shape [N, Hs, Ws, Cs] and make fold_sinf frontend-agnostic with flatten_nd attribute.

## Changes

### Core Fold Improvements (3 commits from original branch)
- **Fix fold output shape**: Restore correct output shape `[N, Hs, Ws, Cs]` after fold operation
  - Introduce `Cs = C * stride_h * stride_w` variable for clarity
  - Fix stride_w assertion that incorrectly checked against H instead of W
  - Update docstring to match reference implementation
- **Frontend-agnostic fold_sinf**: Add `flatten_nd` boolean attribute to control output shape behavior
  - `flatten_nd=False` (default): Returns standard 4D shape `[N, Hs, Ws, Cs]`
  - `flatten_nd=True`: Returns flattened 2D shape for TTNN ROW_MAJOR/L1_SHARDED inputs (matches tt-metal behavior)
  - TTNN frontend computes `flatten_nd` from input layout/memory_config, mirroring tt-metal fold_device_op.cpp logic
- **Update test expectations**: Align fold tests with corrected output shapes and attributes

### Independence Fixes (2 commits)
- **Revert scalar-as-attr test changes**: Remove test_ttnn_tensor.py changes that depend on infrastructure introduced in another PR, to keep this PR independent
- **Fix mypy Optional type**: Use explicit `MemoryConfig | None` instead of implicit Optional to satisfy mypy's no_implicit_optional requirement

## Why These Changes?
The original fold_sinf hard-coded `[N,Hs,Ws,Cs]` output, which did not match hardware behavior for L1-sharded ROW_MAJOR inputs in ViT workloads. The `flatten_nd` attribute allows fold to behave correctly for both generic frontends (4D) and TTNN workloads that require 2D flattening.