### PR TITLE
feat(431): add SI profiling helper scripts for TT-Metal profiling on IRD systems

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,23 +11,21 @@ repos:
         -   id: spdx-checker
             name: Check SPDX License and Copyright
             description: Check SPDX License and Copyright
-            language: python
-            entry: tools/spdxchecker.py
+            language: system
+            entry: python tools/spdxchecker.py
             args: [--config, .github/spdxchecker-config.yml, --loglevel, error]
-            additional_dependencies: [pyyaml, loguru, pydantic]
             pass_filenames: false
         -   id: static checker
             name: Run static checks on the repository
             description: Check static checks
-            language: python
-            entry: ./checkin_tests.py
+            language: system
+            entry: python ./checkin_tests.py
             args:  [static]
-            # additional_dependencies: [pyyaml, loguru, pydantic]
             pass_filenames: false
         -   id: unit tests
             name: Run unit tests
             description: Run unit tests
-            language: python
+            language: system
             entry: pytest
             args: [-m, 'unit and not slow and not tools_secondary']
             pass_filenames: false

--- a/tests/test_tools/test_spdxchecker.py
+++ b/tests/test_tools/test_spdxchecker.py
@@ -72,6 +72,32 @@ def test_collects_all_files_in_directory(tmp_path):
     (tmp_path / ".git" / "ignored_file").write_text("")
     assert collect_all_files(str(tmp_path)) == ["file1.py", "file2.js"]
 
+
+def test_collects_all_files_skips_git_pointer_file_in_worktree(tmp_path):
+    """In a linked git worktree, ``.git`` is a one-line pointer file at the root, not a directory.
+
+    The walker must skip it just like it skips the ``.git`` directory in a normal checkout.
+    """
+    (tmp_path / "file1.py").write_text("")
+    (tmp_path / "file2.js").write_text("")
+    # .git as a regular file (linked-worktree case)
+    (tmp_path / ".git").write_text("gitdir: /path/to/main-repo/.git/worktrees/some-name\n")
+    assert collect_all_files(str(tmp_path)) == ["file1.py", "file2.js"]
+
+
+def test_collects_all_files_does_not_descend_into_git_directory(tmp_path):
+    """os.walk should be pruned at .git so deep .git/ subtrees don't slow the SPDX check.
+
+    Confirms files nested several levels deep inside .git are not even visited (not just
+    skipped after visiting).  Regression guard for the `dirs.remove('.git')` prune.
+    """
+    (tmp_path / "file1.py").write_text("")
+    (tmp_path / ".git").mkdir()
+    nested = tmp_path / ".git" / "objects" / "ab" / "cd"
+    nested.mkdir(parents=True)
+    (nested / "deep_file.py").write_text("")
+    assert collect_all_files(str(tmp_path)) == ["file1.py"]
+
 def test_collects_git_status_files(tmp_path):
     res = get_active_files(True, ConfigFileModel()) # collect_git_status_files(True) != []
     assert isinstance(res, list)

--- a/tools/si_profiling_helpers/README.md
+++ b/tools/si_profiling_helpers/README.md
@@ -1,0 +1,280 @@
+# TT-Metal Helper Scripts
+
+A collection of utility scripts for streamlining tt-metal development, setup, profiling, and performance analysis workflows.
+
+## Overview
+
+This repository contains helper scripts that codify common tt-metal development patterns and reduce manual setup steps when working with tt-metal, TTNN, and profiling tools.
+
+## Installation & Setup
+
+These scripts are part of the **Polaris** repository but are designed to work alongside **tt-metal** and **tt-npe** repositories. For use on IRD systems, the scripts need to be copied to the target machine.
+
+### Recommended Directory Structure
+
+```
+workspace/
+├── si_profiling_helpers/      # These helper scripts (from polaris/tools/si_profiling_helpers/)
+│   ├── setup-step-1-fresh-build.sh
+│   ├── setup-step-2-new-login.sh
+│   ├── run-ttnn-profiler.py
+│   └── README.md
+├── tt-metal/                  # TT-Metal repository clone
+│   ├── build_metal.sh
+│   ├── create_venv.sh
+│   ├── python_env/
+│   └── ...
+└── tt-npe/                    # TT-NPE repository clone
+    ├── build-npe.sh
+    ├── ENV_SETUP
+    └── ...
+```
+
+### Copying Scripts to IRD Systems
+
+```bash
+# From your local machine with polaris repository
+cd /path/to/polaris/tools/si_profiling_helpers
+
+# Copy to IRD system
+scp -r . username@ird-system:/path/to/workspace/si_profiling_helpers/
+
+# Or copy individual files as needed
+scp setup-step-1-fresh-build.sh setup-step-2-new-login.sh run-ttnn-profiler.py \
+    username@ird-system:/path/to/workspace/si_profiling_helpers/
+```
+
+### Initial Setup on IRD System
+
+```bash
+# 1. SSH to IRD system
+ssh username@ird-system
+
+# 2. Create workspace directory and navigate to it
+mkdir -p ~/workspace
+cd ~/workspace
+
+# 3. Clone required repositories (if not already present)
+git clone <tt-metal-repo-url> tt-metal
+git clone <tt-npe-repo-url> tt-npe
+
+# 4. Run initial build (from tt-metal directory)
+cd tt-metal
+bash ../si_profiling_helpers/setup-step-1-fresh-build.sh
+
+# 5. Configure environment (run in each new shell session)
+source ../si_profiling_helpers/setup-step-2-new-login.sh
+```
+
+## Scripts Index
+
+### Setup Scripts
+
+#### [`setup-step-1-fresh-build.sh`](setup-step-1-fresh-build.sh)
+Initial setup script for fresh tt-metal installation.
+- Builds tt-metal (profiler support is always enabled)
+- Creates Python virtual environment
+- Builds tt-npe (Lightweight Network-on-Chip Performance Estimator) toolkit with clang-20
+- **When to use:** After fresh-cloning tt-metal or pulling major updates
+- **Usage:** `cd /path/to/tt-metal && bash setup-step-1-fresh-build.sh`
+- **Prerequisites:** clang-20 and clang++-20 must be installed and in PATH
+
+#### [`setup-step-2-new-login.sh`](setup-step-2-new-login.sh)
+Environment configuration script for new shell sessions.
+- Activates Python virtual environment
+- Sets TT_METAL_HOME and PYTHONPATH
+- Sources NPE profiling tools (required for run-ttnn-profiler.py)
+- **When to use:** Every time you open a new terminal session
+- **Usage:** `cd /path/to/tt-metal && source setup-step-2-new-login.sh`
+- **Note:** Must use `source` or `.`, not `bash`
+- **Note:** TTNN profiling configuration is automatically handled by run-ttnn-profiler.py
+
+---
+
+### Profiling and Analysis Tools
+
+#### [`run-ttnn-profiler.py`](run-ttnn-profiler.py)
+Comprehensive TTNN profiler runner that wraps tracy with multiple profiling modes.
+
+**Features:**
+- Supports three profiling modes: raw profiling, NOC traces, and performance counters
+- Pytest integration support
+- Optional cleanup of large generated directories (npe_viz, .logs)
+- Dry-run capability for command preview
+- Automatic TTNN environment configuration with profiling overrides
+- Optional disable-logging flag for workloads with device sync issues
+
+**Usage:**
+```bash
+# Basic profiling only
+python run-ttnn-profiler.py \
+    --command "test_ttnn_functional_vit.py" \
+    --report-name vit_test \
+    --output-dir ./profiler_output \
+    --basic-only
+
+# Full profiling with pytest and cleanup
+python run-ttnn-profiler.py \
+    --command "tests/ttnn/unit_tests/test_model.py::test_forward" \
+    --pytest \
+    --report-name model_test \
+    --output-dir ./profiler_output \
+    --cleanup
+
+# With logging disabled (for workloads with device sync issues)
+python run-ttnn-profiler.py \
+    --command "test.py" \
+    --report-name test \
+    --output-dir ./output \
+    --disable-logging
+```
+
+**Prerequisites:**
+- NPE tools on PATH (automatically configured by setup-step-2-new-login.sh)
+- loguru package installed
+- **Board must be reset before profiling:** Use `tensix_reset.py` to automatically detect and reset the board
+  - See "Board Reset" section below for details
+
+#### [`tensix_reset.py`](tensix_reset.py)
+Automatically detects and resets Tensix board(s) via `tt-smi`.
+
+**Features:**
+- Parses `tt-smi -ls` output to find resettable boards without manual index lookup
+- Resets a single board by default; requires `--multiple-boards` when multiple boards are present
+
+**Usage:**
+```bash
+# Reset the single available board
+python tensix_reset.py
+
+# Reset all boards on a multi-board system
+python tensix_reset.py --multiple-boards
+```
+
+---
+
+## Quick Start
+
+### First-Time Setup
+Assuming you've followed the recommended directory structure above:
+
+```bash
+# Navigate to tt-metal directory
+cd ~/workspace/tt-metal
+
+# 1. Build tt-metal (also builds tt-npe)
+bash ../si_profiling_helpers/setup-step-1-fresh-build.sh
+
+# 2. Configure environment (in new shell sessions)
+source ../si_profiling_helpers/setup-step-2-new-login.sh
+```
+
+### Board Reset
+
+**IMPORTANT:** Always reset the board before running profiling to ensure clean hardware state.
+
+```bash
+# Automatically detect and reset the board
+python ../si_profiling_helpers/tensix_reset.py
+
+# If multiple boards are present and all should be reset
+python ../si_profiling_helpers/tensix_reset.py --multiple-boards
+```
+
+**Manual fallback** (if `tensix_reset.py` is not working):
+```bash
+# List devices to identify the board index
+tt-smi -ls
+
+# Reset by index (e.g., index 0)
+tt-smi -r 0
+```
+
+**Why reset is required:**
+- Hardware state from previous runs can interfere with profiling accuracy
+- Ensures consistent starting conditions for each profiling session
+- Clears any stale device state or hung operations
+
+### Running Profiler
+```bash
+# From tt-metal directory:
+
+# 1. Reset the board
+python ../si_profiling_helpers/tensix_reset.py
+
+# 2. Run profiler with all modes
+python ../si_profiling_helpers/run-ttnn-profiler.py \
+    --command "test_script.py" \
+    --report-name my_test \
+    --output-dir ./profiler_output
+
+# Example: Run pytest test with profiler
+python ../si_profiling_helpers/run-ttnn-profiler.py \
+    --command "tests/ttnn/unit_tests/test_model.py::test_forward" \
+    --pytest \
+    --report-name pytest_test \
+    --output-dir ./profiler_output_pytest
+```
+
+---
+
+## Documentation
+
+All scripts include comprehensive inline documentation:
+- Detailed usage instructions and examples
+- Required and optional parameters
+- Prerequisites and environment requirements
+- Input/output format specifications
+- Error handling and exit codes
+
+See individual script headers for complete documentation.
+
+---
+
+## Requirements
+
+### Common Requirements
+- Python 3.8 or later
+- loguru package: `pip install loguru`
+
+### Build Scripts
+- clang-20 and clang++-20 installed and in PATH
+
+### Profiling Scripts
+- tt-metal repository
+- tt-npe tools (for profiling operations)
+- tracy profiler module
+
+---
+
+## Repository Structure
+
+```
+si_profiling_helpers/
+├── README.md                      # This file
+├── setup-step-1-fresh-build.sh    # Initial build setup
+├── setup-step-2-new-login.sh      # Session environment setup
+├── run-ttnn-profiler.py           # TTNN profiler runner
+└── tensix_reset.py                # Automated board reset via tt-smi
+```
+
+---
+
+## License
+
+These scripts are utility tools for tt-metal development workflows.
+
+---
+
+## Contributing
+
+When adding new scripts:
+1. Include comprehensive header documentation
+2. Add usage examples (multiple scenarios)
+3. Document all parameters and prerequisites
+4. Add function-level docstrings
+5. Update this README.md index
+
+---
+
+**Last Updated:** April 8, 2026

--- a/tools/si_profiling_helpers/run-ttnn-profiler.py
+++ b/tools/si_profiling_helpers/run-ttnn-profiler.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""
+TTNN Profiler Runner
+
+This script runs the TTNN profiler with multiple profiling modes using tracy.
+It supports basic profiling, NOC trace collection, and performance counter capture.
+
+Usage:
+    python3 run-ttnn-profiler.py --command "<test_command>" \
+        --report-name <name> --output-dir <dir> [options]
+
+Examples:
+    # Basic profiling only
+    python3 run-ttnn-profiler.py \
+        --command "test_ttnn_functional_vit.py" \
+        --report-name vit_test \
+        --output-dir ./profiler_output \
+        --basic-only
+
+    # Full profiling (raw + NOC traces + perf counters)
+    python3 run-ttnn-profiler.py \
+        --command "test_ttnn_functional_vit.py" \
+        --report-name vit_full \
+        --output-dir ./profiler_output
+
+    # Pytest mode with cleanup
+    python3 run-ttnn-profiler.py \
+        --command "tests/ttnn/unit_tests/test_model.py::test_forward" \
+        --pytest \
+        --report-name model_test \
+        --output-dir ./profiler_output \
+        --cleanup
+
+    # Dry run to see commands without executing
+    python3 run-ttnn-profiler.py \
+        --command "test.py" \
+        --report-name test \
+        --output-dir ./out \
+        --dryrun
+
+Required Arguments:
+    --command       Test script or command to run under the profiler
+    --report-name   Name for the profiling report
+    --output-dir    Directory to save profiler outputs (must not exist)
+
+Optional Arguments:
+    --pytest            Run command with pytest (-m pytest prefix)
+    --basic-only        Skip NOC traces and performance counter collection
+    --disable-logging   Disable TTNN logging (enable_logging=False in config overrides)
+                        Some workloads like VGG have device synchronize calls that
+                        fail when enable_logging is true. Use this flag for such cases.
+    --show-output       Show stdout/stderr in real-time during command execution.
+                        Useful for monitoring progress and debugging hanging commands.
+                        By default, output is only captured and saved to results file.
+    --cleanup           Remove npe_viz and .logs directories after profiling.
+                        These generated directories can be very large; use this flag
+                        if their contents are not needed for analysis.
+    --dryrun, -n        Show commands without executing them
+
+Output Structure:
+    <output-dir>/
+        ├── generated/              # TTNN generated files
+        ├── results_typescript.txt  # Command outputs and results
+        ├── raw/                    # Tracy raw profiling output
+        ├── perf/                   # Tracy performance counter output (full mode only)
+        └── trace/                  # Tracy NOC trace output (full mode only)
+
+Prerequisites:
+    - NPE tools must be on PATH (source tt-npe/ENV_SETUP)
+    - Tracy profiler module must be available
+    - loguru package must be installed
+
+Notes:
+    - The script runs up to 3 profiling passes:
+      1. Raw profiling with TTNN config overrides
+      2. Performance counter collection (unless --basic-only)
+      3. NOC trace collection (unless --basic-only)
+    - Execution stops if any pass fails
+    - 'generated' directory is automatically moved to output directory
+"""
+
+import os
+import sys
+import argparse
+import importlib.util
+import json
+import shutil
+import subprocess
+import threading
+
+from loguru import logger
+
+
+def is_npe_on_path() -> bool:
+    """Check if NPE tools are available on the Python path."""
+    return importlib.util.find_spec('npe_analyze_noc_trace_dir') is not None
+
+
+def run_and_capture(argv: list[str], show_output: bool = False) -> subprocess.CompletedProcess[str]:
+    """Execute a command and capture its output.
+
+    Args:
+        argv (list[str]): Command and arguments as a list (shell=False).
+        show_output (bool): If True, display stdout/stderr in real-time while capturing.
+                           If False (default), only capture output silently.
+
+    Returns:
+        subprocess.CompletedProcess: Result object with returncode, stdout, stderr
+    """
+    process = subprocess.Popen(
+        argv,
+        shell=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+    proc_stdout = process.stdout
+    proc_stderr = process.stderr
+    assert proc_stdout is not None
+    assert proc_stderr is not None
+
+    stdout_lines: list[str] = []
+    stderr_lines: list[str] = []
+
+    def read_stdout() -> None:
+        for line in iter(proc_stdout.readline, ''):
+            if line:
+                if show_output:
+                    print(line, end='')
+                    sys.stdout.flush()
+                stdout_lines.append(line)
+        proc_stdout.close()
+
+    def read_stderr() -> None:
+        for line in iter(proc_stderr.readline, ''):
+            if line:
+                if show_output:
+                    print(line, end='', file=sys.stderr)
+                    sys.stderr.flush()
+                stderr_lines.append(line)
+        proc_stderr.close()
+
+    stdout_thread = threading.Thread(target=read_stdout)
+    stderr_thread = threading.Thread(target=read_stderr)
+
+    stdout_thread.start()
+    stderr_thread.start()
+
+    process.wait()
+
+    stdout_thread.join()
+    stderr_thread.join()
+
+    result = subprocess.CompletedProcess(
+        args=argv,
+        returncode=process.returncode,
+        stdout=''.join(stdout_lines),
+        stderr=''.join(stderr_lines),
+    )
+
+    if result.returncode == 0:
+        logger.info('Command ran successfully.')
+    else:
+        logger.error('Command failed to run.')
+
+    return result
+
+
+def setup_environment(report_name: str, enable_logging: bool = True) -> None:
+    """Configure TTNN environment variables for profiling.
+
+    Sets up TTNN_CONFIG_OVERRIDES with profiling-friendly settings and
+    enables device profiler environment variables. Also sets TT_METAL_HOME
+    and PYTHONPATH based on the current working directory.
+
+    Note: This script is expected to be run from the tt-metal home directory.
+
+    Args:
+        report_name (str): Name for the profiling report
+        enable_logging (bool): Whether to enable TTNN logging. Defaults to True.
+            Set to False for workloads like VGG that have device synchronize
+            calls which fail when logging is enabled.
+    """
+    metal_home = os.getcwd()
+    os.environ['TT_METAL_HOME'] = metal_home
+
+    current_pythonpath = os.environ.get('PYTHONPATH', '')
+    if current_pythonpath:
+        os.environ['PYTHONPATH'] = f'{metal_home}:{current_pythonpath}'
+    else:
+        os.environ['PYTHONPATH'] = metal_home
+
+    environ = {
+        'enable_fast_runtime_mode': False,
+        'enable_logging': enable_logging,
+        'report_name': report_name,
+        'enable_graph_report': False,
+        'enable_detailed_buffer_report': True,
+        'enable_detailed_tensor_report': False,
+        'enable_comparison_mode': False,
+    }
+    os.environ['TTNN_CONFIG_OVERRIDES'] = json.dumps(environ)
+
+    os.environ['TT_METAL_DEVICE_PROFILER'] = '1'
+    os.environ['TT_METAL_PROFILER_SYNC'] = '1'
+
+
+def run_profiler(
+    command: str,
+    output_dir: str,
+    pytest_mode: bool,
+    report_name: str,
+    collect_noc_traces: bool = False,
+    collect_perf_counters: bool = False,
+    enable_logging: bool = True,
+    show_output: bool = False,
+    dryrun: bool = False,
+) -> subprocess.CompletedProcess[str] | None:
+    """Run the TTNN profiler with specified options.
+
+    Args:
+        command (str): Test script or command to run under the profiler
+        output_dir (str): Directory to save profiler output for this pass
+        pytest_mode (bool): If True, prefix command with '-m pytest'
+        report_name (str): Name for the profiling report
+        collect_noc_traces (bool): If True, collect NOC traces
+        collect_perf_counters (bool): If True, collect performance counters
+        enable_logging (bool): Whether to enable TTNN logging in config overrides
+        show_output (bool): If True, display command stdout/stderr in real-time
+        dryrun (bool): If True, show commands without executing
+
+    Returns:
+        subprocess.CompletedProcess or None: Result object or None if dryrun
+    """
+    argv = ['python3', '-m', 'tracy', '-p', '-r', '-v', '--op-support-count=100000', '-o', output_dir]
+    if collect_noc_traces:
+        argv.append('--collect-noc-traces')
+    if collect_perf_counters:
+        argv.append('--profiler-capture-perf-counters=all')
+    if pytest_mode:
+        argv.extend(['-m', 'pytest', command])
+    else:
+        argv.append(command)
+
+    if collect_noc_traces:
+        mode = 'trace'
+    elif collect_perf_counters:
+        mode = 'perf-counter'
+    else:
+        mode = 'raw'
+
+    logger.info(f'Running command in {mode} mode: {" ".join(argv)}')
+
+    if mode == 'raw':
+        setup_environment(report_name, enable_logging)
+    else:
+        if 'TTNN_CONFIG_OVERRIDES' in os.environ:
+            del os.environ['TTNN_CONFIG_OVERRIDES']
+
+    if dryrun:
+        return None
+
+    result = run_and_capture(argv, show_output=show_output)
+    if result.returncode == 0:
+        logger.info(f'Profiler {mode} mode output saved to: {output_dir} with report name: {report_name}')
+
+    return result
+
+
+def anyfails(results: list[subprocess.CompletedProcess[str] | None]) -> bool:
+    """Check if any profiler run failed."""
+    for result in results:
+        if result is None:
+            continue
+        if result.returncode != 0:
+            return True
+    return False
+
+
+def cleanup_directories(output_dir: str) -> None:
+    """Remove npe_viz and .logs directories and profile_log_device.csv files recursively from output directory."""
+    logger.info('Performing cleanup...')
+    dirs_to_remove = ['npe_viz', '.logs']
+    files_to_remove = ['profile_log_device.csv']
+    for root, dirs, files in os.walk(output_dir, topdown=False):
+        for dir_name in dirs:
+            if dir_name in dirs_to_remove:
+                dir_path = os.path.join(root, dir_name)
+                logger.info(f'Removing directory: {dir_path}')
+                shutil.rmtree(dir_path)
+        for file_name in files:
+            if file_name in files_to_remove:
+                file_path = os.path.join(root, file_name)
+                logger.info(f'Removing file: {file_path}')
+                os.remove(file_path)
+    logger.info('Cleanup completed.')
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Run the TTNN profiler')
+    parser.add_argument('--command', type=str, required=True, help='Test script or command to run under the profiler')
+    parser.add_argument('--pytest', action='store_true', help='Run the profiler in pytest mode')
+    parser.add_argument('--report-name', type=str, required=True, help='Name of the profiler report')
+    parser.add_argument('--output-dir', type=str, required=True, help='Directory to save the profiler output')
+    parser.add_argument(
+        '--basic-only', action='store_true', help='Only run basic profiling (skip NOC traces and performance counters)'
+    )
+    parser.add_argument(
+        '--disable-logging',
+        action='store_true',
+        help='Disable TTNN logging (enable_logging=False). Use for workloads like VGG with device synchronize calls that fail when logging is enabled. Defaults to logging enabled.',
+    )
+    parser.add_argument(
+        '--show-output',
+        action='store_true',
+        help='Show stdout/stderr in real-time during command execution. Useful for monitoring progress and debugging hanging commands.',
+    )
+    parser.add_argument(
+        '--cleanup',
+        action='store_true',
+        help='Remove npe_viz and .logs directories from output directory after run. These directories can be very large; use this flag if their contents are not needed.',
+    )
+    parser.add_argument('--dryrun', '-n', action='store_true', help='show but do not execute commands')
+    args = parser.parse_args()
+
+    command = args.command
+    output_dir = os.path.realpath(args.output_dir)
+    pytest_mode = args.pytest
+    report_name = args.report_name
+    enable_logging = not args.disable_logging
+    show_output = args.show_output
+    logger.remove()
+    logger.add(sys.stdout, level='INFO')
+
+    if not args.dryrun:
+        if os.path.exists(output_dir):
+            logger.error(f'Output directory {output_dir} already exists. Please specify a new directory.')
+            return 1
+        if os.path.exists('generated'):
+            logger.error("Directory named 'generated' already exists. Please remove it before running the profiler.")
+            return 1
+        if not args.basic_only and not is_npe_on_path():
+            logger.error('NPE not on path; source tt-npe/ENV_SETUP')
+            return 1
+        os.makedirs(output_dir)
+
+    if any([word in args.command for word in ['tests/', 'pytest']]) and not args.pytest:
+        logger.error('possibly using pytest without providing --pytest knob to this script')
+
+    if 'vgg' in args.command.lower() and enable_logging:
+        logger.error('possibly running VGG without disabling logging')
+        os.system('sleep 5')
+
+    raw_dir = os.path.join(output_dir, 'raw')
+    perf_dir = os.path.join(output_dir, 'perf')
+    trace_dir = os.path.join(output_dir, 'trace')
+
+    result1 = run_profiler(
+        command, raw_dir, pytest_mode, report_name,
+        collect_noc_traces=False, collect_perf_counters=False,
+        enable_logging=enable_logging, show_output=show_output, dryrun=args.dryrun,
+    )
+    results = [result1]
+
+    if not args.basic_only:
+        if not anyfails(results):
+            result2 = run_profiler(
+                command, perf_dir, pytest_mode, report_name,
+                collect_noc_traces=False, collect_perf_counters=True,
+                enable_logging=enable_logging, show_output=show_output, dryrun=args.dryrun,
+            )
+            results.append(result2)
+        if not anyfails(results):
+            result3 = run_profiler(
+                command, trace_dir, pytest_mode, report_name,
+                collect_noc_traces=True, collect_perf_counters=False,
+                enable_logging=enable_logging, show_output=show_output, dryrun=args.dryrun,
+            )
+            results.append(result3)
+
+    if args.dryrun:
+        return 0
+
+    try:
+        os.rename('generated', os.path.join(output_dir, 'generated'))
+    except Exception:
+        pass
+
+    output_filename = os.path.join(output_dir, 'results_typescript.txt')
+    with open(output_filename, 'w') as summary_file:
+        for res in results:
+            if res is not None:
+                summary_file.write(f'Command: {" ".join(res.args)}\n')
+                summary_file.write(f'Return code: {res.returncode}\n')
+                summary_file.write(f'Stdout:\n{res.stdout}\n')
+                summary_file.write(f'Stderr:\n{res.stderr}\n')
+    logger.info('output saved in {}', output_filename)
+
+    if args.cleanup:
+        cleanup_directories(output_dir)
+    return 0
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/tools/si_profiling_helpers/setup-step-1-fresh-build.sh
+++ b/tools/si_profiling_helpers/setup-step-1-fresh-build.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+# setup-step-1-fresh-build.sh
+set -euo pipefail
+#
+# Description:
+#   Initial setup script for a fresh tt-metal installation.
+#   Builds tt-metal, creates a Python virtual environment,
+#   and builds tt-npe (Neural Processing Engine) toolkit.
+#
+# Usage:
+#   cd /path/to/tt-metal
+#   bash setup-step-1-fresh-build.sh
+#
+# When to use:
+#   - After fresh-cloning tt-metal repository
+#   - After pulling major updates that require a rebuild
+#   - When setting up tt-metal on a new machine
+#
+# What this does:
+#   1. Builds tt-metal
+#   2. Creates Python virtual environment in python_env/
+#   3. Builds tt-npe with clang-20 compiler
+#
+# Next steps:
+#   After this completes successfully, run setup-step-2-new-login.sh
+#
+# Prerequisites:
+#   - Run from the tt-metal repository root directory
+#   - build_metal.sh, create_venv.sh, and build-npe.sh must exist
+#   - clang-20 and clang++-20 must be installed and in PATH
+#   - Required build dependencies must be installed
+
+# Build tt-metal (profiler support is always enabled)
+./build_metal.sh
+
+# Create Python virtual environment
+./create_venv.sh
+
+# Activate venv so tt-npe build picks up the right Python interpreter
+source python_env/bin/activate
+
+# Build tt-npe with clang-20 compiler
+cd ../tt-npe
+bash build-npe.sh

--- a/tools/si_profiling_helpers/setup-step-2-new-login.sh
+++ b/tools/si_profiling_helpers/setup-step-2-new-login.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+# setup-step-2-new-login.sh
+#
+# Description:
+#   Environment setup script to run after tt-metal is built.
+#   Configures Python environment and TTNN settings for development and profiling.
+#
+# Usage:
+#   cd /path/to/tt-metal
+#   source setup-step-2-new-login.sh
+#
+#   Note: Must use 'source' or '.' to execute, not 'bash', so that
+#   environment variables persist in your current shell.
+#
+# When to use:
+#   - Every time you open a new terminal/shell session
+#   - After running setup-step-1-fresh-build.sh for the first time
+#   - Before running any tt-metal tests or profiling
+#
+# What this does:
+#   1. Activates the Python virtual environment
+#   2. Sets TT_METAL_HOME to current directory
+#   3. Adds current directory to PYTHONPATH
+#   4. Sources NPE profiling tools (required for run-ttnn-profiler.py)
+#
+# Notes:
+#   - Profiling-specific configuration (TTNN_CONFIG_OVERRIDES, profiler flags)
+#     is now handled automatically by run-ttnn-profiler.py
+#   - For manual TTNN configuration or debug logging, see optional steps below
+#
+# Prerequisites:
+#   - setup-step-1-fresh-build.sh must have completed successfully
+#   - python_env/ directory must exist
+#   - Run from the tt-metal repository root directory
+
+# Sanity check: ensure this is sourced from the tt-metal repository root
+if [[ ! -f python_env/bin/activate || ! -f build_metal.sh ]]; then
+    echo "ERROR: setup-step-2-new-login.sh must be sourced from the tt-metal repository root." >&2
+    echo "       Expected files not found: python_env/bin/activate, build_metal.sh" >&2
+    return 1
+fi
+
+# Activate Python virtual environment
+source python_env/bin/activate
+
+# Set tt-metal home directory
+export TT_METAL_HOME=$(pwd)
+
+# Prepend tt-metal to Python path (preserving any existing entries)
+if [[ -n "${PYTHONPATH:-}" ]]; then
+    export PYTHONPATH="$(pwd):${PYTHONPATH}"
+else
+    export PYTHONPATH="$(pwd)"
+fi
+
+# Enable NPE profiling tools (required for run-ttnn-profiler.py)
+source ../tt-npe/ENV_SETUP
+
+echo "Environment configured successfully!"
+echo "TT_METAL_HOME: $TT_METAL_HOME"
+echo "Python environment: $(which python)"
+echo ""
+echo "Note: run-ttnn-profiler.py will automatically configure profiling-specific"
+echo "      settings (TTNN_CONFIG_OVERRIDES, TT_METAL_DEVICE_PROFILER, etc.)"
+
+# ============================================================================
+# Optional Manual Steps (uncomment as needed)
+# ============================================================================
+
+# Manually configure TTNN settings (if not using run-ttnn-profiler.py)
+# export TTNN_CONFIG_OVERRIDES='{
+#   "enable_fast_runtime_mode": false,
+#   "enable_logging": true,
+#   "report_name": "report",
+#   "enable_graph_report": false,
+#   "enable_detailed_buffer_report": true,
+#   "enable_detailed_tensor_report": false,
+#   "enable_comparison_mode": false
+# }'
+
+# Manually enable device profiler (if not using run-ttnn-profiler.py)
+# export TT_METAL_DEVICE_PROFILER=1
+# export TT_METAL_PROFILER_SYNC=1
+
+# Enable debug-level operation logging
+# export TT_LOGGER_TYPES=Op
+# export TT_LOGGER_LEVEL=Debug

--- a/tools/si_profiling_helpers/tensix_reset.py
+++ b/tools/si_profiling_helpers/tensix_reset.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+import os
+import argparse
+import re
+
+from loguru import logger
+
+
+def tt_smi_find_indices():
+    with os.popen('tt-smi -ls | iconv -f UTF-8 -t ASCII -c') as fin:
+        lines = [l.rstrip() for l in fin]
+    can_be_reset_index = [tmp for tmp, l in enumerate(lines) if 'can be reset' in l]
+    if not can_be_reset_index:
+        raise ValueError('tt-smi output does not identify boards that can be reset')
+    if len(can_be_reset_index) > 1:
+        raise ValueError('tt-smi output has multiple lines matching boards that can be reset')
+    indices = []
+    for line in lines[can_be_reset_index[0] + 1:]:
+        m = re.search('^ [0-9]+', line)
+        if not m:
+            continue
+        indices.append(m.group(0).strip())
+    if len(indices) == 0:
+        raise ValueError('tt-smi output does not identify boards that can be reset')
+    return indices
+
+    # tt-smi -ls | iconv -f UTF-8 -t ASCII -c  | sed '1,/can be reset/d' | grep '^ [0-9]' | sed 's/^ \([0-9]*\).*/\1/'
+
+
+def reset_boards(indices: list[str]) -> int:
+    index_str = ','.join(indices)
+    cmd = f'tt-smi -r {index_str}'
+    logger.info(f'resetting board(s) #{index_str}')
+    ret = os.system(cmd)
+    if ret != 0:
+        raise ValueError(f'{cmd} failed, exit code {ret}')
+    logger.success(f'Executed {cmd} successfully, board(s) #{index_str} reset successfully')
+    return ret
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Reset Tensix board(s) via tt-smi')
+    parser.add_argument('--multiple-boards', action='store_true',
+                        help='allow resetting more than one board when multiple are found')
+    args = parser.parse_args()
+
+    indices = tt_smi_find_indices()
+    if len(indices) > 1 and not args.multiple_boards:
+        raise ValueError(
+            f'found {len(indices)} boards ({", ".join(f"#{i}" for i in indices)}); '
+            'pass --multiple-boards to reset all of them'
+        )
+    return reset_boards(indices)
+
+
+if __name__ == '__main__':
+    exit(main())
+

--- a/tools/spdxchecker.py
+++ b/tools/spdxchecker.py
@@ -214,17 +214,32 @@ def collect_all_files(dirname: str) -> list[str]:
     files: list[str] = []
     filename: str
     root: str
-    _dirs: list[str]
+    dirs: list[str]
     filenames: list[str]
     # Normalize dirname to use forward slashes
     dirname_normalized = dirname.replace('\\', '/')
-    for root, _dirs, filenames in os.walk(dirname):
+    for root, dirs, filenames in os.walk(dirname):
+        # Prune .git from the walk so os.walk doesn't recurse into the
+        # (potentially large) .git/objects subtree on non-worktree checkouts.
+        # In linked worktrees .git is a one-line pointer file rather than a
+        # directory, so it's not in `dirs` and this no-ops there.  Mutating
+        # `dirs` in-place during top-down walk is the os.walk-documented way
+        # to skip a subtree.
+        if '.git' in dirs:
+            dirs.remove('.git')
         # Normalize root path
         root_normalized = root.replace('\\', '/')
-        # Skip .git directory; Only the startswith condition will wrongly match .gitHub directory
+        # Belt-and-suspenders: even with the prune above, keep the path-prefix
+        # skip in case os.walk is invoked elsewhere or a symlink reintroduces
+        # the directory.  The trailing slash on '/.git/' is intentional: it
+        # prevents the startswith from also matching '.gitHub' / '.gitignore_local/'.
         if root_normalized == dirname_normalized + '/.git' or root_normalized.startswith(dirname_normalized + '/.git/'):
             continue
         for filename in filenames:
+            # Skip the .git file at the worktree root (git creates this as a
+            # one-line pointer file in linked worktrees instead of a .git dir).
+            if filename == '.git' and root_normalized == dirname_normalized:
+                continue
             # Build relative path with forward slashes
             full_path = os.path.join(root, filename).replace('\\', '/')
             rel_path = os.path.relpath(full_path, dirname).replace(os.sep, '/')


### PR DESCRIPTION
## Summary

- Adds `tools/si_profiling_helpers/` with three scripts and a README to standardize TT-Metal profiling workflows on IRD systems
- `setup-step-1-fresh-build.sh`: one-time build of tt-metal + tt-npe with profiler support (clang-20)
- `setup-step-2-new-login.sh`: per-session env setup (venv, TT_METAL_HOME, PYTHONPATH, NPE tools)
- `run-ttnn-profiler.py`: multi-mode tracy profiler runner (raw, NOC traces, perf counters) with pytest integration, dry-run, and optional cleanup

## Test plan

- [ ] Copy scripts to IRD system via scp and run `setup-step-1-fresh-build.sh` from tt-metal directory
- [ ] Source `setup-step-2-new-login.sh` in a new shell and verify env vars are set
- [ ] Run `run-ttnn-profiler.py --dryrun` to verify command construction
- [ ] Run `run-ttnn-profiler.py` against a known TTNN test and verify profiler output directories are created
- [ ] Run with `--basic-only`, `--disable-logging`, `--cleanup` flags and verify each behaves correctly

Closes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)