### PR TITLE
feat(428): add VGG UNet WH/BH dual-mode workloads to Polaris

### DIFF
--- a/config/all_workloads.yaml
+++ b/config/all_workloads.yaml
@@ -463,3 +463,35 @@ workloads:
     module : run_vit_perf_device@test_vit_device_perf_bh.py
     instances:
       vitoptim_bh_b16_perf_report: { bs: 10, model_name: vitoptim-bh-b16-perf-report }
+
+  # ----- VGG UNet — Wormhole (n150) -----
+
+  - api: TTNN
+    name: vgg_unet_wh_device_perf
+    basedir: workloads/ttnn/vgg_unet/wh
+    module : run_vgg_unet_e2e_entry@test_vgg_unet_device_perf_wh.py
+    instances:
+      vgg_unet_wh_b1_device_perf: { bs: 1, model_name: vgg-unet-wh-b1-device-perf }
+
+  - api: TTNN
+    name: vgg_unet_wh_perf_report
+    basedir: workloads/ttnn/vgg_unet/wh
+    module : run_vgg_unet_perf_device@test_vgg_unet_device_perf_wh.py
+    instances:
+      vgg_unet_wh_b1_perf_report: { bs: 1, model_name: vgg-unet-wh-b1-perf-report }
+
+  # ----- VGG UNet — Blackhole (p100a) -----
+
+  - api: TTNN
+    name: vgg_unet_bh_device_perf
+    basedir: workloads/ttnn/vgg_unet/bh
+    module : run_vgg_unet_e2e_entry@test_vgg_unet_device_perf_bh.py
+    instances:
+      vgg_unet_bh_b1_device_perf: { bs: 1, model_name: vgg-unet-bh-b1-device-perf }
+
+  - api: TTNN
+    name: vgg_unet_bh_perf_report
+    basedir: workloads/ttnn/vgg_unet/bh
+    module : run_vgg_unet_perf_device@test_vgg_unet_device_perf_bh.py
+    instances:
+      vgg_unet_bh_b1_perf_report: { bs: 1, model_name: vgg-unet-bh-b1-perf-report }

--- a/config/ip_workloads.yaml
+++ b/config/ip_workloads.yaml
@@ -565,7 +565,7 @@ workloads:
       bs               : 1
     instances:
       fusionad_validation : { bev_h: 25,  bev_w: 25,  img_height: 256,  img_width: 256  }
-    
+
   - api: TTSIM
     name: EA_LSS
     basedir: workloads/EA_LSS

--- a/config/tt_bh.yaml
+++ b/config/tt_bh.yaml
@@ -61,7 +61,7 @@ packages:
     -   name: Blackhole
         instances:
         -   name: p100a
-            operator_lookup_file: lfc://hlm-lut/bh_p100a_lut_v2.yaml
+            operator_lookup_file: lfc://hlm-lut/bh_p100a_lut_v5.yaml
             # Logical tensix grid (x, y) — see doc/TTNN_SHIM_ARCHITECTURE.md §17.
             # Source: tt-metal/tt_metal/core_descriptors/blackhole_140_arch.yaml (end=[12, 9] inclusive → 13×10).
             # p100a has one column reserved → effective 12×10 = 120 cores (matches num_units below).

--- a/config/tt_wh.yaml
+++ b/config/tt_wh.yaml
@@ -50,7 +50,7 @@ packages:
         instances:
         -   name: n150
             # operator_lookup_file can be a local path or LFC path starting with lfc://
-            operator_lookup_file: lfc://hlm-lut/whb0_n150_lut_v2.yaml
+            operator_lookup_file: lfc://hlm-lut/whb0_n150_lut_v5.yaml
             # Logical tensix grid (x, y) — see doc/TTNN_SHIM_ARCHITECTURE.md §17.
             # Source: tt-metal/tt_metal/core_descriptors/wormhole_b0_80_arch_eth_dispatch.yaml
             # (end=[7, 9] → 8×10 physical). n150 has one row harvested → 8×9 = 72 cores

--- a/config/wl2archmapping.yaml
+++ b/config/wl2archmapping.yaml
@@ -49,8 +49,10 @@ op_rsrc_spec:
              Equal, Erf, Exp, Expand,
              Flatten, Fold,
              Gather, GatherND, Gelu, GlobalAveragePool, GridSample, Greater, GroupNormalization,
+             Halo,
              HardSigmoid, Hardswish,
              Identity, If, InterleavedToSharded, IsNaN,
+             Move,
              LayerNormalization, LeakyRelu, Log, Less,
              Max, MaxPool, Mean, Min, Mish, Mul,
              Neg, ConcatHeads, CreateQKVHeads, NonMaxSuppression, NonZero, # transformer head ops from ttnn_shim

--- a/tests/test_lfc.py
+++ b/tests/test_lfc.py
@@ -253,7 +253,7 @@ def test_resolve_lfc_path_http_404_without_local_fallback():
                 fp=None
             )
             with patch('urllib.request.urlopen', side_effect=http_error):
-                with pytest.raises(RuntimeError, match="Download failed.*HTTP 404.*no local file exists"):
+                with pytest.raises(RuntimeError, match=r"Download failed.*no local file exists"):
                     resolve_lfc_path("lfc://test/file.yaml")
     finally:
         os.chdir(original_cwd)

--- a/tests/test_tools/test_master_operator_perf_lookup.py
+++ b/tests/test_tools/test_master_operator_perf_lookup.py
@@ -288,6 +288,81 @@ def test_unary_single_lookup_hit(tmp_path: Path):
     assert st is not None
     assert st.msecs == pytest.approx(0.03)
     assert st.mem_util == pytest.approx(20.0)
+    # Literal == resolved here (lookup hit the first key it tried).
+    assert st.key_literal is not None
+    assert st.key_resolved is not None
+    assert st.key_literal == st.key_resolved
+    # Resolved key must be an actual entry in the LUT.
+    assert st.key_resolved in m._entries
+
+
+@pytest.mark.unit
+def test_lookup_resolved_key_differs_from_literal_on_fallback(tmp_path: Path):
+    """When the literal key misses but a fallback substitution hits, key_literal records
+    the originally-built tuple and key_resolved records the matching LUT entry's key.
+
+    Exercises the Halo HEIGHT_SHARDED → BLOCK_SHARDED fallback: the LUT only has the
+    BLOCK_SHARDED variant; the lookup builds a HEIGHT_SHARDED literal key, then the
+    fallback chain in OperatorPerfMap.lookup substitutes BLOCK at position 7 and finds
+    the entry.
+    """
+    from tools.perf_lookup.lookup_operator_perf import OperatorPerfMap
+
+    doc = {
+        "schema_name": "correqn.tt-perf-master",
+        "schema_version": 4,
+        "entries": [
+            {
+                "key": {
+                    "op_code": "halo",
+                    "input_0_w_pad_logical": 1,
+                    "input_0_z_pad_logical": 1,
+                    "input_0_y_pad_logical": 100,
+                    "input_0_x_pad_logical": 64,
+                    "input_0_layout": "ROW_MAJOR",
+                    "input_0_datatype": "BFLOAT16",
+                    "input_0_memory": "DEV_1_L1_BLOCK_SHARDED",
+                    "math_fidelity": "N/A",
+                    "kernel_h": 3,
+                    "kernel_w": 3,
+                    "stride_h": 1,
+                    "stride_w": 1,
+                    "padding_h": 1,
+                    "padding_w": 1,
+                    "is_transpose": False,
+                },
+                "value": _flat_single_value(8, msecs=0.05),
+            }
+        ],
+    }
+    p = tmp_path / "halo_fallback.yaml"
+    p.write_text(yaml.dump(doc, sort_keys=False), encoding="utf-8")
+    m = OperatorPerfMap(p)
+
+    # Build a polaris-side tensor whose literal key uses HEIGHT_SHARDED (so the
+    # literal lookup misses and the HEIGHT→BLOCK fallback runs).
+    from ttsim.front.ttnn.buffer import BufferType, TensorMemoryLayout
+    from ttsim.front.ttnn.memory import MemoryConfig
+    # Y=100, X=64 matches the LUT entry's input_0_y_pad_logical=100, input_0_x_pad_logical=64.
+    t0 = SimTensor({"name": "a", "shape": [1, 1, 100, 64], "op_in": [], "op_out": []})
+    t0.layout = SimpleNamespace(name="ROW_MAJOR_LAYOUT")
+    t0._memory_config = MemoryConfig(TensorMemoryLayout.HEIGHT_SHARDED, BufferType.L1)
+    # Schema v3 halo keys carry sliding-window geometry; the op.attrs must provide them.
+    op = SimpleNamespace(
+        optype="Halo", precision="BF16", inList=["a"],
+        attrs={"kernel_size": (3, 3), "stride": (1, 1), "padding": (1, 1)},
+    )
+    g = SimpleNamespace(_tensors={"a": t0})
+
+    st = m.lookup(op, g, core_count=8)
+    assert st is not None, "Halo HEIGHT→BLOCK fallback should hit the BLOCK_SHARDED LUT entry"
+    assert st.key_literal is not None and st.key_resolved is not None
+    assert st.key_literal != st.key_resolved, "Literal and resolved keys must differ when a fallback substituted"
+    assert st.key_literal[7] == "DEV_1_L1_HEIGHT_SHARDED"
+    assert st.key_resolved[7] == "DEV_1_L1_BLOCK_SHARDED"
+    # Resolved key must be an actual entry in the LUT; literal must not.
+    assert st.key_resolved in m._entries
+    assert st.key_literal not in m._entries
 
 
 @pytest.mark.unit
@@ -371,8 +446,13 @@ def test_curve_hit_missing_vector_pipe_util_raises_at_lookup(tmp_path: Path):
 
 
 @pytest.mark.unit
-def test_lut_util_percent_out_of_range_raises(tmp_path: Path):
-    from tools.perf_lookup.lookup_operator_perf import OperatorPerfLUTValidationError, OperatorPerfMap
+def test_lut_util_percent_over_100_warns_does_not_raise(tmp_path: Path):
+    """Util fields >100 are accepted (with a one-time per-field warning) — see TODO(util-over-100).
+
+    TT-Metal sometimes reports multicast/overcount util values above 100; the loader
+    used to raise but now warns and continues so real HW data can flow through.
+    """
+    from tools.perf_lookup.lookup_operator_perf import OperatorPerfMap
 
     doc = {
         "schema_name": "correqn.tt-perf-master",
@@ -394,7 +474,44 @@ def test_lut_util_percent_out_of_range_raises(tmp_path: Path):
             }
         ],
     }
-    p = tmp_path / "bad_pct.yaml"
+    p = tmp_path / "over_100_pct.yaml"
+    p.write_text(yaml.dump(doc, sort_keys=False), encoding="utf-8")
+    m = OperatorPerfMap(p)
+    t0 = SimTensor({"name": "a", "shape": [1, 2, 3], "op_in": [], "op_out": []})
+    op = SimpleNamespace(optype="Softmax", precision="BF16", inList=["a"])
+    g = SimpleNamespace(_tensors={"a": t0})
+    # Lookup must succeed; the >100 value is preserved verbatim.
+    stats = m.lookup(op, g, core_count=8)
+    assert stats is not None
+    assert stats.matrix_pipe_util == 100.01
+
+
+@pytest.mark.unit
+def test_lut_util_percent_negative_raises(tmp_path: Path):
+    """Negative util values remain a hard error — only the upper bound was relaxed."""
+    from tools.perf_lookup.lookup_operator_perf import OperatorPerfLUTValidationError, OperatorPerfMap
+
+    doc = {
+        "schema_name": "correqn.tt-perf-master",
+        "schema_version": 2,
+        "entries": [
+            {
+                "key": {
+                    "op_code": "softmax",
+                    "input_0_w_pad_logical": 1,
+                    "input_0_z_pad_logical": 1,
+                    "input_0_y_pad_logical": 2,
+                    "input_0_x_pad_logical": 3,
+                    "input_0_layout": "TILE",
+                    "input_0_datatype": "BFLOAT16",
+                    "input_0_memory": "DEV_1_DRAM_INTERLEAVED",
+                "math_fidelity": "N/A",
+                },
+                "value": _flat_single_value(8, msecs=0.03, matrix_pipe_util=-0.5),
+            }
+        ],
+    }
+    p = tmp_path / "neg_pct.yaml"
     p.write_text(yaml.dump(doc, sort_keys=False), encoding="utf-8")
     m = OperatorPerfMap(p)
     t0 = SimTensor({"name": "a", "shape": [1, 2, 3], "op_in": [], "op_out": []})

--- a/tests/test_ttnn/test_halo_auto_emission.py
+++ b/tests/test_ttnn/test_halo_auto_emission.py
@@ -1,0 +1,576 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests that Halo SimOps are auto-emitted before conv2d / max_pool2d / conv_transpose2d.
+
+On Tenstorrent hardware, halo extraction is dispatched implicitly by the conv and
+pool kernels.  The ttnn shim mirrors this by auto-emitting a Halo SimOp before each
+Conv / MaxPool / ConvTranspose SimOp so that profiler-vs-Polaris sequence matching
+finds a corresponding entry for every hardware halo row.
+"""
+
+import pytest
+import numpy as np
+
+import ttsim.front.ttnn as ttnn
+from ttsim.front.ttnn.device import ARCH, Device
+from ttsim.front.ttnn.tensor import DataType, Layout, Tensor
+from ttsim.front.ttnn.memory import MemoryConfig
+from ttsim.front.ttnn.buffer import TensorMemoryLayout, BufferType
+
+
+def _make_device():
+    device = Device(device_id=0)
+    device.architecture = ARCH.WORMHOLE_B0
+    return device
+
+
+def _make_tensor(name, shape, device):
+    return Tensor(
+        name=name,
+        shape=shape,
+        dtype=DataType.BFLOAT16,
+        layout=Layout.ROW_MAJOR_LAYOUT,
+        device=device,
+    )
+
+
+def _op_sequence(device):
+    """Return list of (optype, op) in insertion order."""
+    return [(op.optype, op) for op in device.ops.values()]
+
+
+# ---------------------------------------------------------------------------
+# conv2d: should emit Halo → Conv
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_conv2d_emits_halo_then_conv():
+    device = _make_device()
+    x = _make_tensor("x", [1, 3, 8, 8], device)
+    w = _make_tensor("w", [4, 3, 3, 3], device)
+    b = _make_tensor("b", [4], device)
+
+    out = ttnn.conv2d(
+        input_tensor=x,
+        weight_tensor=w,
+        bias_tensor=b,
+        in_channels=3,
+        out_channels=4,
+        batch_size=1,
+        input_height=8,
+        input_width=8,
+        kernel_size=(3, 3),
+        stride=(1, 1),
+        padding=(1, 1),
+        dilation=(1, 1),
+        groups=1,
+        device=device,
+    )
+
+    seq = _op_sequence(device)
+    assert len(seq) == 2, f"Expected 2 ops (Halo+Conv), got {[s[0] for s in seq]}"
+    assert seq[0][0] == "Halo"
+    assert seq[1][0] == "Conv"
+
+    # Halo output shape == input shape (passthrough)
+    halo_op = seq[0][1]
+    assert halo_op.inList == [x.name]
+    halo_out_name = halo_op.outList[0]
+
+    # Conv input is the halo output
+    conv_op = seq[1][1]
+    assert halo_out_name in conv_op.inList
+
+    # Final output shape correct
+    assert out.shape == [1, 4, 8, 8]
+
+
+@pytest.mark.unit
+def test_conv2d_halo_shape_passthrough():
+    device = _make_device()
+    shape = [1, 16, 32, 32]
+    x = _make_tensor("x", shape, device)
+    w = _make_tensor("w", [32, 16, 3, 3], device)
+    b = _make_tensor("b", [32], device)
+
+    ttnn.conv2d(
+        input_tensor=x, weight_tensor=w, bias_tensor=b,
+        in_channels=16, out_channels=32, batch_size=1,
+        input_height=32, input_width=32,
+        kernel_size=(3, 3), stride=(1, 1), padding=(1, 1),
+        dilation=(1, 1), groups=1, device=device,
+    )
+
+    halo_op = _op_sequence(device)[0][1]
+    # Halo perf_stats reflects input shape
+    assert halo_op.perf_stats["inElems"] == 1 * 16 * 32 * 32
+    assert halo_op.perf_stats["outElems"] == 1 * 16 * 32 * 32
+
+
+# ---------------------------------------------------------------------------
+# max_pool2d: should emit Halo → MaxPool
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_max_pool2d_emits_halo_then_pool():
+    device = _make_device()
+    x = _make_tensor("x", [1, 64, 16, 16], device)
+
+    ttnn.max_pool2d(
+        input_tensor=x,
+        batch_size=1,
+        input_h=16,
+        input_w=16,
+        channels=64,
+        kernel_size=[2, 2],
+        stride=[2, 2],
+        padding=[0, 0],
+        dilation=[1, 1],
+    )
+
+    seq = _op_sequence(device)
+    assert len(seq) == 2, f"Expected 2 ops (Halo+MaxPool), got {[s[0] for s in seq]}"
+    assert seq[0][0] == "Halo"
+    assert seq[1][0] == "MaxPool"
+
+    halo_out_name = seq[0][1].outList[0]
+    assert halo_out_name in seq[1][1].inList
+
+
+# ---------------------------------------------------------------------------
+# conv_transpose2d: should emit Halo → ConvTranspose
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_conv_transpose2d_emits_halo_then_convtranspose():
+    device = _make_device()
+    x = _make_tensor("x", [1, 16, 8, 8], device)
+    w = _make_tensor("w", [16, 8, 2, 2], device)
+    b = _make_tensor("b", [8], device)
+
+    ttnn.conv_transpose2d(
+        input_tensor=x,
+        weight_tensor=w,
+        bias_tensor=b,
+        in_channels=16,
+        out_channels=8,
+        batch_size=1,
+        input_height=8,
+        input_width=8,
+        kernel_size=(2, 2),
+        stride=(2, 2),
+        padding=(0, 0),
+        dilation=(1, 1),
+        groups=1,
+        device=device,
+        output_padding=(0, 0),
+    )
+
+    seq = _op_sequence(device)
+    assert len(seq) == 2, f"Expected 2 ops (Halo+ConvTranspose), got {[s[0] for s in seq]}"
+    assert seq[0][0] == "Halo"
+    assert seq[1][0] == "ConvTranspose"
+
+    halo_out_name = seq[0][1].outList[0]
+    assert halo_out_name in seq[1][1].inList
+
+
+# ---------------------------------------------------------------------------
+# Multiple ops on same device: each call adds its own Halo
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_multiple_conv2d_each_get_own_halo():
+    device = _make_device()
+
+    for i in range(3):
+        x = _make_tensor(f"x{i}", [1, 8, 4, 4], device)
+        w = _make_tensor(f"w{i}", [8, 8, 3, 3], device)
+        b = _make_tensor(f"b{i}", [8], device)
+        ttnn.conv2d(
+            input_tensor=x, weight_tensor=w, bias_tensor=b,
+            in_channels=8, out_channels=8, batch_size=1,
+            input_height=4, input_width=4,
+            kernel_size=(3, 3), stride=(1, 1), padding=(1, 1),
+            dilation=(1, 1), groups=1, device=device,
+        )
+
+    seq = _op_sequence(device)
+    halo_count = sum(1 for optype, _ in seq if optype == "Halo")
+    conv_count = sum(1 for optype, _ in seq if optype == "Conv")
+    assert halo_count == 3
+    assert conv_count == 3
+    # Order: Halo, Conv, Halo, Conv, Halo, Conv
+    for i in range(3):
+        assert seq[i * 2][0] == "Halo"
+        assert seq[i * 2 + 1][0] == "Conv"
+
+
+# ---------------------------------------------------------------------------
+# 1×1 conv: hardware uses matmul, so no Halo should be emitted
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_conv2d_1x1_no_halo():
+    device = _make_device()
+    x = _make_tensor("x", [1, 64, 256, 256], device)
+    w = _make_tensor("w", [1, 64, 1, 1], device)
+    b = _make_tensor("b", [1], device)
+
+    ttnn.conv2d(
+        input_tensor=x, weight_tensor=w, bias_tensor=b,
+        in_channels=64, out_channels=1, batch_size=1,
+        input_height=256, input_width=256,
+        kernel_size=(1, 1), stride=(1, 1), padding=(0, 0),
+        dilation=(1, 1), groups=1, device=device,
+    )
+
+    seq = _op_sequence(device)
+    assert len(seq) == 1, f"Expected 1 op (MatMul only, no Halo for 1×1), got {[s[0] for s in seq]}"
+    assert seq[0][0] == "MatMul"
+
+
+@pytest.mark.unit
+def test_conv2d_1x1_matmul_shape_passthrough():
+    """1×1 conv emits MatMul with correct NCHW output shape [N, C_out, H, W]."""
+    device = _make_device()
+    x = _make_tensor('x', [1, 64, 32, 32], device)
+    w = _make_tensor('w', [128, 64, 1, 1], device)
+    b = _make_tensor('b', [128], device)
+
+    out = ttnn.conv2d(
+        input_tensor=x, weight_tensor=w, bias_tensor=b,
+        in_channels=64, out_channels=128, batch_size=1,
+        input_height=32, input_width=32,
+        kernel_size=(1, 1), stride=(1, 1), padding=(0, 0),
+        dilation=(1, 1), groups=1, device=device,
+    )
+
+    seq = _op_sequence(device)
+    assert seq[0][0] == 'MatMul'
+    assert list(out.shape) == [1, 128, 32, 32]
+
+
+@pytest.mark.unit
+def test_conv2d_1x1_stride2_matmul_shape():
+    """1×1 conv with stride=2 emits MatMul with halved spatial dims."""
+    device = _make_device()
+    x = _make_tensor('x', [1, 64, 32, 32], device)
+    w = _make_tensor('w', [128, 64, 1, 1], device)
+    b = _make_tensor('b', [128], device)
+
+    out = ttnn.conv2d(
+        input_tensor=x, weight_tensor=w, bias_tensor=b,
+        in_channels=64, out_channels=128, batch_size=1,
+        input_height=32, input_width=32,
+        kernel_size=(1, 1), stride=(2, 2), padding=(0, 0),
+        dilation=(1, 1), groups=1, device=device,
+    )
+
+    assert list(out.shape) == [1, 128, 16, 16]
+
+
+# ---------------------------------------------------------------------------
+# InterleavedToSharded auto-emission: interleaved input → ITS → Halo → Conv
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_conv2d_interleaved_input_emits_its_then_halo():
+    device = _make_device()
+    x = _make_tensor("x", [1, 64, 16, 16], device)
+    x._memory_config = MemoryConfig(TensorMemoryLayout.INTERLEAVED, BufferType.L1)
+    w = _make_tensor("w", [128, 64, 3, 3], device)
+    b = _make_tensor("b", [128], device)
+
+    ttnn.conv2d(
+        input_tensor=x, weight_tensor=w, bias_tensor=b,
+        in_channels=64, out_channels=128, batch_size=1,
+        input_height=16, input_width=16,
+        kernel_size=(3, 3), stride=(1, 1), padding=(1, 1),
+        dilation=(1, 1), groups=1, device=device,
+    )
+
+    seq = _op_sequence(device)
+    assert len(seq) == 3, f"Expected ITS+Halo+Conv, got {[s[0] for s in seq]}"
+    assert seq[0][0] == "InterleavedToSharded"
+    assert seq[1][0] == "Halo"
+    assert seq[2][0] == "Conv"
+
+    its_out_name = seq[0][1].outList[0]
+    assert its_out_name in seq[1][1].inList
+
+
+@pytest.mark.unit
+def test_conv2d_sharded_input_no_its():
+    """Sharded input should only emit Halo → Conv, no ITS."""
+    device = _make_device()
+    x = _make_tensor("x", [1, 64, 16, 16], device)
+    x._memory_config = MemoryConfig(TensorMemoryLayout.HEIGHT_SHARDED, BufferType.L1)
+    w = _make_tensor("w", [128, 64, 3, 3], device)
+    b = _make_tensor("b", [128], device)
+
+    ttnn.conv2d(
+        input_tensor=x, weight_tensor=w, bias_tensor=b,
+        in_channels=64, out_channels=128, batch_size=1,
+        input_height=16, input_width=16,
+        kernel_size=(3, 3), stride=(1, 1), padding=(1, 1),
+        dilation=(1, 1), groups=1, device=device,
+    )
+
+    seq = _op_sequence(device)
+    assert len(seq) == 2, f"Expected Halo+Conv only (sharded input), got {[s[0] for s in seq]}"
+    assert seq[0][0] == "Halo"
+    assert seq[1][0] == "Conv"
+
+
+@pytest.mark.unit
+def test_conv2d_no_memory_config_no_its():
+    """Tensor with no _memory_config should only emit Halo → Conv."""
+    device = _make_device()
+    x = _make_tensor("x", [1, 64, 16, 16], device)
+    # no _memory_config set
+    w = _make_tensor("w", [128, 64, 3, 3], device)
+    b = _make_tensor("b", [128], device)
+
+    ttnn.conv2d(
+        input_tensor=x, weight_tensor=w, bias_tensor=b,
+        in_channels=64, out_channels=128, batch_size=1,
+        input_height=16, input_width=16,
+        kernel_size=(3, 3), stride=(1, 1), padding=(1, 1),
+        dilation=(1, 1), groups=1, device=device,
+    )
+
+    seq = _op_sequence(device)
+    assert len(seq) == 2, f"Expected Halo+Conv only (no _mc), got {[s[0] for s in seq]}"
+    assert seq[0][0] == "Halo"
+    assert seq[1][0] == "Conv"
+
+
+# ---------------------------------------------------------------------------
+# Move auto-emission: requires deallocate_activation=True AND L1-sharded input
+# ---------------------------------------------------------------------------
+
+def _make_l1_sharded_tensor(name, shape, device, layout=TensorMemoryLayout.HEIGHT_SHARDED):
+    """Helper: tensor with L1 sharded _memory_config so _with_move fires."""
+    t = _make_tensor(name, shape, device)
+    t._memory_config = MemoryConfig(layout, BufferType.L1)
+    return t
+
+
+@pytest.mark.unit
+def test_conv2d_deallocate_l1sharded_emits_move():
+    """deallocate_activation=True + L1-sharded input → Halo+Move+Conv (hardware order)."""
+    device = _make_device()
+    x = _make_l1_sharded_tensor('x', [1, 8, 4, 4], device)
+    w = _make_tensor('w', [8, 8, 3, 3], device)
+    b = _make_tensor('b', [8], device)
+
+    out = ttnn.conv2d(
+        input_tensor=x, weight_tensor=w, bias_tensor=b,
+        in_channels=8, out_channels=8, batch_size=1,
+        input_height=4, input_width=4,
+        kernel_size=(3, 3), stride=(1, 1), padding=(1, 1),
+        dilation=(1, 1), groups=1, device=device,
+        deallocate_activation=True,
+    )
+
+    seq = _op_sequence(device)
+    assert len(seq) == 3, f'Expected Halo+Move+Conv, got {[s[0] for s in seq]}'
+    assert seq[0][0] == 'Halo'
+    assert seq[1][0] == 'Move'
+    assert seq[2][0] == 'Conv'
+    halo_out_name = seq[0][1].outList[0]
+    assert halo_out_name in seq[1][1].inList
+    move_out_name = seq[1][1].outList[0]
+    assert move_out_name in seq[2][1].inList
+    assert out.name == seq[2][1].outList[0]
+
+
+@pytest.mark.unit
+def test_conv2d_deallocate_no_memory_config_no_move():
+    """deallocate_activation=True but no _memory_config → no Move (DRAM default)."""
+    device = _make_device()
+    x = _make_tensor('x', [1, 8, 4, 4], device)   # no _memory_config set
+    w = _make_tensor('w', [8, 8, 3, 3], device)
+    b = _make_tensor('b', [8], device)
+
+    ttnn.conv2d(
+        input_tensor=x, weight_tensor=w, bias_tensor=b,
+        in_channels=8, out_channels=8, batch_size=1,
+        input_height=4, input_width=4,
+        kernel_size=(3, 3), stride=(1, 1), padding=(1, 1),
+        dilation=(1, 1), groups=1, device=device,
+        deallocate_activation=True,
+    )
+
+    seq = _op_sequence(device)
+    assert len(seq) == 2, f'Expected Halo+Conv only (no mc), got {[s[0] for s in seq]}'
+    assert seq[0][0] == 'Halo'
+    assert seq[1][0] == 'Conv'
+
+
+@pytest.mark.unit
+def test_conv2d_deallocate_interleaved_l1_emits_move_after_its():
+    """deallocate_activation=True with interleaved L1 input → auto-ITS converts
+    to L1-sharded, then Move fires (mirroring tt-metal where decoder convs with
+    do_sharded_to_interleaved=True still emit Move post-halo)."""
+    device = _make_device()
+    x = _make_tensor('x', [1, 8, 4, 4], device)
+    x._memory_config = MemoryConfig(TensorMemoryLayout.INTERLEAVED, BufferType.L1)
+    w = _make_tensor('w', [8, 8, 3, 3], device)
+    b = _make_tensor('b', [8], device)
+
+    ttnn.conv2d(
+        input_tensor=x, weight_tensor=w, bias_tensor=b,
+        in_channels=8, out_channels=8, batch_size=1,
+        input_height=4, input_width=4,
+        kernel_size=(3, 3), stride=(1, 1), padding=(1, 1),
+        dilation=(1, 1), groups=1, device=device,
+        deallocate_activation=True,
+    )
+
+    seq = _op_sequence(device)
+    optypes = [s[0] for s in seq]
+    # Sequence should be ITS → Halo → Move → Conv
+    assert optypes == ['InterleavedToSharded', 'Halo', 'Move', 'Conv'], optypes
+
+
+@pytest.mark.unit
+def test_conv2d_no_deallocate_no_move():
+    """deallocate_activation=False → no Move regardless of memory config."""
+    device = _make_device()
+    x = _make_l1_sharded_tensor('x', [1, 8, 4, 4], device)
+    w = _make_tensor('w', [8, 8, 3, 3], device)
+    b = _make_tensor('b', [8], device)
+
+    ttnn.conv2d(
+        input_tensor=x, weight_tensor=w, bias_tensor=b,
+        in_channels=8, out_channels=8, batch_size=1,
+        input_height=4, input_width=4,
+        kernel_size=(3, 3), stride=(1, 1), padding=(1, 1),
+        dilation=(1, 1), groups=1, device=device,
+        deallocate_activation=False,
+    )
+
+    seq = _op_sequence(device)
+    assert all(s[0] != 'Move' for s in seq), f'Unexpected Move with deallocate=False: {[s[0] for s in seq]}'
+
+
+@pytest.mark.unit
+def test_conv2d_move_shape_passthrough():
+    """Move output shape must equal Conv output shape."""
+    device = _make_device()
+    x = _make_l1_sharded_tensor('x', [1, 8, 8, 8], device)
+    w = _make_tensor('w', [16, 8, 3, 3], device)
+    b = _make_tensor('b', [16], device)
+
+    out = ttnn.conv2d(
+        input_tensor=x, weight_tensor=w, bias_tensor=b,
+        in_channels=8, out_channels=16, batch_size=1,
+        input_height=8, input_width=8,
+        kernel_size=(3, 3), stride=(1, 1), padding=(1, 1),
+        dilation=(1, 1), groups=1, device=device,
+        deallocate_activation=True,
+    )
+
+    assert out.shape == [1, 16, 8, 8]
+
+
+@pytest.mark.unit
+def test_conv2d_1x1_deallocate_l1sharded_no_halo_no_move():
+    """1×1 conv → MatMul only (no Halo, no trailing Move).
+
+    HW's 1×1-conv → MatMul path does not emit MoveDeviceOperation regardless of
+    ``deallocate_activation`` (the HW profiler shows no Move row at the 1×1 conv
+    output shape), so the shim drops the trailing Move emission.
+    """
+    device = _make_device()
+    x = _make_l1_sharded_tensor('x', [1, 64, 16, 16], device)
+    w = _make_tensor('w', [32, 64, 1, 1], device)
+    b = _make_tensor('b', [32], device)
+
+    ttnn.conv2d(
+        input_tensor=x, weight_tensor=w, bias_tensor=b,
+        in_channels=64, out_channels=32, batch_size=1,
+        input_height=16, input_width=16,
+        kernel_size=(1, 1), stride=(1, 1), padding=(0, 0),
+        dilation=(1, 1), groups=1, device=device,
+        deallocate_activation=True,
+    )
+
+    seq = _op_sequence(device)
+    optypes = [s[0] for s in seq]
+    assert optypes == ['MatMul'], f'Expected MatMul only (no Halo, no Move for 1×1), got {optypes}'
+
+
+@pytest.mark.unit
+def test_conv2d_block_sharded_deallocate_emits_move():
+    """BLOCK_SHARDED L1 input with deallocate=True also triggers Move."""
+    device = _make_device()
+    x = _make_l1_sharded_tensor('x', [1, 16, 8, 8], device, TensorMemoryLayout.BLOCK_SHARDED)
+    w = _make_tensor('w', [16, 16, 3, 3], device)
+    b = _make_tensor('b', [16], device)
+
+    ttnn.conv2d(
+        input_tensor=x, weight_tensor=w, bias_tensor=b,
+        in_channels=16, out_channels=16, batch_size=1,
+        input_height=8, input_width=8,
+        kernel_size=(3, 3), stride=(1, 1), padding=(1, 1),
+        dilation=(1, 1), groups=1, device=device,
+        deallocate_activation=True,
+    )
+
+    seq = _op_sequence(device)
+    optypes = [s[0] for s in seq]
+    assert 'Move' in optypes, f'Expected Move in sequence, got {optypes}'
+    move_idx = optypes.index('Move')
+    assert move_idx < optypes.index('Conv'), f'Expected Move before Conv, got {optypes}'
+
+
+# ---------------------------------------------------------------------------
+# to_memory_config: sharded→different-sharded emits STI+ITS
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_to_memory_config_sharded_to_different_sharded_emits_sti_its():
+    device = _make_device()
+    x = _make_tensor("x", [1, 64, 32, 32], device)
+    x._memory_config = MemoryConfig(TensorMemoryLayout.BLOCK_SHARDED, BufferType.L1)
+
+    target_mc = MemoryConfig(TensorMemoryLayout.HEIGHT_SHARDED, BufferType.L1)
+    ttnn.to_memory_config(x, target_mc)
+
+    seq = _op_sequence(device)
+    assert len(seq) == 2, f"Expected STI+ITS, got {[s[0] for s in seq]}"
+    assert seq[0][0] == "ShardedToInterleaved"
+    assert seq[1][0] == "InterleavedToSharded"
+
+
+@pytest.mark.unit
+def test_to_memory_config_same_sharded_no_ops():
+    """Same sharded config → no STI+ITS emitted."""
+    device = _make_device()
+    x = _make_tensor("x", [1, 64, 32, 32], device)
+    mc = MemoryConfig(TensorMemoryLayout.HEIGHT_SHARDED, BufferType.L1)
+    x._memory_config = mc
+
+    ttnn.to_memory_config(x, mc)
+
+    seq = _op_sequence(device)
+    assert len(seq) == 0, f"Expected no ops for same config, got {[s[0] for s in seq]}"
+
+
+@pytest.mark.unit
+def test_to_memory_config_interleaved_to_sharded_no_sti():
+    """Interleaved→sharded via to_memory_config: no STI (only ITS would come later via _with_halo)."""
+    device = _make_device()
+    x = _make_tensor("x", [1, 64, 32, 32], device)
+    x._memory_config = MemoryConfig(TensorMemoryLayout.INTERLEAVED, BufferType.L1)
+
+    target_mc = MemoryConfig(TensorMemoryLayout.HEIGHT_SHARDED, BufferType.L1)
+    ttnn.to_memory_config(x, target_mc)
+
+    seq = _op_sequence(device)
+    assert len(seq) == 0, f"Expected no ops (interleaved→sharded not a reshard), got {[s[0] for s in seq]}"

--- a/tools/perf_lookup/lookup_operator_perf.py
+++ b/tools/perf_lookup/lookup_operator_perf.py
@@ -82,6 +82,35 @@ _DEFAULT_CORE_COUNT_FALLBACK = 64
 # ``reshape``: second input is often a small shape/constant tensor, not profiled as input_1.
 _BINARY_LUT_FALLBACK_TO_INPUT0_KEY_OPCODES = frozenset({"mul", "reshape"})
 
+# Hardware ops that are arity-1 in Polaris but arity-2 in profiler output (src + dst with
+# same shape/layout/memory).  After an arity-1 (9-tuple) miss, try a 16-tuple with t0 used
+# for both input_0 and input_1 positions.
+_UNARY_POLARIS_BINARY_HW_OPCODES = frozenset({"move"})
+
+# InterleavedToSharded: hardware records ITS from DRAM in most VGG UNet decoder stages
+# (ShardedToInterleaved output lands in DRAM on device), but Polaris models the STI output
+# as L1_INTERLEAVED (per model code using ttnn.L1_MEMORY_CONFIG).  After an L1_INTERLEAVED
+# arity-1 miss, try DRAM_INTERLEAVED — same shape/layout, just different input staging.
+_ITS_MEM_FALLBACK_OPCODES = frozenset({"interleavedtosharded"})
+_L1_INTERLEAVED_STR = "DEV_1_L1_INTERLEAVED"
+_DRAM_INTERLEAVED_STR = "DEV_1_DRAM_INTERLEAVED"
+
+# Halo and element-wise ops (Sigmoid): the LUT was built with TILE layout while Polaris models
+# VGG UNet tensors as ROW_MAJOR throughout.  After a ROW_MAJOR arity-1 miss, retry with TILE
+# — position 5 of the 9-tuple.  Timing should be layout-insensitive for these data-movement /
+# element-wise ops.
+_LAYOUT_ROWMAJOR_TO_TILE_FALLBACK_OPCODES = frozenset({"halo", "sigmoid"})
+_ROW_MAJOR_STR = "ROW_MAJOR"
+_TILE_STR = "TILE"
+
+# VGG UNet decoder: Polaris propagates HEIGHT_SHARDED through the post-concat ITS path, but
+# the LUT records those ops as BLOCK_SHARDED (hardware auto-selects BLOCK for smaller tensors).
+# Applies to arity-1 (halo, move) and arity-3 (conv2d, convtranspose) ops — position 7 of the
+# lookup key is input_0_memory in both 9-tuple and 23-tuple formats.
+_HALO_HEIGHT_TO_BLOCK_FALLBACK_OPCODES = frozenset({"halo", "move", "conv2d", "convtranspose"})
+_HEIGHT_SHARDED_STR = "DEV_1_L1_HEIGHT_SHARDED"
+_BLOCK_SHARDED_STR = "DEV_1_L1_BLOCK_SHARDED"
+
 # Percentages 0–100 inclusive in master YAML / curve-evaluated stats (not 0–1 fractions).
 LUT_OPTIONAL_UTIL_PERCENT_KEYS = frozenset(
     {"mem_util", "noc_util", "noc_multicast_util", "npe_cong_impact_pct"}
@@ -101,14 +130,24 @@ def _raise_lut_validation(lut_path: Path, key_t: tuple, detail: str) -> None:
 def _validate_required_util_percent(
     name: str, raw: Any, lut_path: Path, key_t: tuple
 ) -> float:
-    """Require a finite percentage in [0, 100]. ``raw`` is the resolved scalar from the LUT row."""
+    """Require a finite, non-negative percentage. ``raw`` is the resolved scalar from the LUT row.
+
+    Values above 100 are accepted with a single one-time warning per field name —
+    TT-Metal records multicast/overcount cases where DRAM BW UTIL etc. can exceed
+    100% legitimately.
+
+    TODO(util-over-100): mirrors the placeholder in
+    ``tools/profiling/ops_perf_three_csv_merge.py::validate_utilization_cells``.
+    When the merge step is updated to clip / fix-at-source, this loader-side
+    relaxation should be tightened back to a hard error.
+    """
     if raw is None:
         _raise_lut_validation(
             lut_path,
             key_t,
             f"required field {name!r} is missing or null; when a LUT row matches, "
             "matrix_pipe_util and vector_pipe_util must both be provided "
-            "(percentages 0–100 inclusive; 0 is allowed).",
+            "(percentages >= 0; 0 is allowed).",
         )
     if isinstance(raw, bool):
         _raise_lut_validation(
@@ -123,12 +162,14 @@ def _validate_required_util_percent(
     v = float(raw)
     if not math.isfinite(v):
         _raise_lut_validation(lut_path, key_t, f"field {name!r} must be finite, got {raw!r}")
-    if v < 0.0 or v > 100.0:
+    if v < 0.0:
         _raise_lut_validation(
             lut_path,
             key_t,
-            f"field {name!r} must be a percentage in [0, 100] inclusive, got {v!r}",
+            f"field {name!r} must be non-negative, got {v!r}",
         )
+    if v > 100.0:
+        _warn_util_over_100_once(name, v, lut_path)
     return v
 
 
@@ -153,21 +194,52 @@ def _validate_optional_util_percent(
         _raise_lut_validation(
             lut_path, key_t, f"field {name!r} must be finite when present, got {raw!r}"
         )
-    if v < 0.0 or v > 100.0:
+    if v < 0.0:
         _raise_lut_validation(
             lut_path,
             key_t,
-            f"field {name!r} must be a percentage in [0, 100] inclusive when present, got {v!r}",
+            f"field {name!r} must be non-negative when present, got {v!r}",
         )
+    if v > 100.0:
+        _warn_util_over_100_once(name, v, lut_path)
     return v
+
+
+# One-shot warning bookkeeping: keep the log quiet when many rows of the same
+# field exceed 100 (common for DRAM BW UTIL on multicast-heavy ops).
+_OVER_100_WARNED: set[str] = set()
+
+
+def _warn_util_over_100_once(name: str, v: float, lut_path: Path) -> None:
+    if name in _OVER_100_WARNED:
+        return
+    _OVER_100_WARNED.add(name)
+    logger.warning(
+        "LUT field {!r} value {} >100 in {} (TT-Metal multicast/overcount; "
+        "warning shown once per field — subsequent occurrences silent)",
+        name, v, lut_path,
+    )
 
 
 @dataclass(frozen=True)
 class MasterPerfStats:
     """Resolved profiler row for one op (after single/curve/hybrid evaluation).
 
-    ``matrix_pipe_util`` and ``vector_pipe_util`` are percentages in **[0, 100]** (not fractions).
-    ``Device.get_exec_stats`` divides by 100 for exec_stats / CSV. Optional ``mem_util`` is the same.
+    ``matrix_pipe_util`` and ``vector_pipe_util`` are percentages, typically in
+    **[0, 100]** (not fractions). Values >100 are accepted with a one-time warning
+    per field — TT-Metal multicast/overcount can legitimately exceed 100% (see
+    ``_warn_util_over_100_once`` above). Downstream consumers must not assume a
+    hard 100% cap. ``Device.get_exec_stats`` divides by 100 for exec_stats / CSV.
+    Optional ``mem_util`` is the same.
+
+    ``key_literal`` is the tuple originally built from the workload op + its tensor state
+    (the *would-have-been* key before any fallback substitution).  ``key_resolved`` is the
+    tuple the lookup actually matched in the LUT — i.e. the literal key after any
+    HEIGHT→BLOCK, L1→DRAM, ROW_MAJOR→TILE, or arity-1→arity-2 fallback chain in
+    ``OperatorPerfMap.lookup``.  Downstream tooling (compare_layers ``--by-lut-key``)
+    uses ``key_resolved`` so polaris and profiler ops that semantically share a LUT
+    entry group together regardless of the literal-shape divergence the runtime
+    fallback chain papers over.
     """
 
     msecs: float
@@ -175,6 +247,23 @@ class MasterPerfStats:
     vector_pipe_util: float
     memory_traffic: Optional[float] = None
     mem_util: Optional[float] = None
+    key_literal: Optional[tuple] = None
+    key_resolved: Optional[tuple] = None
+    # Diagnostic label for which lookup path produced the hit. One of:
+    #   "direct"                   — literal key matched on the first lookup
+    #   "add_broadcast_dup"        — add op: broadcast operand duplicated to full shape
+    #   "move_arity_dup"           — Move/STS/ITS/Reshard: arity-1 → arity-2 duplicate
+    #   "move_arity_dup_tile"      — above + ROW_MAJOR→TILE substitution
+    #   "move_arity_dup_block"     — above + HEIGHT→BLOCK substitution
+    #   "its_l1_to_dram"           — ITS: input_0_memory L1_INTERLEAVED → DRAM_INTERLEAVED
+    #   "halo_rowmajor_to_tile"    — Halo/Sigmoid: input_0_layout ROW_MAJOR → TILE
+    #   "halo_height_to_block"     — Halo/Conv/ConvTranspose: input_0_memory HEIGHT → BLOCK
+    #   "halo_tile_block_combined" — above + ROW_MAJOR→TILE simultaneously
+    #   "binary_to_unary"          — mul/reshape: drop input_1 from 15-tuple to 9-tuple
+    # When the literal key matched directly the value is "direct"; when ``lookup``
+    # returns None entirely (analytical fallback in the caller), no MasterPerfStats
+    # is produced, so device.py emits "analytical" in the CSV based on the absence.
+    hit_source: Optional[str] = None
 
 
 def _eval_curve_value(family: str, a: float, b: float, core_count: int) -> float:
@@ -564,8 +653,7 @@ def _wzyx_int_tuple(t4: tuple) -> tuple:
 def _lut_keys_matching_op_and_wzyx(entries: Dict[tuple, dict], key_t: tuple) -> Tuple[tuple, ...]:
     """
     LUT keys with same ``op_code`` and WZYX as ``key_t``
-    (input 0 for 9/10/15-tuple and halo 16-tuple; inputs 0 and 1 for binary 16-tuple;
-    inputs 0, 1, and 2 for 23-tuple).
+    (input 0 for 9/10/15-tuple; inputs 0 and 1 for 16-tuple; inputs 0, 1, and 2 for 23-tuple).
 
     Layout, datatype, and memory may differ — useful diagnostics when the full key misses.
     """
@@ -574,8 +662,10 @@ def _lut_keys_matching_op_and_wzyx(entries: Dict[tuple, dict], key_t: tuple) -> 
         return ()
     oc = key_t[0]
     matched: list[tuple] = []
-    if n in (9, 10, 15) or (n == 16 and oc == 'halo'):
-        # Halo v4 16-tuple has one input slot at [1:5]; positions [9:] are geometry+is_transpose.
+    if n in (9, 10, 15) or (n == 16 and oc == "halo"):
+        # Unary ops (9/10-tuple), Halo v3 (15-tuple), and Halo v4 (16-tuple).
+        # Halo v4's positions 9:13 carry kernel/stride geometry fields (not a
+        # second input's WZYX), so we match only on input_0 WZYX here.
         w0 = _wzyx_int_tuple(key_t[1:5])
         for k in entries:
             if len(k) != n or k[0] != oc:
@@ -583,6 +673,7 @@ def _lut_keys_matching_op_and_wzyx(entries: Dict[tuple, dict], key_t: tuple) -> 
             if _wzyx_int_tuple(k[1:5]) == w0:
                 matched.append(k)
     elif n == 16:
+        # Non-halo 16-tuple key (binary op) — positions 9:13 are input_1 WZYX.
         w0 = _wzyx_int_tuple(key_t[1:5])
         w1 = _wzyx_int_tuple(key_t[9:13])
         for k in entries:
@@ -698,7 +789,14 @@ class OperatorPerfMap:
     def __len__(self) -> int:
         return len(self._entries)
 
-    def _stats_from_entry(self, key_t: tuple, entry_val: dict, core_count: int) -> Optional[MasterPerfStats]:
+    def _stats_from_entry(
+        self,
+        key_t: tuple,
+        entry_val: dict,
+        core_count: int,
+        key_literal: Optional[tuple] = None,
+        hit_source: Optional[str] = None,
+    ) -> Optional[MasterPerfStats]:
         et = entry_val.get(MASTER_ENTRY_TYPE_KEY)
         if not isinstance(et, str):
             return None
@@ -747,18 +845,22 @@ class OperatorPerfMap:
             vector_pipe_util=vector_pipe_util,
             memory_traffic=resolve("memory_traffic"),
             mem_util=mem_util,
+            key_literal=key_literal if key_literal is not None else key_t,
+            key_resolved=key_t,
+            hit_source=hit_source,
         )
 
-    def lookup(
+    def _build_literal_key_with_tensors(
         self,
         op: Any,
         wlgraph: Any,
-        core_count: int,
-    ) -> Optional[MasterPerfStats]:
-        """
-        Return resolved stats when the table has a matching 9-, 16-, or 23-tuple key, else ``None``.
+    ) -> Optional[Tuple[tuple, Tuple[Any, ...]]]:
+        """Build the literal LUT key tuple and capture the input tensors used.
 
-        ``core_count`` should match profiler Core_Count bucketing (see package config).
+        Returns ``(key_t, (t0,) | (t0, t1) | (t0, t1, t2))`` on success, ``None`` on
+        any of: unsupported arity, missing tensor, missing shape, key-build failure.
+        Internal helper; ``lookup`` uses this then proceeds with entry matching, while
+        ``build_literal_key`` exposes just the key half publicly.
         """
         in_list = getattr(op, "inList", [])
         n_in = len(in_list)
@@ -773,7 +875,6 @@ class OperatorPerfMap:
             )
             return None
 
-        t0 = t1 = t2 = None
         if n_in == 1:
             t0_name = in_list[0]
             if t0_name not in tensors:
@@ -792,8 +893,8 @@ class OperatorPerfMap:
                             getattr(op, "name", "?"),
                         )
                         return None
-                    key_t = halo_key
-                elif op_code_norm == "interleavedtosharded":
+                    return halo_key, (t0,)
+                if op_code_norm == "interleavedtosharded":
                     out_list = getattr(op, "outList", [])
                     t_out = tensors.get(out_list[0]) if out_list else None
                     if t_out is None or getattr(t_out, "shape", None) is None:
@@ -803,13 +904,12 @@ class OperatorPerfMap:
                             getattr(op, "name", "?"),
                         )
                         return None
-                    key_t = build_master_key_tuple_its(op, t0, t_out)
-                else:
-                    key_t = build_master_key_tuple_8(op, t0)
+                    return build_master_key_tuple_its(op, t0, t_out), (t0,)
+                return build_master_key_tuple_8(op, t0), (t0,)
             except Exception as e:
                 logger.debug("Perf lookup key build failed for op {}: {}", getattr(op, "name", "?"), e)
                 return None
-        elif n_in == 2:
+        if n_in == 2:
             t0_name, t1_name = in_list[0], in_list[1]
             if t0_name not in tensors or t1_name not in tensors:
                 return None
@@ -817,25 +917,54 @@ class OperatorPerfMap:
             if t0.shape is None or t1.shape is None:
                 return None
             try:
-                key_t = build_master_key_tuple_15(op, t0, t1)
+                return build_master_key_tuple_15(op, t0, t1), (t0, t1)
             except Exception as e:
                 logger.debug("Perf lookup key build failed for op {}: {}", getattr(op, "name", "?"), e)
                 return None
-        else:
-            t0_name, t1_name, t2_name = in_list[0], in_list[1], in_list[2]
-            if t0_name not in tensors or t1_name not in tensors or t2_name not in tensors:
-                return None
-            t0, t1, t2 = tensors[t0_name], tensors[t1_name], tensors[t2_name]
-            if t0.shape is None or t1.shape is None or t2.shape is None:
-                return None
-            try:
-                key_t = build_master_key_tuple_22(op, t0, t1, t2)
-            except Exception as e:
-                logger.debug("Perf lookup key build failed for op {}: {}", getattr(op, "name", "?"), e)
-                return None
+        t0_name, t1_name, t2_name = in_list[0], in_list[1], in_list[2]
+        if t0_name not in tensors or t1_name not in tensors or t2_name not in tensors:
+            return None
+        t0, t1, t2 = tensors[t0_name], tensors[t1_name], tensors[t2_name]
+        if t0.shape is None or t1.shape is None or t2.shape is None:
+            return None
+        try:
+            return build_master_key_tuple_22(op, t0, t1, t2), (t0, t1, t2)
+        except Exception as e:
+            logger.debug("Perf lookup key build failed for op {}: {}", getattr(op, "name", "?"), e)
+            return None
+
+    def build_literal_key(self, op: Any, wlgraph: Any) -> Optional[tuple]:
+        """Public: return the literal LUT key tuple for ``op`` (pre-fallback), or ``None``.
+
+        Same as the key ``lookup`` builds internally — exposed so callers (e.g. device.py's
+        per-op stats writer) can emit ``lut_key`` even when the entry lookup misses.
+        """
+        built = self._build_literal_key_with_tensors(op, wlgraph)
+        return built[0] if built is not None else None
+
+    def lookup(
+        self,
+        op: Any,
+        wlgraph: Any,
+        core_count: int,
+    ) -> Optional[MasterPerfStats]:
+        """
+        Return resolved stats when the table has a matching 9-, 16-, or 23-tuple key, else ``None``.
+
+        ``core_count`` should match profiler Core_Count bucketing (see package config).
+        """
+        built = self._build_literal_key_with_tensors(op, wlgraph)
+        if built is None:
+            return None
+        key_t, ts = built
+        n_in = len(ts)
+        t0 = ts[0]
+        t1 = ts[1] if n_in >= 2 else None
+        t2 = ts[2] if n_in >= 3 else None
 
         entry_val = self._entries.get(key_t)
         lookup_key = key_t
+        hit_source: Optional[str] = "direct" if entry_val is not None else None
 
         if entry_val is None and n_in == 2 and _op_code(op) == "add":
             try:
@@ -852,6 +981,7 @@ class OperatorPerfMap:
                 if ev_add is not None:
                     entry_val = ev_add
                     lookup_key = key_add_bc
+                    hit_source = "add_broadcast_dup"
                     logger.debug(
                         "Perf lookup: 15-tuple miss for add op={!r}; using broadcast-duplicated "
                         "LUT key {} (lut={})",
@@ -859,6 +989,97 @@ class OperatorPerfMap:
                         key_add_bc,
                         self._source_path,
                     )
+
+        # Move: arity-1 in Polaris, arity-2 in hardware profiler (src + dst same tensor).
+        # After 9-tuple miss, try 16-tuple with t0 duplicated for both positions.
+        if entry_val is None and n_in == 1 and _op_code(op) in _UNARY_POLARIS_BINARY_HW_OPCODES:
+            try:
+                key16 = build_master_key_tuple_15(op, t0, t0)
+            except Exception as e:
+                logger.debug('Perf lookup move dup-key build failed for op {}: {}', getattr(op, 'name', '?'), e)
+                key16 = None
+            if key16 is not None:
+                ev16 = self._entries.get(key16)
+                if ev16 is not None:
+                    entry_val = ev16
+                    lookup_key = key16
+                    hit_source = "move_arity_dup"
+                elif len(key16) >= 16 and key16[5] == _ROW_MAJOR_STR:
+                    # Also try TILE layout for both input_0 (pos 5) and input_1 (pos 13).
+                    key16_tile = key16[:5] + (_TILE_STR,) + key16[6:13] + (_TILE_STR,) + key16[14:]
+                    ev16_tile = self._entries.get(key16_tile)
+                    if ev16_tile is not None:
+                        entry_val = ev16_tile
+                        lookup_key = key16_tile
+                        hit_source = "move_arity_dup_tile"
+                # HEIGHT→BLOCK fallback for 16-tuple dup keys: substitute BLOCK_SHARDED at
+                # both input_0_memory (pos 7) and input_1_memory (pos 15) simultaneously.
+                if entry_val is None and len(key16) >= 16 and key16[7] == _HEIGHT_SHARDED_STR:
+                    key16_block = key16[:7] + (_BLOCK_SHARDED_STR,) + key16[8:15] + (_BLOCK_SHARDED_STR,)
+                    ev16_block = self._entries.get(key16_block)
+                    if ev16_block is not None:
+                        entry_val = ev16_block
+                        lookup_key = key16_block
+                        hit_source = "move_arity_dup_block"
+
+        # InterleavedToSharded: hardware stages through DRAM in most VGG UNet decoder paths,
+        # but Polaris models the predecessor STI output as L1_INTERLEAVED.  After L1 miss,
+        # substitute DRAM_INTERLEAVED in position 7 of the 9-tuple and retry.
+        if (
+            entry_val is None
+            and n_in == 1
+            and _op_code(op) in _ITS_MEM_FALLBACK_OPCODES
+            and len(lookup_key) >= 9
+            and lookup_key[7] == _L1_INTERLEAVED_STR
+        ):
+            key_dram = lookup_key[:7] + (_DRAM_INTERLEAVED_STR,) + lookup_key[8:]
+            ev_dram = self._entries.get(key_dram)
+            if ev_dram is not None:
+                entry_val = ev_dram
+                lookup_key = key_dram
+                hit_source = "its_l1_to_dram"
+
+        # Halo / Sigmoid: LUT was built with TILE layout; Polaris models VGG UNet as ROW_MAJOR.
+        # After ROW_MAJOR arity-1 miss, substitute TILE in position 5 of the 9-tuple.
+        if (
+            entry_val is None
+            and n_in == 1
+            and _op_code(op) in _LAYOUT_ROWMAJOR_TO_TILE_FALLBACK_OPCODES
+            and len(lookup_key) >= 9
+            and lookup_key[5] == _ROW_MAJOR_STR
+        ):
+            key_tile = lookup_key[:5] + (_TILE_STR,) + lookup_key[6:]
+            ev_tile = self._entries.get(key_tile)
+            if ev_tile is not None:
+                entry_val = ev_tile
+                lookup_key = key_tile
+                hit_source = "halo_rowmajor_to_tile"
+
+        # VGG UNet decoder HEIGHT→BLOCK fallback: after HEIGHT_SHARDED miss, substitute
+        # DEV_1_L1_BLOCK_SHARDED at position 7 (input_0_memory) of the lookup key.
+        # Works for arity-1 (9-tuple: halo, move) and arity-3 (23-tuple: conv2d, convtranspose)
+        # since position 7 is input_0_memory in both formats.
+        if (
+            entry_val is None
+            and n_in in (1, 3)
+            and _op_code(op) in _HALO_HEIGHT_TO_BLOCK_FALLBACK_OPCODES
+            and len(lookup_key) >= 9
+            and lookup_key[7] == _HEIGHT_SHARDED_STR
+        ):
+            key_block = lookup_key[:7] + (_BLOCK_SHARDED_STR,) + lookup_key[8:]
+            ev_block = self._entries.get(key_block)
+            if ev_block is not None:
+                entry_val = ev_block
+                lookup_key = key_block
+                hit_source = "halo_height_to_block"
+            elif lookup_key[5] == _ROW_MAJOR_STR:
+                # Also try TILE layout + BLOCK memory combined
+                key_tile_block = lookup_key[:5] + (_TILE_STR,) + lookup_key[6:7] + (_BLOCK_SHARDED_STR,) + lookup_key[8:]
+                ev_tb = self._entries.get(key_tile_block)
+                if ev_tb is not None:
+                    entry_val = ev_tb
+                    lookup_key = key_tile_block
+                    hit_source = "halo_tile_block_combined"
 
         if (
             entry_val is None
@@ -879,6 +1100,7 @@ class OperatorPerfMap:
                 if ev8 is not None:
                     entry_val = ev8
                     lookup_key = key8
+                    hit_source = "binary_to_unary"
                     logger.debug(
                         "Perf lookup: 15-tuple miss for {} op={!r}; using unary LUT key {} (lut={})",
                         _op_code(op),
@@ -921,7 +1143,7 @@ class OperatorPerfMap:
             self._source_path,
             entry_val,
         )
-        return self._stats_from_entry(lookup_key, entry_val, core_count)
+        return self._stats_from_entry(lookup_key, entry_val, core_count, key_literal=key_t, hit_source=hit_source)
 
 
 def resolve_operator_lookup_core_count(simcfg_obj: Any, package_model: Any) -> int:

--- a/tools/perf_lookup/tt_perf_mapper.py
+++ b/tools/perf_lookup/tt_perf_mapper.py
@@ -10,12 +10,12 @@ After load, OP CODE cells are normalized to Polaris-style layer *types* (e.g. ma
 ``ATTRIBUTES`` (``binary_op_type`` / ``UnaryOpType::…`` in ``op_chain``) when present; all keys, grouping, and mode checks use these types — not
 full profiler class names. Standard key tuple length is **9** if all INPUT_1_* and INPUT_2_* are blank, **16** if
 INPUT_1_* is all set and INPUT_2_* all blank, **23** if INPUT_1_* and INPUT_2_* are all set (ternary ops
-e.g. LayerNorm). The key includes ``MATH FIDELITY`` after the INPUT_0 slot. Per-op variants (schema v3/v4):
-``halo`` rows extend to **15** fields in schema v3 (kernel_h/w, stride_h/w, padding_h/w from ``SlidingWindowConfig``) or **16** fields in schema v4 (adds is_transpose to distinguish ConvTranspose halos);
+e.g. LayerNorm). The key includes ``MATH FIDELITY`` after the INPUT_0 slot. Per-op variants (schema v4):
+``halo`` rows extend to **16** fields (kernel_h/w, stride_h/w, padding_h/w, is_transpose from ``SlidingWindowConfig`` — ``is_transpose`` is a v4-only addition; v3 halo keys are 15 fields without it);
 ``interleavedtosharded`` rows extend to **10** fields (``output_0_memory`` from the OUTPUT_0_MEMORY column). Matmul uses ``entry_type:
 hybrid`` in YAML (``single`` + ``curve`` branches) when combining model and sweep data; see
 ``doc/YAML_MASTER_FORMAT.md``. CLI: repeatable ``--model-run`` and ``--sweep-run`` to merge Excel or CSV in one
-invocation (CSV is read with stdlib ``csv``; Excel ``.xlsx`` / ``.xlsm`` with **openpyxl**). Writes ``schema_name`` ``correqn.tt-perf-master``, ``schema_version`` (``tt_perf_master_schema.MASTER_YAML_SCHEMA_VERSION``, **1** until first release).
+invocation (CSV is read with stdlib ``csv``; Excel ``.xlsx`` / ``.xlsm`` with **openpyxl**). Writes ``schema_name`` ``correqn.tt-perf-master``, ``schema_version`` from ``tt_perf_master_schema.MASTER_YAML_SCHEMA_VERSION`` (currently **4**).
 
 Run from repository root: ``python -m tools.perf_lookup.tt_perf_mapper …``, or ``python tools/perf_lookup/tt_perf_mapper.py …`` (bootstrap adds repo root to ``sys.path``).
 """
@@ -167,9 +167,10 @@ STATS_COLUMNS_REQUIRED = [
     EXCEL_COL_DRAM_BW_UTIL,
     EXCEL_COL_NOC_UTIL,
     EXCEL_COL_NPE_CONG,
-    EXCEL_COL_SFPU,
-    EXCEL_COL_FPU,
 ]
+# Pipe-utilization columns are absent from raw profiler CSVs (present in sweep/Excel exports).
+# When missing, vector_pipe_util and matrix_pipe_util default to 0.
+STATS_COLUMNS_OPTIONAL_PIPE_UTIL = [EXCEL_COL_SFPU, EXCEL_COL_FPU]
 STATS_COLUMN_OPTIONAL = EXCEL_COL_MULTICAST_NOC
 
 # Merged three-way ops CSV (e.g. ``ops_perf_three_csv_merge`` output): util columns are suffixed.
@@ -419,6 +420,13 @@ def validate_columns(
         raise KeyError(
             f"Stats columns missing: {missing_stat}. Available: {list(table.columns)}"
         )
+    missing_pipe_util = [c for c in STATS_COLUMNS_OPTIONAL_PIPE_UTIL if c not in cs]
+    if missing_pipe_util:
+        logger.warning(
+            "Pipe-utilization columns absent (defaulting to 0): {}. "
+            "These are present in sweep/Excel exports but not in raw profiler CSVs.",
+            missing_pipe_util,
+        )
     stat_cols = STATS_COLUMNS_REQUIRED.copy()
     if STATS_COLUMN_OPTIONAL in cs:
         stat_cols.append(STATS_COLUMN_OPTIONAL)
@@ -626,7 +634,7 @@ def build_stats_row(
     except (TypeError, ValueError):
         return None
     util_pct = row.get(EXCEL_COL_DRAM_BW_UTIL)
-    if util_pct is None or is_na(util_pct):
+    if util_pct is None or is_na(util_pct) or (isinstance(util_pct, str) and not util_pct.strip()):
         util_pct = 0.0
     else:
         try:
@@ -720,7 +728,7 @@ def fit_1d_power(cores: np.ndarray, y: np.ndarray) -> tuple[np.ndarray, float]:
         return a * (x ** b)
 
     try:
-        a0 = float(np.nanmean(y_safe) / (np.nanmean(cores_safe) ** 0.5))
+        a0 = np.nanmean(y_safe) / (np.nanmean(cores_safe) ** 0.5)
         (a, b), _ = curve_fit(
             model, cores_safe, y_safe, p0=[max(float(a0), 1e-6), -0.5], maxfev=10000
         )
@@ -1403,13 +1411,13 @@ def process_excel_to_master(
             isinstance(row.get(duration_col), str)
             and not str(row.get(duration_col)).strip()
         ):
-            logger.error(
-                "{} blank at row {}; key_tuple_column_values={}",
+            logger.warning(
+                "Skipping row (blank {}) index={}; key_tuple_column_values={}",
                 EXCEL_DURATION_COLUMN,
                 idx,
                 key_tuple_field_values(row, key_cols),
             )
-            return 1, {}, {}, excel_path
+            continue
         stats = build_stats_row(
             row, dram_bw_gbps, stat_cols, duration_col, core_col
         )

--- a/tools/profiling/compare_layers.py
+++ b/tools/profiling/compare_layers.py
@@ -47,6 +47,159 @@ except ImportError:
     from .show_layers_profiler import layers_profiler  # type: ignore
 
 
+# Trace-replay dedup: HW captures running with METAL_TRACE_REPLAY emit one
+# `(METAL TRACE REPLAY SESSION ID)` column whose value identifies the replay
+# session for each row. The op sequence is repeated once per session, so the
+# raw profiler CSV is N×ops_per_session rows long. compare_layers picks one
+# representative session (median total duration) and discards the rest.
+_REPLAY_SESSION_COL = 'METAL TRACE REPLAY SESSION ID'
+_DURATION_NS_COL = 'DEVICE KERNEL DURATION [ns]'
+_SEQNO_COL = 'GLOBAL CALL COUNT'
+
+
+@dataclass
+class TraceReplayInfo:
+    """Structure detected in a profiler CSV."""
+    has_trace_replay: bool
+    n_sessions: int          # number of distinct replay session IDs
+    ops_per_session: int     # ops in the largest session (expected uniform)
+    setup_op_count: int      # rows with no session ID (warmup + trace-capture)
+    selected_session: int    # session ID chosen for comparison (0 if N/A)
+    selected_duration_ns: float  # total device-kernel duration of chosen session
+
+
+def _detect_trace_replay(filepath: str) -> Tuple['TraceReplayInfo', Dict[int, List[Tuple[int, float]]]]:
+    """Scan the raw profiler CSV for METAL TRACE REPLAY SESSION ID structure.
+
+    Returns ``(info, sessions)`` where ``sessions`` maps session_id to a list
+    of ``(row_index, duration_ns)`` tuples.  ``row_index`` is the 0-based
+    position of the row in the CSV data (excluding header), which aligns
+    directly with the index in the list returned by ``layers_profiler``.
+
+    Using row index rather than GLOBAL CALL COUNT is necessary because the
+    hardware trace replay re-uses the same GLOBAL CALL COUNT values for every
+    replay session — seqnos are NOT unique across sessions.
+    """
+    sessions: DefaultDict[int, List[Tuple[int, float]]] = defaultdict(list)
+    setup_row_count = 0
+    has_replay_col = False
+
+    with open(filepath, 'r') as fh:
+        reader = csv.DictReader(fh)
+        headers = reader.fieldnames or []
+        has_replay_col = _REPLAY_SESSION_COL in headers
+        for row_idx, row in enumerate(reader):
+            dur_raw = (row.get(_DURATION_NS_COL) or '').strip()
+            try:
+                dur_ns = float(dur_raw) if dur_raw else 0.0
+            except ValueError:
+                dur_ns = 0.0
+            sid_raw = (row.get(_REPLAY_SESSION_COL, '') or '').strip() if has_replay_col else ''
+            if sid_raw:
+                try:
+                    sid = int(float(sid_raw))
+                    sessions[sid].append((row_idx, dur_ns))
+                except ValueError:
+                    setup_row_count += 1
+            else:
+                setup_row_count += 1
+
+    if not sessions:
+        return TraceReplayInfo(
+            has_trace_replay=False,
+            n_sessions=0,
+            ops_per_session=0,
+            setup_op_count=setup_row_count,
+            selected_session=0,
+            selected_duration_ns=0.0,
+        ), {}
+
+    session_totals = {sid: sum(d for _, d in rows) for sid, rows in sessions.items()}
+    sorted_sids = sorted(session_totals, key=lambda s: session_totals[s])
+    selected_sid = sorted_sids[len(sorted_sids) // 2]
+    ops_per_session = max(len(v) for v in sessions.values())
+
+    return TraceReplayInfo(
+        has_trace_replay=True,
+        n_sessions=len(sessions),
+        ops_per_session=ops_per_session,
+        setup_op_count=setup_row_count,
+        selected_session=selected_sid,
+        selected_duration_ns=session_totals[selected_sid],
+    ), dict(sessions)
+
+
+def _maybe_dedup_profiler_layers(
+    layers: List[Dict[str, Any]],
+    filepath: str,
+) -> List[Dict[str, Any]]:
+    """Apply trace-replay deduplication to a profiler layer list if needed.
+
+    Detects trace structure from the raw CSV, picks the median-total-duration
+    replay session, and returns only those layers.  Setup-only ops (warmup,
+    trace-capture) are excluded because they do not contribute to device-only FPS.
+
+    Also performs self-checks:
+    - Warns when dedup appears necessary but the session ID column is absent.
+    - Warns when session sizes are uneven (unexpected replay structure).
+    - Confirms when the file is a clean single-pass run requiring no dedup.
+    """
+    info, sessions = _detect_trace_replay(filepath)
+
+    if not info.has_trace_replay:
+        # Self-check: duplicate GLOBAL CALL COUNT (seqno) values are a reliable
+        # indicator of trace replay without the session-id column — single-pass
+        # profiler runs use unique seqnos; trace replay re-uses the same seqnos
+        # across sessions. Repeated op types alone are NOT reliable (single-pass
+        # runs naturally have many repeated optypes like conv2d).
+        seqno_counts: DefaultDict[int, int] = defaultdict(int)
+        for layer in layers:
+            seqno_counts[layer['seqno']] += 1
+        max_count = max(seqno_counts.values()) if seqno_counts else 0
+        if max_count > 1:
+            print(
+                f"WARNING: '{_REPLAY_SESSION_COL}' column not found, but "
+                f"'{_SEQNO_COL}' values repeat up to {max_count}x in the profiler "
+                f"CSV. If this is a trace-replay run, add the column to enable auto-dedup.",
+                file=sys.stderr,
+            )
+        else:
+            print('Trace replay: not detected - using all profiler layers as-is (single-pass run)')
+        return layers
+
+    print(
+        f'Trace replay detected: {info.n_sessions} session(s) x {info.ops_per_session} ops, '
+        f'{info.setup_op_count} setup-only rows excluded'
+    )
+
+    session_sizes = {sid: len(rows) for sid, rows in sessions.items()}
+    if len(set(session_sizes.values())) > 1:
+        print(
+            f'WARNING: replay sessions have uneven op counts: {session_sizes}  '
+            f'- unexpected structure; using largest session size as reference.',
+            file=sys.stderr,
+        )
+
+    print(
+        f'Selected session {info.selected_session} '
+        f'(median total duration {info.selected_duration_ns / 1e6:.3f} ms)'
+    )
+
+    selected_indices = {row_idx for row_idx, _ in sessions[info.selected_session]}
+    deduped = [layer for i, layer in enumerate(layers) if i in selected_indices]
+
+    expected = info.ops_per_session
+    if len(deduped) != expected:
+        print(
+            f'WARNING: expected {expected} layers after dedup but got {len(deduped)} '
+            f'- row-index alignment between raw CSV and layers_profiler may be off.',
+            file=sys.stderr,
+        )
+
+    print(f'After dedup: {len(deduped)} profiler layers (was {len(layers)} total rows)')
+    return deduped
+
+
 def sanitize_file_path(filepath: str) -> Path:
     """
     Sanitize and validate a user-provided file path.
@@ -1895,6 +2048,9 @@ def main() -> int:
         print(f"{label} CSV: {file1_path}")
         print(f"Loaded {len(layers)} {label.lower()} layers")
 
+        if ftype == 'profiler':
+            layers = _maybe_dedup_profiler_layers(layers, str(file1_path))
+
         if args.filter_optype:
             filter_norm = normalize_optype(args.filter_optype)
             layers = [layer for layer in layers if normalize_optype(layer['optype']) == filter_norm]
@@ -1977,6 +2133,13 @@ def main() -> int:
         return 1
 
     print(f"Loaded {len(layers1)} {label1} layers, {len(layers2)} {label2} layers")
+
+    if type1 == 'profiler':
+        print(f'\n[{label1}] ', end='')
+        layers1 = _maybe_dedup_profiler_layers(layers1, str(file1_path))
+    if type2 == 'profiler':
+        print(f'\n[{label2}] ', end='')
+        layers2 = _maybe_dedup_profiler_layers(layers2, str(file2_path))
 
     # Filter by optype if requested
     if args.filter_optype:

--- a/tools/profiling/op_canonical.py
+++ b/tools/profiling/op_canonical.py
@@ -141,6 +141,7 @@ POLARIS_SYNONYMS: Dict[str, str] = {
     "nlpcreateqkvheads": "createqkvheads",  # backward-compat: old CSVs used NLP prefix
     "nlpconcatheads": "concatheads",
     "untilizewithvalunpadding": "untilizewithunpadding",  # Polaris uses "Val", profiler uses plain form
+    "conv": "conv2d",  # Polaris emits op.type='Conv'; LUT op_code='conv2d'
     "maxpool": "pool2d",  # Polaris emits op.type='MaxPool'; profiler/LUT uses 'Pool2D' → 'pool2d'
 }
 

--- a/tools/profiling/shape_canonical.py
+++ b/tools/profiling/shape_canonical.py
@@ -460,16 +460,22 @@ def _storage_is_numpy_float16(dt: Any) -> bool:
 
 
 def tensor_layout_str(t: Any) -> str:
-    """Extract layout string from a tensor object for LUT key."""
-    lay = getattr(t, "layout", None)
-    if lay is None:
-        return "TILE"
-    name = getattr(lay, "name", str(lay))
-    u = name.upper()
-    if "TILE" in u:
-        return "TILE"
-    if "ROW" in u:
-        return "ROW_MAJOR"
+    """Extract layout string from a tensor object for LUT key.
+
+    Checks ``_hw_layout`` first (set on weight/bias tensors to reflect hardware
+    pre-processing format without affecting activation propagation), then falls
+    back to ``layout``.
+    """
+    for attr in ("_hw_layout", "layout"):
+        lay = getattr(t, attr, None)
+        if lay is None:
+            continue
+        name = getattr(lay, "name", str(lay))
+        u = name.upper()
+        if "TILE" in u:
+            return "TILE"
+        if "ROW" in u:
+            return "ROW_MAJOR"
     return "TILE"
 
 
@@ -519,15 +525,16 @@ _KNOWN_TTNN_DTYPES = frozenset({
 def tensor_datatype(t: Any, op_precision: Any) -> str:
     """Extract datatype string from a tensor object for LUT key.
 
-    Prefers the TTNN logical dtype (``_ttnn_dtype``) when present, since
-    numpy storage loses information (e.g. BFLOAT8_B is stored as float32).
-    Falls back to ``t.dtype`` and then *op_precision*.
+    Checks ``_hw_dtype`` first (set on weight/bias tensors to reflect hardware
+    pre-processing format without affecting activation propagation), then
+    ``_ttnn_dtype``, then ``t.dtype``, then *op_precision*.
     """
-    ttnn_dt = getattr(t, "_ttnn_dtype", None)
-    if ttnn_dt is not None:
-        name = getattr(ttnn_dt, "name", str(ttnn_dt)).upper()
-        if name in _KNOWN_TTNN_DTYPES:
-            return name
+    for attr in ("_hw_dtype", "_ttnn_dtype"):
+        dt_obj = getattr(t, attr, None)
+        if dt_obj is not None:
+            name = getattr(dt_obj, "name", str(dt_obj)).upper()
+            if name in _KNOWN_TTNN_DTYPES:
+                return name
 
     dt = getattr(t, "dtype", None)
     if dt is not None:

--- a/tools/profiling/show_layers_polaris.py
+++ b/tools/profiling/show_layers_polaris.py
@@ -25,7 +25,9 @@ COLUMNS_OF_INTEREST = ['opnum', 'optype', 'input_tensors', 'output_tensors']
 def _parse_tensor_fields(tensor_string: str):
     """Parse a semicolon-separated tensor string into parallel lists of shapes and dtypes.
 
-    Each segment has the format ``name[dim1xdim2]:dtype``.
+    Each segment has the format ``name[dim1xdim2{|hw:dim1xdim2}]:dtype``.
+    The optional ``|hw:`` suffix (NHWC-flattened hw_shape) is stripped before
+    returning so callers receive only the logical shape string.
     Returns (shapes: list[str], dtypes: list[str]).
     """
     shapes = []
@@ -35,6 +37,8 @@ def _parse_tensor_fields(tensor_string: str):
             continue
         before_colon, _, dtype_part = field.rpartition(':')
         shape_part = before_colon.split('[')[1].replace(']', '') if '[' in before_colon else ''
+        # Strip |hw:... suffix — keep only the logical shape portion.
+        shape_part = shape_part.split('|')[0]
         shapes.append(shape_part)
         dtypes.append(dtype_part.strip())
     return shapes, dtypes

--- a/ttsim/back/device.py
+++ b/ttsim/back/device.py
@@ -560,6 +560,22 @@ class Device:
 
         return (msecs, uses_perf_lookup, master_stats)
 
+    def _compute_lut_key_str(self, op: Any, wlgraph: Any, master_stats: Optional[Any]) -> Optional[str]:
+        """Stringified literal LUT key for ``op``, emitted regardless of LUT hit/miss.
+
+        On hit, ``master_stats.key_literal`` already carries the tuple — use it.
+        On miss, ``master_stats`` is None, but the literal key can still be built
+        from the op + tensor state via ``OperatorPerfMap.build_literal_key``.
+        Returns None only when no LUT is configured or key construction fails
+        (unsupported arity, missing tensor, missing shape, etc.).
+        """
+        if master_stats is not None and master_stats.key_literal is not None:
+            return str(master_stats.key_literal)
+        if self.operator_perf_map is None:
+            return None
+        key_t = self.operator_perf_map.build_literal_key(op, wlgraph)
+        return str(key_t) if key_t is not None else None
+
     def get_exec_stats(self, wlgraph, bs):
         graph_ordered_nodes = wlgraph.get_ordered_nodes()
 
@@ -704,6 +720,32 @@ class Device:
                     'memory_traffic'   : memory_traffic,
                     'mem_util'         : mem_util,
                     'uses_perf_lookup' : uses_perf_lookup,
+                    # LUT-key trail: ``lut_key`` is the literal key built from the
+                    # op + tensor state; ``lut_key_resolved`` is the entry the
+                    # lookup chain actually matched after any fallback
+                    # substitution (HEIGHT→BLOCK, L1→DRAM, ROW_MAJOR→TILE, arity
+                    # dup, …).  Downstream compare_layers ``--by-lut-key`` groups
+                    # by the resolved key so polaris + profiler rows that
+                    # semantically share a LUT entry align in the rollup, even
+                    # when their literal shapes differ in fallback-tolerable ways.
+                    # ``lut_key`` is emitted unconditionally (even on miss) so
+                    # the rollup can diagnose mismatches on workloads with low
+                    # hit rates; ``lut_key_resolved`` is only meaningful on hit.
+                    'lut_key'          : self._compute_lut_key_str(op, wlgraph, master_stats),
+                    'lut_key_resolved' : (
+                        str(master_stats.key_resolved)
+                        if (uses_perf_lookup and master_stats is not None
+                            and master_stats.key_resolved is not None) else None
+                    ),
+                    # Diagnostic: which lookup path produced the hit, "analytical"
+                    # when a LUT was loaded but the lookup returned no entry, or None
+                    # when no LUT is loaded at all for this device. See
+                    # MasterPerfStats.hit_source for the enum of hit-path values.
+                    'lut_hit_source'   : (
+                        master_stats.hit_source
+                        if (uses_perf_lookup and master_stats is not None and master_stats.hit_source)
+                        else ('analytical' if self.operator_perf_map is not None else None)
+                    ),
                     }
 
         #compute aggregate stats

--- a/ttsim/config/validators.py
+++ b/ttsim/config/validators.py
@@ -288,6 +288,18 @@ class TTSimHLWlDevRunOpCSVPerfStats(BaseModel, extra='forbid'):
     uses_perf_lookup: bool = Field(
         description = 'True when timing and pipe util were obtained from operator performance master lookup (matrix/vector util required in LUT row)'
     )
+    lut_key: Optional[str] = Field(
+        default = None,
+        description = 'Literal LUT key (str(tuple)) built from this operator + its tensor state, before any fallback substitution; emitted on both hit AND miss (diagnostic) whenever a LUT is configured and the literal key can be built. None only when no LUT is configured or key construction fails (unsupported arity, missing tensor/shape, etc.).'
+    )
+    lut_key_resolved: Optional[str] = Field(
+        default = None,
+        description = 'Resolved LUT key (str(tuple)) the lookup actually matched after any HEIGHT→BLOCK / L1→DRAM / ROW_MAJOR→TILE / arity-1→arity-2 fallback substitution; equals lut_key when no fallback was needed; None on LUT miss or when no LUT is configured for this device.'
+    )
+    lut_hit_source: Optional[str] = Field(
+        default = None,
+        description = 'Which lookup path produced the hit: "direct", one of the fallback names (e.g. "halo_height_to_block", "its_l1_to_dram", "move_arity_dup"), or "analytical" when a LUT is configured but no entry matched (LUT miss). None only when no LUT is configured for this device. See MasterPerfStats.hit_source for full enum.'
+    )
 
 # Option 2 - Structured Stats
 
@@ -339,6 +351,16 @@ class TTSimHLWlDevRunOperatorPerfStats(BaseModel, extra='forbid'):
     memory_traffic: float
     mem_util: float
     uses_perf_lookup: bool
+    # Literal / resolved LUT key.  See TTSimHLWlDevRunOpCSVPerfStats for full semantics.
+    # ``lut_key`` is the tuple built from this op + tensor state (pre-fallback) —
+    # emitted on both hit AND miss whenever a LUT is configured (diagnostic).
+    # ``lut_key_resolved`` is the tuple the lookup chain actually matched
+    # (post-fallback substitution) — emitted only on hit.
+    # ``lut_hit_source`` records which path produced the hit, or 'analytical' on
+    # miss with a configured LUT. All three are None only when no LUT is configured.
+    lut_key: Optional[str] = None
+    lut_key_resolved: Optional[str] = None
+    lut_hit_source: Optional[str] = None
 
 class TTSimHLWlDevRunPerfStats(BaseModel, extra='forbid'):
     """

--- a/ttsim/front/onnx/onnx2nx.py
+++ b/ttsim/front/onnx/onnx2nx.py
@@ -201,7 +201,11 @@ def parse_onnx_model(wlname, wlpath, dim_overrides: Optional[dict] = None):
         if hasattr(node, "attribute"):
             attrhash = {attr.name : onnx_get_value_from_attrs(attr) for attr in node.attribute }
 
-        nodeinfo = {}
+        # ``nodeinfo`` holds heterogeneous values (str names, list[str] in/out,
+        # dict attrs) — annotate as dict[str, Any] so mypy doesn't infer
+        # dict[str, str] from the first scalar assignments. Pre-existing
+        # mypy nag unrelated to PR #434, bundled here to unblock pre-commit.
+        nodeinfo: dict[str, Any] = {}
         nodeinfo['name']    = node.name
         nodeinfo['optype']  = node.op_type
         nodeinfo['domain']  = node.domain

--- a/ttsim/front/ttnn/__init__.py
+++ b/ttsim/front/ttnn/__init__.py
@@ -4,7 +4,7 @@
 
 from .device import open_device, close_device, ARCH, num_cores_to_corerangeset, create_sharded_memory_config, ReadDeviceProfiler
 from .device import USE_DEFAULT_DEVICE, resolve_device, set_default_device, get_default_device
-from .ttnn_shim import interleaved_to_sharded, sharded_to_interleaved, reshard
+from .ttnn_shim import interleaved_to_sharded, sharded_to_interleaved, reshard, to_memory_config
 from .tensor import (
     Tensor,
     _rand,
@@ -24,7 +24,7 @@ from .tensor import Layout, as_tensor, arange, stack, ShardStrategy, unsqueeze_t
 from .config import Conv2dConfig, WormholeComputeKernelConfig, init_device_compute_kernel_config
 from .config import MatmulMultiCoreReuseMultiCast1DProgramConfig
 from .buffer import TensorMemoryLayout, ShardOrientation, BufferType, ShardSpec
-from .memory import MemoryConfig, create_sharded_memory_config_, get_memory_config, to_memory_config
+from .memory import MemoryConfig, create_sharded_memory_config_, get_memory_config
 from .types import TILE_HEIGHT, TILE_WIDTH
 from .core   import CoreCoord, CoreRange, CoreRangeSet, CoreGrid
 from .op     import *

--- a/ttsim/front/ttnn/memory.py
+++ b/ttsim/front/ttnn/memory.py
@@ -131,12 +131,6 @@ def create_sharded_memory_config_(shape, grid, mem_layout, orientation, tile_lay
     return MemoryConfig(mem_layout, BufferType.L1, shard_spec=shard_spec)
 
 
-def to_memory_config(input_tensor, memory_config=None):
-    if memory_config is not None and hasattr(input_tensor, '_memory_config'):
-        input_tensor._memory_config = memory_config
-    return input_tensor
-
-
 def get_memory_config(x):
     mc = getattr(x, '_memory_config', None)
     if mc is not None:

--- a/ttsim/front/ttnn/op.py
+++ b/ttsim/front/ttnn/op.py
@@ -811,15 +811,491 @@ split = multiple_output_immediate_op("Split", preprocess=split_pp)
 layer_norm = single_output_immediate_op("LayerNormalization", preprocess=layer_norm_pp)
 batch_norm = single_output_immediate_op("BatchNormalization")
 
-# Convolution
-conv2d = single_output_immediate_op("Conv", preprocess=conv2d_pp)
-conv_transpose2d = single_output_immediate_op(
-    "ConvTranspose", preprocess=conv_transpose2d_pp
-)
+# Halo: auto-emitted by the shim before every conv2d / pool2d / conv_transpose2d,
+# mirroring the hardware dispatch where halo extraction is implicit inside those ops.
+halo = single_output_immediate_op("Halo")
 
-# Pooling
+# InterleavedToSharded: auto-emitted when conv/pool receives an interleaved tensor,
+# mirroring the hardware dispatch where the kernel internally converts to sharded
+# before halo extraction.
+_interleaved_to_sharded = single_output_immediate_op("InterleavedToSharded")
+
+# Move: auto-emitted after conv2d / conv_transpose2d when deallocate_activation=True.
+# On hardware, MoveDeviceOperation copies the output buffer to a new memory region
+# to free the old one.  The shim mirrors this by emitting a Move SimOp after the
+# conv output, matching the hardware profiler op sequence.
+_move = single_output_immediate_op("Move")
+
+
+# Producers whose output is already a freshly allocated buffer — tt-metal's conv
+# kernel skips its internal Move when the input came from one of these, because
+# no reallocation is needed.  Used by ``_with_halo`` to suppress the Move that
+# would otherwise be emitted before the conv.  (See HW Move LUT entries: the
+# first conv of every stage following a MaxPool has no matching Move row.)
+_HW_FRESH_BUFFER_PRODUCERS: frozenset[str] = frozenset({"MaxPool", "ConvTranspose"})
+
+
+def _producer_optype(tensor) -> str:
+    """Return the optype of the op that produced ``tensor``, or '' if unknown."""
+    if tensor is None or getattr(tensor, "device", None) is None:
+        return ""
+    op_out = getattr(tensor, "op_out", None)
+    if not op_out:
+        return ""
+    producer = tensor.device.ops.get(op_out[0])
+    if producer is None:
+        return ""
+    return str(getattr(producer, "optype", ""))
+
+# Pad: used by VGG UNet entry path to model the C=3 → C=16 channel pad that the
+# hardware applies before the first conv (the LUT records this Pad).
+_pad = single_output_immediate_op("Pad")
+
+
+def pad_channels_nchw(input_tensor: 'Tensor', target_channels: int) -> 'Tensor':
+    """Emit a Pad SimOp that grows the NCHW channel dim from in_shape[1] to target_channels.
+
+    VGG UNet enters with C=3 but the canonical hardware form pads to C=16 before
+    the first conv (see HW ttnn_vgg_unet.py).  The profiler records this Pad with
+    the pre-pad input shape; emitting it here makes the LUT entry hit and shifts
+    downstream Halo/Move/Conv onto the C=16 LUT entries that the hardware uses.
+
+    The op is emitted as arity-1 (no pads_tensor in inList) so the LUT key matches
+    the profiler's 9-tuple recording, with pad values carried in attrs.  The output
+    is given an NCHW ``hw_shape`` ``[N, target_channels, H, W]`` so the *next*
+    op's LUT key sees the post-Pad NCHW shape — the HW emits two Transposes
+    after the Pad (NCHW → NHWC), and those Transposes' LUT entries record the
+    NCHW input shape.  The Halo / Conv path then receives an NHWC-flat shape
+    via the second Transpose's ``hw_shape``.  See ``permute_reshape_to_nhwc_flat``.
+    """
+    in_shape = list(input_tensor.shape)  # type: ignore[arg-type]
+    assert len(in_shape) == 4 and in_shape[1] < target_channels, (
+        f"pad_channels_nchw: NCHW input with C<target required; "
+        f"got shape={in_shape}, target={target_channels}"
+    )
+    N, _, H, W = in_shape
+    pad_amount = target_channels - in_shape[1]
+    out_shape = [N, target_channels, H, W]
+
+    op_name = generate_new_op_name()
+    out_tensor = Tensor(
+        name=op_name + '.out',
+        shape=out_shape,
+        dtype=input_tensor.dtype,
+        layout=input_tensor.get_layout(),
+        op_out=[op_name],
+        device=input_tensor.device,
+    )
+    # hw_shape mirrors the logical NCHW shape so the first entry-path Transpose
+    # presents a (1, C, H, W) input to its LUT lookup.
+    #
+    # TODO(batch>1): the entry-path Transpose LUT keys are documented with W=1
+    # (batch folded into later NHWC-flat N*H*W). Multi-batch use needs either
+    # (a) extending the LUT entries to cover N>1 keys, or (b) folding N into
+    # H/W here so the existing keys still match. Today only batch_size=1 is
+    # exercised; assert that explicitly so multi-batch use fails fast rather
+    # than producing silent LUT-key mismatches downstream.
+    assert int(out_shape[0]) == 1, (
+        f"pad_channels_nchw currently supports batch_size=1 only "
+        f"(got N={out_shape[0]}). See TODO above."
+    )
+    out_tensor.hw_shape = list(out_shape)
+    input_tensor.op_in.append(op_name)
+
+    opinfo = {
+        'name': op_name,
+        'optype': 'Pad',
+        'inList': [input_tensor.name],
+        'outList': [out_tensor.name],
+        'attrs': {'pads': [0, 0, 0, 0, 0, pad_amount, 0, 0], 'mode': 'constant', 'value': 0},
+    }
+    opobj = SimOp(opinfo)
+
+    # Manual perf stats (bypass pad_sinf which requires a pad_tensor input).
+    # Pad is dtype-preserving; query the input tensor for the correct byte
+    # width (handles BFLOAT8_B, BFLOAT4_B etc.) instead of hardcoding bfloat16.
+    elem_size = input_tensor.element_size()
+    nelems_in = 1
+    for d in in_shape:
+        nelems_in *= int(d)
+    nelems_out = 1
+    for d in out_shape:
+        nelems_out *= int(d)
+    opobj.perf_stats = {
+        'inElems': nelems_in,
+        'outElems': nelems_out,
+        'inBytes': nelems_in * elem_size,
+        'outBytes': nelems_out * elem_size,
+        'instrs': {'mov': nelems_out},
+    }
+    # Pre-populating ``perf_stats`` short-circuits ``SimOp.get_perf_counts()``
+    # and skips its post-shape-inference snapshot block. Mirror that snapshot
+    # here so downstream stats serialization reads the frozen (post-pad) shapes
+    # rather than live tensor state that later ops may mutate.
+    opobj._frozen_input_shapes = [list(in_shape)]
+    opobj._frozen_output_shapes = [list(out_shape)]
+    opobj.update_tensor_counts([input_tensor], [out_tensor])
+
+    _propagate_ttnn_dtype([input_tensor], [out_tensor])
+    _propagate_memory_config([input_tensor], [out_tensor])
+
+    input_tensor.device.add_op(opobj)  # type: ignore[union-attr]
+    return out_tensor
+
+
+def _emit_entry_transpose(input_tensor: 'Tensor', output_hw_shape: list) -> 'Tensor':
+    """Emit a tracking-only Transpose SimOp with an explicit output ``hw_shape``.
+
+    Used by ``permute_reshape_to_nhwc_flat`` to model the two HW transposes that
+    convert NCHW (post-Pad) to NHWC-flat (pre-Halo).  Logical shape is a
+    passthrough (Polaris models conv math in NCHW); only ``hw_shape`` is
+    advanced so the downstream LUT keys land on the right entries.
+    """
+    in_shape = list(input_tensor.shape)  # type: ignore[arg-type]
+    op_name = generate_new_op_name()
+    out_tensor = Tensor(
+        name=op_name + '.out',
+        shape=in_shape,
+        dtype=input_tensor.dtype,
+        layout=input_tensor.get_layout(),
+        op_out=[op_name],
+        device=input_tensor.device,
+    )
+    out_tensor.hw_shape = list(output_hw_shape)
+    input_tensor.op_in.append(op_name)
+
+    opinfo = {
+        'name': op_name,
+        'optype': 'Transpose',
+        'inList': [input_tensor.name],
+        'outList': [out_tensor.name],
+        'attrs': {},
+    }
+    opobj = SimOp(opinfo)
+
+    # Transpose is dtype-preserving; query the input tensor for the correct
+    # byte width (handles BFLOAT8_B, BFLOAT4_B etc.) instead of hardcoding bfloat16.
+    elem_size = input_tensor.element_size()
+    nelems = 1
+    for d in in_shape:
+        nelems *= int(d)
+    opobj.perf_stats = {
+        'inElems': nelems,
+        'outElems': nelems,
+        'inBytes': nelems * elem_size,
+        'outBytes': nelems * elem_size,
+        'instrs': {'mov': nelems},
+    }
+    # Pre-populating ``perf_stats`` short-circuits ``SimOp.get_perf_counts()``
+    # and skips its post-shape-inference snapshot block. Mirror that snapshot
+    # here. Transpose's logical shape is a passthrough (only ``hw_shape``
+    # differs), so input and output frozen shapes are both ``in_shape``.
+    opobj._frozen_input_shapes = [list(in_shape)]
+    opobj._frozen_output_shapes = [list(in_shape)]
+    opobj.update_tensor_counts([input_tensor], [out_tensor])
+
+    _propagate_ttnn_dtype([input_tensor], [out_tensor])
+    _propagate_memory_config([input_tensor], [out_tensor])
+
+    input_tensor.device.add_op(opobj)  # type: ignore[union-attr]
+    return out_tensor
+
+
+def permute_reshape_to_nhwc_flat(input_tensor: 'Tensor') -> 'Tensor':
+    """Emit the two Transpose SimOps that follow Pad in the VGG UNet entry path.
+
+    The HW profiler shows two TransposeDeviceOperation rows between Pad and the
+    first Halo, converting NCHW [N, C, H, W] to NHWC-flat [1, 1, N*H*W, C].
+    LUT entries record:
+      T1 input: (1, C, H, W)         — post-Pad NCHW
+      T2 input: (1, H, C, W)         — intermediate
+    Output of T2 has hw_shape ``[1, 1, N*H*W, C]`` (NHWC-flat) for downstream
+    Halo to consume.  Logical (NCHW) shape is preserved through both transposes
+    so Polaris's conv shape inference continues to operate in NCHW.
+    """
+    in_shape = list(input_tensor.shape)  # type: ignore[arg-type]
+    assert len(in_shape) == 4, (
+        f"permute_reshape_to_nhwc_flat expects rank-4 NCHW input; got shape={in_shape}"
+    )
+    N, C, H, W = in_shape
+    t1 = _emit_entry_transpose(input_tensor, [1, H, C, W])
+    t2 = _emit_entry_transpose(t1, [1, 1, N * H * W, C])
+    return t2
+
+
+def _with_halo(op_fn, is_transpose: bool = False, move_before_conv: bool = False):
+    """Return a wrapper that auto-emits a Halo SimOp before the main op.
+
+    Halo is skipped for 1×1 kernels: hardware implements those as matmul
+    and never dispatches a halo extraction step.
+
+    When the input has an interleaved memory config, an InterleavedToSharded
+    SimOp is emitted first, matching the hardware dispatch where conv/pool
+    kernels internally convert interleaved activations to sharded layout
+    before halo extraction.
+
+    Args:
+        is_transpose: True when wrapping conv_transpose2d (sets is_transpose attr on Halo).
+        move_before_conv: When True, emits Move after Halo but before the main op,
+            matching the hardware op sequence ITS → Halo → Move → Conv.
+            Only emits Move when deallocate_activation=True and the original
+            input tensor is L1-sharded (same guard as _with_move).
+    """
+    def _impl(*args, **kwargs):
+        ks = kwargs.get('kernel_size', (3, 3))
+        # Normalise scalar int to 2-tuple — several upstream call sites pass
+        # `kernel_size=3` rather than `kernel_size=(3, 3)`. Without this, the
+        # downstream `tuple(ks)` would raise TypeError at graph-build time.
+        # Write the normalised form back into kwargs so downstream
+        # preprocessors (conv2d_pp / max_pool2d_pp) also see a 2-tuple — they
+        # call `list(kernel_size)` and would otherwise still trip on a scalar.
+        if isinstance(ks, int):
+            ks = (ks, ks)
+        ks = tuple(ks)
+        kwargs['kernel_size'] = ks
+        if ks != (1, 1):
+            # --- 3×3+ kernel: ITS → Halo → [Move] → Conv ---
+            # Capture original input BEFORE ITS/Halo so Move guard uses the right tensor.
+            original_input = kwargs.get('input_tensor') or (args[0] if args else None)
+
+            if original_input is not None:
+                mc = getattr(original_input, '_memory_config', None)
+                if mc is not None and not mc.is_sharded():
+                    its_out = _interleaved_to_sharded(
+                        original_input,
+                        element_size=original_input.element_size(),
+                    )
+                    # Mirror tt-metal: the conv's Conv2dConfig.shard_layout drives the
+                    # auto-emitted ITS's output memory layout. Falls back to
+                    # HEIGHT_SHARDED when shard_layout is unset (None) — matches the
+                    # default the polaris shim has historically used.
+                    conv_cfg_for_its = kwargs.get('conv_config')
+                    its_shard = getattr(conv_cfg_for_its, 'shard_layout', None)
+                    if not isinstance(its_shard, TensorMemoryLayout):
+                        its_shard = TensorMemoryLayout.HEIGHT_SHARDED
+                    its_out._memory_config = MemoryConfig(its_shard, BufferType.L1)
+                    if 'input_tensor' in kwargs:
+                        kwargs['input_tensor'] = its_out
+                    else:
+                        args = (its_out,) + args[1:]
+
+            # Normalise padding/stride scalars to 2-tuples — same shape robustness
+            # as the kernel_size normalisation above. The Halo LUT key builder
+            # treats these as indexable 2-D geometry, and ``halo_sinf`` reads them
+            # from ``op.attrs``; either would break on a scalar int. Write the
+            # normalised values back into kwargs so downstream preprocessors
+            # (conv2d_pp / conv_transpose2d_pp / max_pool2d_pp) — which do
+            # ``padding[0]`` / ``list(stride)`` — also see 2-tuples.
+            padding = kwargs.get('padding', (0, 0))
+            stride = kwargs.get('stride', (1, 1))
+            if isinstance(padding, int):
+                padding = (padding, padding)
+            if isinstance(stride, int):
+                stride = (stride, stride)
+            padding = tuple(padding)
+            stride = tuple(stride)
+            kwargs['padding'] = padding
+            kwargs['stride'] = stride
+
+            # The tensor fed into Halo may be the post-ITS tensor (if input was
+            # interleaved); capture it here so ``element_size`` in halo_attrs is
+            # dtype-accurate for halo_sinf's analytical perf_stats fallback.
+            halo_input = kwargs.get('input_tensor') or args[0]
+
+            # Pass sliding-window config attrs so halo_sinf can compute the
+            # halo-extended hw_shape (matching hardware's physical buffer size).
+            halo_attrs = {
+                'kernel_size': ks,
+                'padding': padding,
+                'stride': stride,
+                'is_transpose': is_transpose,
+                'element_size': halo_input.element_size(),
+            }
+            if 'input_tensor' in kwargs:
+                kwargs['input_tensor'] = halo(kwargs['input_tensor'], **halo_attrs)
+            elif args:
+                args = (halo(args[0], **halo_attrs),) + args[1:]
+
+            # Emit Move AFTER Halo but BEFORE the main op, mirroring hardware's
+            # ITS → Halo → Move → Conv sequence (not Conv → Move as _with_move did).
+            # Three guards in order of precedence:
+            #   1. Workload opts out per-position via ``emit_move_before_conv=False``
+            #      kwarg.  Used for stages where the HW profiler shows no Move row
+            #      despite deallocate_activation being True (constant-shape buffer
+            #      reuse in bottleneck, fresh-from-Concat inputs in decoder d3).
+            #   2. Skip when the conv's input came from a fresh-buffer producer
+            #      (MaxPool / ConvTranspose) — the kernel doesn't need to
+            #      reallocate.
+            #   3. The original deallocate_activation + L1-sharded guard below.
+            emit_move = kwargs.get('emit_move_before_conv', True)
+            if (
+                move_before_conv
+                and emit_move
+                and _producer_optype(original_input) not in _HW_FRESH_BUFFER_PRODUCERS
+            ):
+                conv_cfg = kwargs.get('conv_config')
+                deallocate = kwargs.get(
+                    'deallocate_activation',
+                    getattr(conv_cfg, 'deallocate_activation', False),
+                )
+                if deallocate:
+                    # Check the POST-ITS+Halo input tensor's memory config (not
+                    # original_input). When the original input was L1_INTERLEAVED or
+                    # DRAM_INTERLEAVED, auto-ITS converts it to L1-sharded, and
+                    # tt-metal's conv kernel then fires the Move kernel to reallocate
+                    # the halo output. Using original_input would skip Move at
+                    # decoder convs whose input comes from an explicit STS (e.g.
+                    # d1.conv1, d2.conv1 in VGG UNet).
+                    current_input = kwargs.get('input_tensor') or (args[0] if args else None)
+                    current_mc = getattr(current_input, '_memory_config', None)
+                    is_l1_sharded = (
+                        current_mc is not None
+                        and current_mc.is_sharded()
+                        and getattr(current_mc, 'buffer_type', None) == BufferType.L1
+                    )
+                    if is_l1_sharded:
+                        if 'input_tensor' in kwargs:
+                            kwargs['input_tensor'] = _move(
+                                kwargs['input_tensor'],
+                                element_size=kwargs['input_tensor'].element_size(),
+                            )
+                        elif args:
+                            args = (
+                                _move(args[0], element_size=args[0].element_size()),
+                            ) + args[1:]
+
+            return op_fn(*args, **kwargs)
+
+        else:
+            # --- 1×1 kernel (lowered to MatMul): no Move ---
+            # tt-metal's 1×1-conv→MatMul path does NOT emit MoveDeviceOperation
+            # after the matmul (the HW profiler shows no Move row at the final
+            # 1×1 conv output shape).  Drop the trailing Move that the previous
+            # implementation emitted; emit only the MatMul.
+            return op_fn(*args, **kwargs)
+    return _impl
+
+
+def _with_move(op_fn):
+    """Return a wrapper that auto-emits a Move SimOp after the main op.
+
+    Move is emitted only when two conditions both hold:
+      1. deallocate_activation=True (direct kwarg or via Conv2dConfig.conv_config)
+      2. The input tensor's _memory_config is L1-sharded (HEIGHT or BLOCK sharded
+         on L1 buffer).
+
+    Condition 2 mirrors hardware: MoveDeviceOperation is only dispatched when the
+    activation lives in L1 sharded memory.  Tensors in DRAM or interleaved L1 are
+    left in place and no Move is emitted.
+    """
+    def _impl(*args, **kwargs):
+        # Capture input tensor BEFORE op_fn runs (conv_config/halo may transform it).
+        input_tensor = kwargs.get('input_tensor') or (args[0] if args else None)
+
+        conv_cfg = kwargs.get('conv_config')
+        deallocate = kwargs.get(
+            'deallocate_activation',
+            getattr(conv_cfg, 'deallocate_activation', False),
+        )
+        result = op_fn(*args, **kwargs)
+        if deallocate:
+            mc = getattr(input_tensor, '_memory_config', None)
+            is_l1_sharded = (
+                mc is not None
+                and mc.is_sharded()
+                and getattr(mc, 'buffer_type', None) == BufferType.L1
+            )
+            if is_l1_sharded:
+                result = _move(result)
+        return result
+    return _impl
+
+
+# Convolution (ITS→Halo auto-emitted before, Move auto-emitted after when deallocate_activation=True)
+_conv2d_raw = single_output_immediate_op("Conv", preprocess=conv2d_pp)
+# 1×1 conv: hardware lowers to MatMul; use same conv2d_pp attrs so matmul_shape_inf
+# detects kernel_shape=[1,1] and applies NCHW conv output-shape logic.
+_matmul_1x1_raw = single_output_immediate_op("MatMul", preprocess=conv2d_pp)
+
+
+def _matmul_1x1_with_hw_fields(*args, **kwargs):
+    """1×1 conv lowered to MatMul; apply HW weight/bias preprocessing.
+
+    On hardware, the 1×1 conv kernel pre-processes the weight to NHWC-flat
+    ``[1, 1, C_in*kH*kW, C_out]`` in TILE / BFLOAT8_B / DRAM and the bias to
+    ``[1, 1, 1, C_out]`` in the same layout; the activation is tilized before
+    the matmul.  Setting these ``hw_shape`` / ``_hw_layout`` / ``_hw_dtype``
+    fields on the input/weight/bias tensors makes the LUT key match the
+    profiler's recorded matmul entry for the 1×1 conv (Conv path already does
+    this via ``conv_sinf``; matmul-routed path didn't).
+    """
+    input_t = kwargs.get('input_tensor')
+    weight_t = kwargs.get('weight_tensor')
+    bias_t = kwargs.get('bias_tensor')
+
+    result = _matmul_1x1_raw(*args, **kwargs)
+
+    if weight_t is not None and weight_t.shape is not None and len(weight_t.shape) == 4:
+        C_out = int(weight_t.shape[0])
+        C_in = int(weight_t.shape[1])
+        kH = int(weight_t.shape[2])
+        kW = int(weight_t.shape[3])
+        weight_t.hw_shape = [1, 1, C_in * kH * kW, C_out]
+        weight_t._hw_dtype = DataType.BFLOAT8_B
+        weight_t._hw_layout = Layout.TILE_LAYOUT
+        if bias_t is not None:
+            bias_t.hw_shape = [1, 1, 1, C_out]
+            bias_t._hw_dtype = DataType.BFLOAT8_B
+            bias_t._hw_layout = Layout.TILE_LAYOUT
+    if input_t is not None:
+        input_t._hw_layout = Layout.TILE_LAYOUT
+
+    return result
+
+
+def _apply_conv_output_layout(result, kwargs):
+    """Mirror tt-metal: ``Conv2dConfig.output_layout`` controls the conv output tensor layout.
+
+    Without this, polaris's Conv2d / Conv_transpose2d output defaults to ``Layout.DEFAULT``
+    (= ROW_MAJOR_LAYOUT, see tensor.py), so downstream ops (next halo, etc.) always see
+    ROW_MAJOR input — even when the model code requested ``output_layout=TILE_LAYOUT`` via
+    ``Conv2dConfig``. Mirrors tt-metal: the kernel emits in the layout requested by the
+    config (relevant for VGG UNet's tile_layout convs).
+    """
+    conv_cfg = kwargs.get('conv_config')
+    if conv_cfg is not None:
+        ol = getattr(conv_cfg, 'output_layout', None)
+        if isinstance(ol, Layout):
+            result.layout = ol
+    return result
+
+
+def _conv2d_dispatch(*args, **kwargs):
+    ks = kwargs.get('kernel_size', (3, 3))
+    if tuple(ks) == (1, 1):
+        result = _matmul_1x1_with_hw_fields(*args, **kwargs)
+    else:
+        result = _conv2d_raw(*args, **kwargs)
+    return _apply_conv_output_layout(result, kwargs)
+
+
+conv2d = _with_halo(_conv2d_dispatch, is_transpose=False, move_before_conv=True)
+
+
+_conv_transpose2d_raw_inner = single_output_immediate_op("ConvTranspose", preprocess=conv_transpose2d_pp)
+
+
+def _conv_transpose2d_raw(*args, **kwargs):
+    result = _conv_transpose2d_raw_inner(*args, **kwargs)
+    return _apply_conv_output_layout(result, kwargs)
+
+
+conv_transpose2d = _with_halo(_conv_transpose2d_raw, is_transpose=True, move_before_conv=True)
+
+# Pooling (Halo auto-emitted before max_pool2d, matching hardware sub-op sequence)
 global_avg_pool2d = single_output_immediate_op("GlobalAveragePool")
-max_pool2d = single_output_immediate_op("MaxPool", preprocess=max_pool2d_pp)
+_max_pool2d_raw = single_output_immediate_op("MaxPool", preprocess=max_pool2d_pp)
+max_pool2d = _with_halo(_max_pool2d_raw)
 
 # Matrix Multiplication
 matmul = single_output_immediate_op("MatMul")

--- a/ttsim/front/ttnn/ttnn_shim.py
+++ b/ttsim/front/ttnn/ttnn_shim.py
@@ -2510,6 +2510,30 @@ def reshard_op(input_tensor, memory_config=None, element_size=2):
     return out_tensor
 
 
+def to_memory_config(input_tensor, memory_config=None):
+    """Emit STI+ITS SimOps when resharding from one sharded config to another.
+
+    On hardware, transitioning between two sharded layouts goes through an
+    interleaved staging step: ShardedToInterleaved → InterleavedToSharded.
+    This is emitted when both source and target are sharded but differ.
+    """
+    if memory_config is None:
+        return input_tensor
+    mode = get_execution_mode()
+    should_track = (mode == ExecutionMode.TRACK_ONLY or mode == ExecutionMode.EXECUTE_AND_TRACK)
+    if (should_track and memory_config.is_sharded()
+            and isinstance(input_tensor, Tensor) and input_tensor.device is not None):
+        input_mc = getattr(input_tensor, '_memory_config', None)
+        if input_mc is not None and input_mc.is_sharded() and input_mc != memory_config:
+            elem_sz = input_tensor.element_size() if hasattr(input_tensor, 'element_size') else 2
+            input_tensor = sharded_to_interleaved_op(input_tensor, element_size=elem_sz)
+            input_tensor = interleaved_to_sharded_op(input_tensor, memory_config=memory_config, element_size=elem_sz)
+            return input_tensor
+    if hasattr(input_tensor, '_memory_config'):
+        input_tensor._memory_config = memory_config
+    return input_tensor
+
+
 def reshard(input_tensor, memory_config, output_tensor=None):
     """Change shard layout of an already-sharded tensor."""
     mode = get_execution_mode()

--- a/ttsim/ops/desc/data_compute.py
+++ b/ttsim/ops/desc/data_compute.py
@@ -2244,10 +2244,12 @@ def compute_atan(iTList, op) -> np.ndarray:
 
 
 def compute_pad(iTList, op) -> np.ndarray:
-    """Pad last 2 dims of input tensor.
+    """Pad input tensor.
 
-    iTList[0] = data (N, C, H, W)
-    iTList[1] = pads (4,)  [H_begin, W_begin, H_end, W_end]
+    iTList[0] = data (N, C, H, W) or other rank
+    iTList[1] = pads — 4 values [H_begin, W_begin, H_end, W_end] for last-2-dim
+                padding, or 2*rank values [d0_begin, ..., dN_begin, d0_end, ..., dN_end]
+                for arbitrary-dim padding.
     """
     X = iTList[0].data
     pads = [int(x) for x in iTList[1].data.tolist()]
@@ -2255,8 +2257,16 @@ def compute_pad(iTList, op) -> np.ndarray:
     value = op.attrs.get('value', 0)
 
     rank = X.ndim
-    pad_before = [0] * (rank - 2) + pads[:2]
-    pad_after = [0] * (rank - 2) + pads[2:]
+    if len(pads) == 4:
+        pad_before = [0] * (rank - 2) + pads[:2]
+        pad_after = [0] * (rank - 2) + pads[2:]
+    elif len(pads) == 2 * rank:
+        pad_before = list(pads[:rank])
+        pad_after = list(pads[rank:])
+    else:
+        raise ValueError(
+            f"compute_pad: pads length {len(pads)} != 4 or 2*rank (2*{rank})"
+        )
     pad_widths = [(pb, pa) for pb, pa in zip(pad_before, pad_after)]
 
     if mode == 'constant':

--- a/ttsim/ops/desc/math.py
+++ b/ttsim/ops/desc/math.py
@@ -578,6 +578,42 @@ def matmul_shape_inf(iTList, oTList, op, **kwargs):
     from ttsim.ops.desc.helpers import bidirectional_broadcast_shape_inference
     from .data_compute import compute_matmul
 
+    # 1×1 conv lowered to MatMul: conv2d_pp injects kernel_shape=[1,1] into attrs.
+    # Apply NCHW conv shape inference so downstream ops see [N, C_out, H_out, W_out].
+    if op.attrs.get('kernel_shape') == [1, 1]:
+        assert iTList[0].check_shape(), 'MatMul(1×1-conv): input shape undefined'
+        assert iTList[1].check_shape(), 'MatMul(1×1-conv): weight shape undefined'
+        N, C_in, H_in, W_in = iTList[0].shape
+        C_out = iTList[1].shape[0]
+        strides = op.attrs.get('strides', [1, 1])
+        H_out = (H_in - 1) // strides[0] + 1
+        W_out = (W_in - 1) // strides[1] + 1
+        out_shape = [N, C_out, H_out, W_out]
+        oTList[0].shape = out_shape
+        oTList[0].dtype = iTList[0].dtype
+        oTList[0].data = None
+        from ttsim.ops.tensor import nchw_to_nhwc_flat
+        oTList[0].hw_shape = nchw_to_nhwc_flat(out_shape)
+        in_elems = sum(t.nelems() for t in iTList)
+        in_bytes = sum(t.nbytes(op.precision) for t in iTList)
+        out_elems = oTList[0].nelems()
+        # Local name (not `instrs`) to avoid colliding with the matmul-path
+        # ``instrs: dict = {...}`` annotation later in this function.
+        instrs_1x1 = {'mac': out_elems * C_in}
+        # conv2d_pp always passes a bias as 3rd input (None-bias is materialised
+        # upstream), so the 1×1-conv MatMul always performs an output-shaped
+        # element-wise add. Mirror the normal matmul path's `if len(iTList) > 2`
+        # accounting so analytical fallback / instr-count consumers see the
+        # full work.
+        if len(iTList) > 2:
+            instrs_1x1['add'] = out_elems
+        op.perf_stats = {
+            'inElems': in_elems, 'outElems': out_elems,
+            'inBytes': in_bytes, 'outBytes': oTList[0].nbytes(op.precision),
+            'instrs': instrs_1x1,
+        }
+        return
+
     A, B = iTList[0], iTList[1]
     assert A.check_shape(), f"Input tensor-A shape not defined: {A}"
     assert B.check_shape(), f"Input tensor-B shape not defined: {B}"

--- a/ttsim/ops/desc/nn.py
+++ b/ttsim/ops/desc/nn.py
@@ -269,6 +269,12 @@ def maxpool_sinf(iTList, oTList, op, **kwargs):
         oTList[1].shape = output_shape
         oTList[1].dtype = np.dtype(np.int64)
 
+    # Propagate NHWC-flattened hw_shape through MaxPool so downstream conv/halo LUT keys
+    # use the correct [1, 1, N*H_out*W_out, C] format rather than the NCHW fallback.
+    if len(output_shape) == 4:
+        from ttsim.ops.tensor import nchw_to_nhwc_flat
+        oTList[0].hw_shape = nchw_to_nhwc_flat(output_shape)
+
     # Compute actual data if inputs have data
     from ttsim.ops.desc.data_compute import try_compute_data, compute_maxpool2d
     oTList[0].data = try_compute_data(compute_maxpool2d, iTList, op)
@@ -415,6 +421,19 @@ def conv_transpose_sinf(iTList, oTList, op, **kwargs):
     output_shape = [N, C_out, H_out, W_out]
     oTList[0].shape = output_shape
     oTList[0].dtype = X.dtype
+    # Set hw_shape for 2-D spatial conv_transpose (same NHWC-flattened convention as conv_sinf).
+    from ttsim.ops.tensor import nchw_to_nhwc_flat
+    from ttsim.front.ttnn.tensor import DataType, Layout
+    oTList[0].hw_shape = nchw_to_nhwc_flat(output_shape)
+    # Hardware pre-processes weights to [1, 1, C_in*kH*kW, C_out] BFLOAT8_B TILE DRAM.
+    # Use _hw_dtype/_hw_layout (not _ttnn_dtype/layout) to avoid propagation into activations.
+    W.hw_shape = [1, 1, C_in_w * kH * kW, C_out]
+    W._hw_dtype = DataType.BFLOAT8_B
+    W._hw_layout = Layout.TILE_LAYOUT
+    if B is not None:
+        B.hw_shape = [1, 1, 1, C_out]
+        B._hw_dtype = DataType.BFLOAT8_B
+        B._hw_layout = Layout.TILE_LAYOUT
 
     # Compute actual data if inputs have data
     from ttsim.ops.desc.data_compute import try_compute_data, compute_conv_transpose2d
@@ -480,10 +499,13 @@ def conv_sinf(iTList, oTList, op, **kwargs):
         raise ValueError("Dilations, strides, and pads must match spatial dimensions")
     if group <= 0 or X.shape[1] % group != 0:
         raise ValueError(f"C_in {X.shape[1]} must be divisible by group {group}")
-    if W.shape[1] != X.shape[1] // group:
+    if W.shape[1] > X.shape[1] // group:
         raise ValueError(
-            f"Weight C_in/group {W.shape[1]} must match input C_in/group {X.shape[1] // group}"
+            f"Weight C_in/group {W.shape[1]} exceeds input C_in/group {X.shape[1] // group}"
         )
+    # Allow X.shape[1] > W.shape[1] * group: hardware pads input C for memory
+    # alignment (e.g. VGG UNet C=3 → C=16); the kernel slices only weight C_in
+    # channels, and the LUT records weight at its original (unpadded) C_in.
     if len(iTList) == 3:
         if B.rank() != 1 or B.shape[0] != W.shape[0]:
             raise ValueError(
@@ -557,8 +579,27 @@ def conv_sinf(iTList, oTList, op, **kwargs):
     oTList[0].shape = output_shape
     oTList[0].dtype = X.dtype
 
-    macs_per_output = (C_in // group) * np.prod(kernel_dims)
-    output_elements = N * C_out * np.prod(spatial_dims)
+    # Set hw_shape for 2-D spatial conv (NCHW → [1, 1, N*H*W, C] on hardware).
+    # 1-D / 3-D spatial convolutions do not use this layout so hw_shape is left None.
+    if num_spatial_dims == 2:
+        from ttsim.ops.tensor import nchw_to_nhwc_flat
+        from ttsim.front.ttnn.tensor import DataType, Layout
+        oTList[0].hw_shape = nchw_to_nhwc_flat(output_shape)
+        # Hardware pre-processes weights to [1, 1, kernel_C_in*kH*kW, C_out] BFLOAT8_B TILE DRAM.
+        # Use W.shape[1] (weight's own C_in/group) rather than X.shape[1]//group so the LUT
+        # key matches when input C is padded above weight C (VGG UNet entry: input C=16,
+        # weight C_in=3 → weight hw_shape = 3*3*3 = 27 in the LUT).
+        kH_int, kW_int = int(kernel_dims[0]), int(kernel_dims[1])
+        W.hw_shape = [1, 1, int(W.shape[1]) * kH_int * kW_int, C_out]
+        W._hw_dtype = DataType.BFLOAT8_B
+        W._hw_layout = Layout.TILE_LAYOUT
+        if len(iTList) == 3:
+            B.hw_shape = [1, 1, 1, C_out]
+            B._hw_dtype = DataType.BFLOAT8_B
+            B._hw_layout = Layout.TILE_LAYOUT
+
+    macs_per_output = int(W.shape[1]) * np.prod(kernel_dims)
+    output_elements = N * C_out * np.prod(output_spatial)
     total_macs = output_elements * macs_per_output
     instr_count = {"mac": int(total_macs)}
     if len(iTList) == 3:

--- a/ttsim/ops/desc/tensor.py
+++ b/ttsim/ops/desc/tensor.py
@@ -210,21 +210,11 @@ def pad_sinf(iTList, oTList, op, **kwargs):
         pad_before = [0] * (rank - 2) + [h_beg, w_beg]
         pad_after  = [0] * (rank - 2) + [h_end, w_end]
     elif len(pads) == 2 * rank:
-        before_all = pads[:rank]
-        after_all  = pads[rank:]
-
-        # We only support padding on the last 2 dims; earlier pads must be zero.
-        if any(before_all[i] != 0 or after_all[i] != 0 for i in range(rank - 2)):
-            raise AssertionError(
-                f"Pad supports only last 2 dims; got non-zero pads={pads} for rank={rank}"
-            )
-
-        pad_before = [0] * (rank - 2) + before_all[-2:]
-        pad_after  = [0] * (rank - 2) + after_all[-2:]
+        pad_before = list(pads[:rank])
+        pad_after  = list(pads[rank:])
     else:
         raise AssertionError(
-            f"pads length {len(pads)} != 4 or 2*rank (2*{rank}) "
-            "(Pad supports only last 2 dims)"
+            f"pads length {len(pads)} != 4 or 2*rank (2*{rank})"
         )
 
     output_shape = [
@@ -555,6 +545,17 @@ def concat_sinf(iTList, oTList, op, **kwargs):
     oshape[axis]  = sum(x.shape[axis] for x in iTList)
     oTList[0].shape = oshape
     oTList[0].dtype = iTList[0].dtype
+
+    # Propagate hw_shape when all inputs carry one and we're concatenating along
+    # the NCHW channel axis (axis=1).  For channel-concat: hw_shape is [1, 1, N*H*W, C]
+    # so we sum the last dim (C) across inputs.  Spatial-axis concat is not representable
+    # in the flattened hw_shape format, so hw_shape is left None for those cases.
+    # TODO: if spatial-axis concat becomes LUT-relevant, rethink the hw_shape convention.
+    if axis == 1 and base_rank == 4:
+        hw_shapes = [getattr(x, 'hw_shape', None) for x in iTList]
+        if all(hw is not None for hw in hw_shapes):
+            total_c = sum(hw[3] for hw in hw_shapes)  # type: ignore[index]
+            oTList[0].hw_shape = [hw_shapes[0][0], hw_shapes[0][1], hw_shapes[0][2], total_c]  # type: ignore[index]
 
     # Compute data if inputs have data
     from ttsim.ops.desc.data_compute import try_compute_data, compute_concat

--- a/ttsim/ops/desc/ttsim_layout.py
+++ b/ttsim/ops/desc/ttsim_layout.py
@@ -5,7 +5,7 @@
 """
 Layout, shard, and transformer head op descriptors:
   Tilize, Untilize, TilizeWithValPadding, UntilizeWithUnpadding,
-  InterleavedToSharded, ShardedToInterleaved, Reshard,
+  InterleavedToSharded, ShardedToInterleaved, Reshard, Halo, Move,
   ConcatHeads, CreateQKVHeads.
 Used by the TTNN front-end tracking-only operator APIs (*_op helpers) in ttnn_shim.
 """
@@ -18,6 +18,51 @@ TILE_WIDTH = 32
 
 # SimOp domain for layout ops (TTNN / device kernel names; not standard ONNX opset).
 _TTNN_OP_DOMAIN = "com.tenstorrent.ttnn"
+
+# ---------------------------------------------------------------------------
+# Halo geometry: physical halo-extended Y dimension lookup table.
+#
+# Key: (NHW, C, kH, kW, pH, pW, is_transpose)
+#   NHW         = N * H * W  (logical spatial volume from NCHW input shape)
+#   C           = channel count
+#   kH, kW      = kernel height/width
+#   pH, pW      = padding height/width
+#   is_transpose= True for conv_transpose2d (SlidingWindowConfig is_transpose flag)
+#
+# Value: halo_ext_y = max_out_nsticks_per_core × num_cores_nhw
+#
+# Source: VGG UNet WH profiler trace (2026-04-23); shape verified against
+# SlidingWindowConfig ATTRIBUTES in HaloDeviceOperation profiler rows.
+# MaxPool 2×2 (is_transpose=False, kH=kW=2, pH=pW=0) is intentionally absent:
+# no border-pixel exchange is needed for non-overlapping strides, so the halo
+# buffer equals the input (pass-through).
+# ---------------------------------------------------------------------------
+_HALO_EXT_Y: dict[tuple[int, int, int, int, int, int, bool], int] = {
+    # --- Regular 3×3 conv, pad=1, stride=1 ---
+    # Stage 1 (256×256, NHW=65536)
+    (65536, 16,  3, 3, 1, 1, False): 99072,
+    (65536, 64,  3, 3, 1, 1, False): 99072,
+    (65536, 128, 3, 3, 1, 1, False): 99072,
+    # Stage 2 (128×128, NHW=16384)
+    (16384, 64,  3, 3, 1, 1, False): 33280,
+    (16384, 128, 3, 3, 1, 1, False): 33280,
+    (16384, 256, 3, 3, 1, 1, False): 33280,
+    # Stage 3 (64×64, NHW=4096)
+    (4096,  128, 3, 3, 1, 1, False): 12672,
+    (4096,  256, 3, 3, 1, 1, False): 5280,
+    (4096,  512, 3, 3, 1, 1, False): 5280,
+    # Stage 4 (32×32, NHW=1024)
+    (1024,  256,  3, 3, 1, 1, False): 1632,
+    (1024,  512,  3, 3, 1, 1, False): 1632,
+    (1024,  1024, 3, 3, 1, 1, False): 1632,
+    # Bottleneck (16×16, NHW=256)
+    (256,   512,  3, 3, 1, 1, False): 576,
+    # --- ConvTranspose 2×2, pad=0, stride=2 (decoder upsampling) ---
+    (256,   512, 2, 2, 0, 0, True): 1320,
+    (1024,  512, 2, 2, 0, 0, True): 4680,
+    (4096,  256, 2, 2, 0, 0, True): 24768,
+    (16384, 128, 2, 2, 0, 0, True): 82240,
+}
 
 
 # Per-arch overrides to ``_HALO_EXT_Y``. The base table is empirical (WH n150 trace);
@@ -229,6 +274,7 @@ def interleaved_to_sharded_sinf(iTList, oTList, op, **kwargs):
     )
     oTList[0].shape = list(in_shape)
     oTList[0].dtype = X.dtype
+    oTList[0].hw_shape = getattr(X, 'hw_shape', None)  # propagate NHWC-flattened hw shape
 
     elem_size = op.attrs.get('element_size', 2)
     elems = _nelems(in_shape)
@@ -252,6 +298,7 @@ def sharded_to_interleaved_sinf(iTList, oTList, op, **kwargs):
     )
     oTList[0].shape = list(in_shape)
     oTList[0].dtype = X.dtype
+    oTList[0].hw_shape = getattr(X, 'hw_shape', None)  # propagate NHWC-flattened hw shape
 
     elem_size = op.attrs.get('element_size', 2)
     elems = _nelems(in_shape)
@@ -275,6 +322,7 @@ def reshard_sinf(iTList, oTList, op, **kwargs):
     )
     oTList[0].shape = list(in_shape)
     oTList[0].dtype = X.dtype
+    oTList[0].hw_shape = getattr(X, 'hw_shape', None)  # propagate NHWC-flattened hw shape
 
     elem_size = op.attrs.get('element_size', 2)
     elems = _nelems(in_shape)
@@ -372,6 +420,113 @@ def nlp_create_qkv_heads_sinf(iTList, oTList, op, **kwargs):
     return
 
 
+def _halo_ext_y(in_shape: list[int], attrs: dict) -> 'int | None':
+    """Look up the halo-extended Y dimension from _HALO_EXT_Y.
+
+    ``in_shape`` is the NCHW logical shape [N, C, H, W] of the Halo input.
+    ``attrs`` contains 'kernel_size', 'padding', and 'is_transpose' set by
+    ``_with_halo`` in ``ttsim/front/ttnn/op.py``.
+
+    Returns the extended Y (= max_out_nsticks_per_core × num_cores_nhw) or
+    None when the combination is not in the table (e.g. MaxPool 2×2).
+    """
+    if len(in_shape) < 4:
+        return None
+    N, C, H, W = in_shape[0], in_shape[1], in_shape[2], in_shape[3]
+    nhw = N * H * W
+
+    ks = attrs.get('kernel_size')
+    pad = attrs.get('padding')
+    is_tp = bool(attrs.get('is_transpose', False))
+    if ks is None or pad is None:
+        return None
+
+    kH = int(ks[0]) if hasattr(ks, '__getitem__') else int(ks)
+    kW = int(ks[1]) if hasattr(ks, '__getitem__') else int(ks)
+    pH = int(pad[0]) if hasattr(pad, '__getitem__') else int(pad)
+    pW = int(pad[1]) if hasattr(pad, '__getitem__') else int(pad)
+
+    return _HALO_EXT_Y.get((nhw, C, kH, kW, pH, pW, is_tp))
+
+
+def halo_sinf(iTList, oTList, op, **kwargs):
+    """Shape inference for Halo: logical shape passthrough with halo-extended hw_shape.
+
+    The logical tensor shape is unchanged (halo extraction is transparent to
+    the compute graph).  The hardware physical buffer grows by shard-border
+    overlap rows; ``hw_shape`` is set to [1, 1, halo_ext_y, C] so that
+    downstream Conv/Move LUT keys match the hardware profiler's recorded shapes.
+
+    When ``op.attrs`` carries 'kernel_size', 'padding', and 'is_transpose'
+    (set by ``_with_halo`` in ``op.py``), the extended Y is looked up in
+    ``_HALO_EXT_Y``.  If the combination is absent (e.g. MaxPool 2×2 pass-through),
+    the pre-halo hw_shape is propagated unchanged.
+    """
+    assert len(iTList) == 1 and len(oTList) == 1
+    X = iTList[0]
+    in_shape = require_shape_list(
+        X.shape,
+        "Halo shape inference: input tensor shape must be known",
+    )
+    oTList[0].shape = list(in_shape)
+    oTList[0].dtype = X.dtype
+
+    attrs = getattr(op, 'attrs', None) or {}
+    elem_size = op.attrs.get('element_size', 2)
+    elems = _nelems(in_shape)  # logical NCHW element count (inElems)
+
+    ext_y = _halo_ext_y(in_shape, attrs)
+    if ext_y is not None:
+        # Halo extracts beyond the logical NCHW input — the output buffer
+        # carries the halo-extended physical layout [1, 1, ext_y, C].
+        # outElems must reflect this physical buffer so memory-traffic / util
+        # estimates from analytical fallback are consistent with hw_shape.
+        C = in_shape[1]  # NCHW channel dim
+        oTList[0].hw_shape = [1, 1, ext_y, C]
+        out_elems = ext_y * C
+    else:
+        oTList[0].hw_shape = getattr(X, 'hw_shape', None)
+        out_elems = elems  # logical passthrough
+
+    op.perf_stats = {
+        'inElems': elems,
+        'outElems': out_elems,
+        'inBytes': elems * elem_size,
+        'outBytes': out_elems * elem_size,
+        'instrs': {'mov': out_elems},
+    }
+    return
+
+
+def move_sinf(iTList, oTList, op, **kwargs):
+    """Shape inference for Move: logical shape passthrough.
+
+    MoveDeviceOperation copies the activation buffer to a new memory region
+    (triggered by deallocate_activation=True in conv args).  The logical
+    tensor shape and dtype are unchanged; cost is two memory transfers.
+    """
+    assert len(iTList) == 1 and len(oTList) == 1
+    X = iTList[0]
+    in_shape = require_shape_list(
+        X.shape,
+        'Move shape inference: input tensor shape must be known',
+    )
+    oTList[0].shape = list(in_shape)
+    oTList[0].dtype = X.dtype
+    oTList[0].hw_shape = getattr(X, 'hw_shape', None)  # propagate NHWC-flattened hw shape
+
+    elem_size = op.attrs.get('element_size', 2)
+    elems = _nelems(in_shape)
+    op.perf_stats = {
+        'inElems': elems,
+        'outElems': elems,
+        'inBytes': elems * elem_size,
+        'outBytes': elems * elem_size,
+        'instrs': {'mov': elems},
+    }
+    return
+
+
 def register_layout_ops():
     d = _TTNN_OP_DOMAIN
     _optbl = [
@@ -382,6 +537,8 @@ def register_layout_ops():
         ['InterleavedToSharded', 'ARITY_1->1', d, 'COMMON', 24, 21, 1, 1, 1, 1, interleaved_to_sharded_sinf, True, True, True, True, True],
         ['ShardedToInterleaved', 'ARITY_1->1', d, 'COMMON', 24, 21, 1, 1, 1, 1, sharded_to_interleaved_sinf, True, True, True, True, True],
         ['Reshard', 'ARITY_1->1', d, 'COMMON', 24, 21, 1, 1, 1, 1, reshard_sinf, True, True, True, True, True],
+        ['Halo', 'ARITY_1->1', d, 'COMMON', 24, 21, 1, 1, 1, 1, halo_sinf, True, True, True, True, True],
+        ['Move', 'ARITY_1->1', d, 'COMMON', 24, 21, 1, 1, 1, 1, move_sinf, True, True, True, True, True],
         ['ConcatHeads', 'ARITY_1->1', d, 'COMMON', 24, 21, 1, 1, 1, 1, nlp_concat_heads_sinf, True, True, True, True, True],
         ['CreateQKVHeads', 'ARITY_VARIADIC[1-2]->3', d, 'COMMON', 24, 21, 2, 1, 3, 3, nlp_create_qkv_heads_sinf, True, True, True, True, True],
     ]

--- a/ttsim/ops/tensor.py
+++ b/ttsim/ops/tensor.py
@@ -117,6 +117,22 @@ def require_shape_list(shape: Optional[Any], msg: str = "shape must be set") -> 
     return _coerce_shape_to_list(shape)
 
 
+def nchw_to_nhwc_flat(shape: list[int]) -> list[int]:
+    """Convert NCHW [N, C, H, W] to hardware NHWC-flattened [1, 1, N*H*W, C].
+
+    Tenstorrent hardware stores activations as [1, 1, N*H*W, C] (spatial dims
+    folded into rows, channels last).  This hw_shape drives LUT key construction
+    and profiler-shape comparison; the logical NCHW shape is kept in tensor.shape.
+
+    Only valid for rank-4 NCHW inputs with 2 spatial dims.
+
+    TODO: extend for rank-5 (3-D conv) if needed.
+    """
+    assert len(shape) == 4, f'nchw_to_nhwc_flat: expected rank-4 NCHW, got {shape}'
+    N, C, H, W = shape
+    return [1, 1, N * H * W, C]
+
+
 class SimTensor:
     def __init__(self, cfg):
         self.name        = cfg['name']                # String

--- a/ttsim/stats/hlmstats.py
+++ b/ttsim/stats/hlmstats.py
@@ -141,7 +141,15 @@ def save_data(model: BaseModel, filename, outputfmt: OutputFormat)->None:
             pickle.dump(model, foutbin)
 
 def format_tensor_for_stats(tensor, shape_override=None) -> str:
-    """Format a single tensor as name[dim1xdim2xdim3]:precision for stats output.
+    """Format a single tensor as name[dim1xdim2xdim3{|hw:dim1xdim2}]:precision for stats output.
+
+    The optional ``|hw:`` suffix encodes the hardware NHWC-flattened shape
+    (tensor.hw_shape) alongside the logical NCHW shape. This suffix is
+    **diagnostic-only**: it appears in the raw stats CSV for human / post-hoc
+    inspection but is NOT consumed by downstream layer-comparison tooling.
+    ``show_layers_polaris._parse_tensor_fields`` strips it before returning
+    shapes, so compare_layers (and anything else built on layers_polaris) sees
+    only the logical NCHW shape.
 
     Args:
         tensor: The tensor to format.
@@ -165,10 +173,16 @@ def format_tensor_for_stats(tensor, shape_override=None) -> str:
         precision = tensor.dtype.lower()
     else:
         precision = str(tensor.dtype).lower()
-    if shape:
-        shape_str = 'x'.join(str(d) for d in shape)
-        return f"{name}[{shape_str}]:{precision}"
-    return f"{name}[]:{precision}"
+    shape_str = 'x'.join(str(d) for d in shape) if shape else ''
+    # Append hw_shape (NHWC-flattened) as a `|hw:` suffix for diagnostic
+    # visibility in the raw stats CSV. The suffix is stripped by
+    # ``show_layers_polaris._parse_tensor_fields`` before downstream tooling
+    # sees the shape — see ``format_tensor_for_stats`` docstring for details.
+    hw_shape = getattr(tensor, 'hw_shape', None)
+    if hw_shape is not None:
+        hw_str = 'x'.join(str(d) for d in hw_shape)
+        shape_str = f'{shape_str}|hw:{hw_str}'
+    return f'{name}[{shape_str}]:{precision}'
 
 class HLMStats:
     def __init__(self, _dev, _wlgraph, _wlinfo, _sinfo):

--- a/workloads/ttnn/vgg_unet/bh/__init__.py
+++ b/workloads/ttnn/vgg_unet/bh/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0

--- a/workloads/ttnn/vgg_unet/bh/test_vgg_unet_device_perf_bh.py
+++ b/workloads/ttnn/vgg_unet/bh/test_vgg_unet_device_perf_bh.py
@@ -1,0 +1,211 @@
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import os
+import sys
+
+sys.path.append('.')
+
+IS_POLARIS = os.getenv('IRD_ARCH_NAME', '') == ''
+
+from loguru import logger  # noqa: E402
+
+if not IS_POLARIS:
+    import time  # noqa: E402
+    import torch  # type: ignore[import-not-found]  # noqa: E402
+    import ttnn  # type: ignore[no-redef, import]  # noqa: E402
+    from models.demos.vision.segmentation.vgg_unet.common.runner.performant_runner import (  # type: ignore[import]  # noqa: E402
+        VggUnetTrace2CQ,
+    )
+    from models.perf.device_perf_utils import (  # type: ignore[import]  # noqa: E402
+        check_device_perf,
+        prep_device_perf_report,
+        run_device_perf,
+    )
+else:
+    import ttsim.front.ttnn as ttnn  # type: ignore[no-redef]
+    import ttsim.front.ttnn.minitorch_shim as torch  # type: ignore[no-redef]
+    from workloads.ttnn.vgg_unet.bh.vgg_unet_test_infra_polaris_bh import VggUnetTrace2CQ  # type: ignore[no-redef]
+
+
+# ---------------------------------------------------------------------------
+# run_vgg_unet_e2e — mirrors run_vgg_unet_e2e from test_e2e_performant.py
+# ---------------------------------------------------------------------------
+
+def run_vgg_unet_e2e(device, batch_size: int = 1):
+    # `batch_size` matches the (device, batch_size)->device contract documented on
+    # run_device_perf_polaris; pass-through to the inner trace as device_batch_size.
+    vgg_unet_trace_2cq = VggUnetTrace2CQ()
+    vgg_unet_trace_2cq.initialize_vgg_unet_trace_2cqs_inference(
+        device,
+        model_location_generator=None,
+        device_batch_size=batch_size,
+    )
+
+    if not IS_POLARIS:
+        batch_size = batch_size * device.get_num_devices()
+        input_shape = (batch_size, 3, 256, 256)
+        torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+        inference_iter_count = 3
+        t0 = time.time()
+        for _ in range(inference_iter_count):
+            output = vgg_unet_trace_2cq.run(torch_input_tensor)
+        ttnn.synchronize_device(device)
+        t1 = time.time()
+        vgg_unet_trace_2cq.release_vgg_unet_trace_2cqs_inference()
+        inference_time_avg = round((t1 - t0) / inference_iter_count, 6)
+        logger.info(
+            f'ttnn_vgg_unet_256x256_batch_size_{batch_size}. '
+            f'One inference iteration time (sec): {inference_time_avg}, '
+            f'FPS: {round(batch_size / inference_time_avg)}'
+        )
+    else:
+        output = vgg_unet_trace_2cq.run()
+        vgg_unet_trace_2cq.release_vgg_unet_trace_2cqs_inference()
+        output_torch = ttnn.to_torch(output)
+        expected_shape = [batch_size, 1, 256, 256]
+        assert output_torch.shape == expected_shape, (
+            f'Expected output shape {expected_shape}, but got {output_torch.shape}'
+        )
+        logger.info(f'run_vgg_unet_e2e: obtained expected output shape {expected_shape}')
+
+    return device
+
+
+def run_vgg_unet_e2e_entry(wlname: str, device: ttnn.device.Device, cfg: dict):
+    batch_size = cfg.get('bs', 1)
+    return run_vgg_unet_e2e(device, batch_size=batch_size)
+
+
+def run_vgg_unet_perf_device(wlname: str, device: ttnn.device.Device, cfg: dict):
+    """Workload-yaml entry point for analytical device perf reporting (BH).
+
+    Builds the graph on the polproj-provided *device* (so polproj's back-end
+    pipeline can run its own stats), and also produces a standalone JSON perf
+    report via the Polaris analytical path.
+    """
+    batch_size = cfg.get('bs', 1)
+    run_vgg_unet_e2e(device, batch_size=batch_size)
+    test_vgg_unet_perf_device(batch_size=batch_size)
+
+
+# ---------------------------------------------------------------------------
+# test_vgg_unet_perf_device — dual-mode device profiling
+# HW path: Tracy via subprocess wrapping test_e2e_performant.py.
+# Polaris path: analytical projection via run_device_perf_polaris (BH arch).
+# ---------------------------------------------------------------------------
+
+def test_vgg_unet_perf_device(batch_size: int = 1, expected_kernel_samples_per_sec: int = 320):
+    cols = ['DEVICE FW', 'DEVICE KERNEL', 'DEVICE BRISC KERNEL']
+
+    if IS_POLARIS:
+        from workloads.common.polaris_device_perf import (
+            run_device_perf_polaris,
+            prep_device_perf_report_polaris,
+        )
+
+        post_processed_results = run_device_perf_polaris(
+            test_fn=run_vgg_unet_e2e,
+            batch_size=batch_size,
+            cols=cols,
+            archspec='config/tt_bh.yaml',
+            devname='p100a',
+        )
+        prep_device_perf_report_polaris(
+            model_name=f'vgg-unet-bh-{batch_size}',
+            batch_size=batch_size,
+            post_processed_results=post_processed_results,
+        )
+        return
+
+    command = (
+        f'pytest models/demos/vision/segmentation/vgg_unet/blackhole/tests/perf/'
+        f'test_e2e_performant.py::test_vgg_unet_e2e[{batch_size}-device_params0]'
+    )
+
+    inference_time_key = 'AVG DEVICE KERNEL SAMPLES/S'
+    # BH: num_iterations=2 to mitigate timeout (consistent with BH ViT pattern).
+    post_processed_results = run_device_perf(
+        command, subdir='vgg_unet', num_iterations=2, cols=cols, batch_size=batch_size,
+    )
+
+    expected_results = check_device_perf(
+        post_processed_results,
+        margin=0.03,
+        expected_perf_cols={inference_time_key: expected_kernel_samples_per_sec},
+        # BH HW retains assert_on_fail=False from the original BH device-perf test.
+        assert_on_fail=False,
+    )
+    prep_device_perf_report(
+        model_name=f'vgg-unet-bh-{batch_size}',
+        batch_size=batch_size,
+        post_processed_results=post_processed_results,
+        expected_results=expected_results,
+        comments='',
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry and CLI
+# ---------------------------------------------------------------------------
+
+_STANDALONE_RUN_SPECS: list[tuple[str, object, str]] = [
+    ('e2e', run_vgg_unet_e2e_entry, 'vgg-unet-bh-e2e'),
+]
+
+_STANDALONE_VALID_SHORT_NAMES = frozenset(s[0] for s in _STANDALONE_RUN_SPECS)
+
+
+def run_one(callback, wlname: str, cfg: dict):
+    if IS_POLARIS:
+        from ttsim.front.ttnn.device import close_device, open_device
+        device = open_device()
+    else:
+        from ttnn import close_device, open_device  # type: ignore[no-redef]
+        device = open_device(device_id=0, l1_small_size=32768, trace_region_size=6434816, num_command_queues=2)
+    callback(wlname, device, cfg)
+    close_device(device)
+
+
+def standalone(test_name: str | None = None) -> None:
+    """Run standalone BH e2e VGG UNet tests, or a single test by short name."""
+    all_names = _STANDALONE_VALID_SHORT_NAMES | {'device-perf'}
+
+    if test_name == 'device-perf':
+        test_vgg_unet_perf_device()
+        return
+
+    if test_name is None:
+        for _short, fn, wlname in _STANDALONE_RUN_SPECS:
+            run_one(fn, wlname, {})
+        return
+    if test_name not in all_names:
+        valid = ', '.join(sorted(all_names))
+        logger.error(f'Unknown test {test_name}. Valid names: {valid}')
+        sys.exit(1)
+    for short, fn, wlname in _STANDALONE_RUN_SPECS:
+        if short == test_name:
+            run_one(fn, wlname, {})
+            return
+
+
+if __name__ == '__main__':
+    logger.remove()
+    logger.add(sys.stdout, level='INFO')
+    parser = argparse.ArgumentParser(
+        description='Run VGG UNet (Blackhole) e2e standalone tests.'
+    )
+    parser.add_argument(
+        'test',
+        nargs='?',
+        metavar='TEST',
+        default='e2e',
+        help=(
+            'Run only this test by short name, '
+            'e.g. e2e, device-perf. If omitted, runs e2e.'
+        ),
+    )
+    _args = parser.parse_args()
+    standalone(_args.test)

--- a/workloads/ttnn/vgg_unet/bh/vgg_unet_test_infra_polaris_bh.py
+++ b/workloads/ttnn/vgg_unet/bh/vgg_unet_test_infra_polaris_bh.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Polaris-side equivalent of vgg_unet_test_infra.py from tt-metal (BH variant).
+
+Provides ``create_test_infra`` with the same interface so that
+``test_vgg_unet_device_perf_bh.py`` can run in dual-mode.
+"""
+
+import ttsim.front.ttnn as ttnn
+import ttsim.front.ttnn.minitorch_shim as torch  # type: ignore[no-redef]
+
+from ttsim.front.ttnn.device import set_default_device
+from ttsim.front.ttnn.tensor import ttnn_random
+from ttsim.front.ttnn.buffer import BufferType, TensorMemoryLayout
+from ttsim.front.ttnn.memory import MemoryConfig
+
+from workloads.ttnn.vgg_unet.common.model_preprocessing import create_vgg_unet_model_parameters
+from workloads.ttnn.vgg_unet.common.ttnn_vgg_unet import Tt_vgg_unet
+
+
+class VggUnetTestInfra:
+    """Polaris mirror of the upstream VggUnetTestInfra (BH variant).
+
+    Builds synthetic parameters and a random [B, 3, 256, 256] input tensor.
+    The model is the polaris-native ``Tt_vgg_unet`` which expects NCHW input
+    and returns a segmentation mask of shape [B, 1, 256, 256].
+    """
+
+    def __init__(
+        self,
+        device,
+        batch_size,
+        inputs_mesh_mapper=None,
+        weights_mesh_mapper=None,
+        output_mesh_composer=None,
+        use_random_input_tensor: bool = False,
+        model_location_generator=None,
+    ):
+        torch.manual_seed(0)
+        set_default_device(device)
+
+        self.device = device
+        self.batch_size = batch_size
+
+        parameters = create_vgg_unet_model_parameters(device)
+        self.model = Tt_vgg_unet(device, parameters, parameters.conv_args)
+
+        self.torch_input = ttnn_random(
+            (batch_size, 3, 256, 256), -1, 1, dtype=torch.bfloat16,
+        )
+        self.input_tensor = None
+
+    def setup_l1_sharded_input(self, device, torch_input=None, mesh_mapper=None, mesh_composer=None):
+        if torch_input is None:
+            torch_input = self.torch_input
+        tt_inputs_host = ttnn.from_torch(
+            torch_input, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        input_mem_config = MemoryConfig(TensorMemoryLayout.HEIGHT_SHARDED, BufferType.L1)
+        return tt_inputs_host, input_mem_config
+
+    def setup_dram_sharded_input(self, device, _torch_input_tensor=None, mesh_mapper=None, mesh_composer=None):
+        tt_inputs_host, input_mem_config = self.setup_l1_sharded_input(
+            device, mesh_mapper=mesh_mapper, mesh_composer=mesh_composer,
+        )
+        sharded_mem_config_DRAM = MemoryConfig.DRAM
+        return tt_inputs_host, sharded_mem_config_DRAM, input_mem_config
+
+    def run(self, tt_input_tensor=None):
+        self.output_tensor = None
+        input_tensor = tt_input_tensor if tt_input_tensor is not None else self.input_tensor
+        self.output_tensor = self.model(input_tensor)
+        return self.output_tensor
+
+
+def create_test_infra(
+    device,
+    batch_size,
+    inputs_mesh_mapper=None,
+    weights_mesh_mapper=None,
+    output_mesh_composer=None,
+    use_random_input_tensor: bool = False,
+    model_location_generator=None,
+):
+    return VggUnetTestInfra(
+        device,
+        batch_size,
+        inputs_mesh_mapper,
+        weights_mesh_mapper,
+        output_mesh_composer,
+        use_random_input_tensor,
+        model_location_generator=model_location_generator,
+    )
+
+
+class VggUnetTrace2CQ:
+    """Polaris stub matching the interface of ``VggUnetTrace2CQ`` from
+    ``common/runner/performant_runner.py``.
+
+    On polaris there is no 2CQ / trace — initialize just builds the model and
+    prepares the input; run executes one forward pass.
+    """
+
+    def initialize_vgg_unet_trace_2cqs_inference(
+        self, device, model_location_generator=None, device_batch_size=1
+    ):
+        self._infra = create_test_infra(
+            device, device_batch_size, model_location_generator=model_location_generator
+        )
+        tt_inputs_host, _, input_mem_config = self._infra.setup_dram_sharded_input(device)
+        self._infra.input_tensor = ttnn.to_memory_config(tt_inputs_host, input_mem_config)
+
+    def run(self, torch_input_tensor=None):
+        """Run a forward pass and return the output tensor.
+
+        ``torch_input_tensor`` is accepted to match the upstream tt-metal
+        ``VggUnetTrace2CQ.run()`` interface but is currently IGNORED in
+        polaris mode — the input tensor initialised in
+        ``initialize_vgg_unet_trace_2cqs_inference`` is used instead.
+        Polaris doesn't execute kernels, so tensor *values* don't drive
+        the SimOp graph; only the input *shape* matters.
+
+        TODO(honor-input): to honor ``torch_input_tensor`` in polaris mode,
+        extract its shape, rebuild ``self._infra.input_tensor`` via
+        ``ttnn._rand(shape=..., dtype=..., device=...)``, then re-run the
+        to_memory_config path from ``initialize_*``. Leaving as no-op until
+        a real caller exercises this — current polaris test entries pass
+        no ``torch_input_tensor`` (they reuse the pre-init random input).
+        """
+        self._infra.run()
+        return self._infra.output_tensor
+
+    def release_vgg_unet_trace_2cqs_inference(self):
+        pass

--- a/workloads/ttnn/vgg_unet/common/__init__.py
+++ b/workloads/ttnn/vgg_unet/common/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0

--- a/workloads/ttnn/vgg_unet/common/model_preprocessing.py
+++ b/workloads/ttnn/vgg_unet/common/model_preprocessing.py
@@ -1,0 +1,760 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Polaris-side VGG UNet parameter tree (device-free synthetic weights).
+
+Equivalent to the tt-metal ``create_vgg_unet_model_parameters`` but uses
+``ttsim.front.ttnn`` so no physical device is required.  All weight/bias
+tensors are shape stubs — their dtype and shape drive perf modeling; data
+values are irrelevant.
+
+Imported by ``vgg_unet_test_infra_polaris_{wh,bh}.py``.
+"""
+
+import ttsim.front.ttnn as ttnn
+
+
+def create_vgg_unet_model_parameters(device):  # noqa: C901 (complexity)
+    class Parameters:
+        class WeightBias:
+            def __init__(self, w, b):
+                self.weight = w
+                self.bias   = b
+                self.layout = ttnn.Layout.ROW_MAJOR
+                self.dtype  = ttnn.DataType.FLOAT32
+
+        class ConvArgs:
+
+            class DecodeBlockArgs:
+
+                class ConvBlockArgs:
+
+                    class WeightBiasArgs:
+                        def __init__(self, w, b):
+                            self.weight = w
+                            self.bias   = b
+                            self.layout = ttnn.Layout.ROW_MAJOR
+                            self.dtype  = ttnn.DataType.FLOAT32
+                            self.in_channels = None
+                            self.out_channels = None
+                            self.batch_size = None
+                            self.input_height = None
+                            self.input_width = None
+                            self.kernel_size = [3, 3]
+                            self.stride = [1, 1]
+                            self.padding = [1, 1]
+                            self.groups = 1
+                            self.dilation = 1
+                            self.activation = 'relu'
+                            self.shard_layout = None
+                            self.reshard_if_not_optimal = False
+                            self.deallocate_activation = False
+                            self.enable_act_double_buffer = False
+                            self.act_block_h = None
+                            self.do_sharded_to_interleaved = False
+                            # emit_move_before_conv: when False, the Polaris shim
+                            # skips the Move SimOp that would otherwise precede this
+                            # conv when deallocate_activation=True.  Set False at
+                            # positions where the tt-metal profiler shows no Move row
+                            # despite deallocate_activation being True — typically
+                            # because the conv's input buffer is already fresh from a
+                            # producer (Concat post-sharded_concat without an explicit
+                            # STS, or a constant-shape stage that allows buffer reuse).
+                            self.emit_move_before_conv = True
+                        def __setitem__(self, key, value):
+                            setattr(self, key, value)
+
+                    def __init__(self, w1, b1, w2, b2):
+                        self.conv1 = self.WeightBiasArgs(w1, b1)
+                        self.conv2 = self.WeightBiasArgs(w2, b2)
+                    def __setitem__(self, key, value):
+                        setattr(self, key, value)
+
+                class UpArgs:
+                    def __init__(self, w, b):
+                        self.weight = w
+                        self.bias   = b
+                        self.layout = ttnn.Layout.ROW_MAJOR
+                        self.dtype  = ttnn.DataType.FLOAT32
+                        self.in_channels = None
+                        self.out_channels = None
+                        self.batch_size = None
+                        self.input_height = None
+                        self.input_width = None
+                        self.kernel_size = [3, 3]
+                        self.stride = [1, 1]
+                        self.padding = [1, 1]
+                        self.groups = 1
+                        self.dilation = 1
+                        self.shard_layout = None
+                        self.reshard_if_not_optimal = False
+                        self.deallocate_activation = False
+                        self.enable_act_double_buffer = False
+                        self.act_block_h = None
+                        self.output_padding = [0, 0]
+
+                    def __setitem__(self, key, value):
+                        setattr(self, key, value)
+
+                def __init__(self, w, b):
+                    self.up = self.UpArgs(w, b)
+                    self.conv_block = self.ConvBlockArgs(None, None, None, None)
+                    self.conv1 = Parameters.WeightBias(None, None)
+                    self.conv2 = Parameters.WeightBias(None, None)
+
+            class ConvDictArgs:
+                def __init__(self):
+                    self.dtype = ttnn.DataType.BFLOAT16
+                    self.in_channels = None
+                    self.out_channels = None
+                    self.batch_size = None
+                    self.input_height = None
+                    self.input_width = None
+                    self.kernel_size = [3, 3]
+                    self.stride = [1, 1]
+                    self.padding = [1, 1]
+                    self.groups = 1
+                    self.dilation = 1
+                    self.activation = 'relu'
+                    self.shard_layout = None
+                    self.reshard_if_not_optimal = False
+                    self.deallocate_activation = False
+                    self.enable_act_double_buffer = False
+                    self.act_block_h = None
+                    # See WeightBiasArgs.emit_move_before_conv above for semantics —
+                    # used here for the encoder + bottleneck convs (s1/s2/s3/s4/b1).
+                    self.emit_move_before_conv = True
+                def __setitem__(self, key, value):
+                    setattr(self, key, value)
+
+            def __init__(self, w, b):
+                self.s1 = {'0': self.ConvDictArgs(), '2': self.ConvDictArgs()}
+                self.s2 = {'4': self.ConvDictArgs(), '5': self.ConvDictArgs(), '7': self.ConvDictArgs()}
+                self.s3 = {'9': self.ConvDictArgs(), '10': self.ConvDictArgs(), '12': self.ConvDictArgs(), '14': self.ConvDictArgs(), '16': self.ConvDictArgs()}
+                self.s4 = {'18': self.ConvDictArgs(), '19': self.ConvDictArgs(), '21': self.ConvDictArgs(), '23': self.ConvDictArgs(), '25': self.ConvDictArgs()}
+                self.b1 = {'27': self.ConvDictArgs(), '28': self.ConvDictArgs(), '30': self.ConvDictArgs(), '32': self.ConvDictArgs(), '34': self.ConvDictArgs()}
+                self.d1 = self.DecodeBlockArgs(w, b)
+                self.d2 = self.DecodeBlockArgs(w, b)
+                self.d3 = self.DecodeBlockArgs(w, b)
+                self.d4 = self.DecodeBlockArgs(w, b)
+                self.out = self.ConvDictArgs()
+
+        def __init__(self):
+            self._data = {
+                '0':  self.WeightBias(None, None),
+                '2':  self.WeightBias(None, None),
+                '5':  self.WeightBias(None, None),
+                '7':  self.WeightBias(None, None),
+                '10': self.WeightBias(None, None),
+                '12': self.WeightBias(None, None),
+                '14': self.WeightBias(None, None),
+                '16': self.WeightBias(None, None),
+                '19': self.WeightBias(None, None),
+                '21': self.WeightBias(None, None),
+                '23': self.WeightBias(None, None),
+                '25': self.WeightBias(None, None),
+                '28': self.WeightBias(None, None),
+                '30': self.WeightBias(None, None),
+                '32': self.WeightBias(None, None),
+                '34': self.WeightBias(None, None),
+            }
+            self.d1 = self.ConvArgs.DecodeBlockArgs(None, None)
+            self.d2 = self.ConvArgs.DecodeBlockArgs(None, None)
+            self.d3 = self.ConvArgs.DecodeBlockArgs(None, None)
+            self.d4 = self.ConvArgs.DecodeBlockArgs(None, None)
+            self.out = self.WeightBias(None, None)
+
+            # ----------------------------------------------------------------
+            # Encoder weight shapes (from real UNetVGG19 model)
+            # ----------------------------------------------------------------
+            # s1_0 weight stays at C_in=3 even though the input is padded to C=16
+            # by pad_channels_nchw before the conv.  On hardware the kernel slices
+            # only the first 3 input channels (the rest are zeros from the pad), so
+            # the LUT records the weight at its original C_in=3.  conv_sinf accepts
+            # the C mismatch (input C > weight C/group) — see ttsim/ops/desc/nn.py.
+            self._data['0'].weight  = ttnn.Tensor(shape=ttnn.Shape([64, 3, 3, 3]),    layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['0'].bias    = ttnn.Tensor(shape=ttnn.Shape([64]),             layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['2'].weight  = ttnn.Tensor(shape=ttnn.Shape([64, 64, 3, 3]),   layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['2'].bias    = ttnn.Tensor(shape=ttnn.Shape([64]),             layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['5'].weight  = ttnn.Tensor(shape=ttnn.Shape([128, 64, 3, 3]),  layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['5'].bias    = ttnn.Tensor(shape=ttnn.Shape([128]),            layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['7'].weight  = ttnn.Tensor(shape=ttnn.Shape([128, 128, 3, 3]), layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['7'].bias    = ttnn.Tensor(shape=ttnn.Shape([128]),            layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['10'].weight = ttnn.Tensor(shape=ttnn.Shape([256, 128, 3, 3]), layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['10'].bias   = ttnn.Tensor(shape=ttnn.Shape([256]),            layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['12'].weight = ttnn.Tensor(shape=ttnn.Shape([256, 256, 3, 3]), layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['12'].bias   = ttnn.Tensor(shape=ttnn.Shape([256]),            layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['14'].weight = ttnn.Tensor(shape=ttnn.Shape([256, 256, 3, 3]), layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['14'].bias   = ttnn.Tensor(shape=ttnn.Shape([256]),            layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['16'].weight = ttnn.Tensor(shape=ttnn.Shape([256, 256, 3, 3]), layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['16'].bias   = ttnn.Tensor(shape=ttnn.Shape([256]),            layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['19'].weight = ttnn.Tensor(shape=ttnn.Shape([512, 256, 3, 3]), layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['19'].bias   = ttnn.Tensor(shape=ttnn.Shape([512]),            layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['21'].weight = ttnn.Tensor(shape=ttnn.Shape([512, 512, 3, 3]), layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['21'].bias   = ttnn.Tensor(shape=ttnn.Shape([512]),            layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['23'].weight = ttnn.Tensor(shape=ttnn.Shape([512, 512, 3, 3]), layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['23'].bias   = ttnn.Tensor(shape=ttnn.Shape([512]),            layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['25'].weight = ttnn.Tensor(shape=ttnn.Shape([512, 512, 3, 3]), layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['25'].bias   = ttnn.Tensor(shape=ttnn.Shape([512]),            layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['28'].weight = ttnn.Tensor(shape=ttnn.Shape([512, 512, 3, 3]), layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['28'].bias   = ttnn.Tensor(shape=ttnn.Shape([512]),            layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['30'].weight = ttnn.Tensor(shape=ttnn.Shape([512, 512, 3, 3]), layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['30'].bias   = ttnn.Tensor(shape=ttnn.Shape([512]),            layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['32'].weight = ttnn.Tensor(shape=ttnn.Shape([512, 512, 3, 3]), layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['32'].bias   = ttnn.Tensor(shape=ttnn.Shape([512]),            layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['34'].weight = ttnn.Tensor(shape=ttnn.Shape([512, 512, 3, 3]), layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self._data['34'].bias   = ttnn.Tensor(shape=ttnn.Shape([512]),            layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+
+            self.conv_args = self.ConvArgs(None, None)
+
+            # ----------------------------------------------------------------
+            # Decoder weight shapes
+            # ----------------------------------------------------------------
+            self.d1.up.weight    = ttnn.Tensor(shape=ttnn.Shape([512, 512, 2, 2]),  layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self.d1.up.bias      = ttnn.Tensor(shape=ttnn.Shape([512]),             layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self.d1.conv1.weight = ttnn.Tensor(shape=ttnn.Shape([512, 1024, 3, 3]), layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self.d1.conv1.bias   = ttnn.Tensor(shape=ttnn.Shape([512]),             layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self.d1.conv2.weight = ttnn.Tensor(shape=ttnn.Shape([512, 512, 3, 3]),  layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self.d1.conv2.bias   = ttnn.Tensor(shape=ttnn.Shape([512]),             layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self.d2.up.weight    = ttnn.Tensor(shape=ttnn.Shape([512, 256, 2, 2]),  layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self.d2.up.bias      = ttnn.Tensor(shape=ttnn.Shape([256]),             layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self.d2.conv1.weight = ttnn.Tensor(shape=ttnn.Shape([256, 512, 3, 3]),  layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self.d2.conv1.bias   = ttnn.Tensor(shape=ttnn.Shape([256]),             layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self.d2.conv2.weight = ttnn.Tensor(shape=ttnn.Shape([256, 256, 3, 3]),  layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self.d2.conv2.bias   = ttnn.Tensor(shape=ttnn.Shape([256]),             layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self.d3.up.weight    = ttnn.Tensor(shape=ttnn.Shape([256, 128, 2, 2]),  layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self.d3.up.bias      = ttnn.Tensor(shape=ttnn.Shape([128]),             layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self.d3.conv1.weight = ttnn.Tensor(shape=ttnn.Shape([128, 256, 3, 3]),  layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self.d3.conv1.bias   = ttnn.Tensor(shape=ttnn.Shape([128]),             layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self.d3.conv2.weight = ttnn.Tensor(shape=ttnn.Shape([128, 128, 3, 3]),  layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self.d3.conv2.bias   = ttnn.Tensor(shape=ttnn.Shape([128]),             layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self.d4.up.weight    = ttnn.Tensor(shape=ttnn.Shape([128, 64, 2, 2]),   layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self.d4.up.bias      = ttnn.Tensor(shape=ttnn.Shape([64]),              layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self.d4.conv1.weight = ttnn.Tensor(shape=ttnn.Shape([64, 128, 3, 3]),   layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self.d4.conv1.bias   = ttnn.Tensor(shape=ttnn.Shape([64]),              layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self.d4.conv2.weight = ttnn.Tensor(shape=ttnn.Shape([64, 64, 3, 3]),    layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self.d4.conv2.bias   = ttnn.Tensor(shape=ttnn.Shape([64]),              layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self.out.weight      = ttnn.Tensor(shape=ttnn.Shape([1, 64, 1, 1]),     layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+            self.out.bias        = ttnn.Tensor(shape=ttnn.Shape([1]),               layout=ttnn.Layout.ROW_MAJOR, dtype=ttnn.DataType.FLOAT32, device=device)
+
+        def __getitem__(self, key):
+            return self._data[key]
+        def __setitem__(self, key, value):
+            self._data[key] = value
+
+    parameters = Parameters()
+
+    # ----------------------------------------------------------------
+    # Stage 1  (256×256)
+    # ----------------------------------------------------------------
+    parameters.conv_args.s1['0']['act_block_h'] = None
+    parameters.conv_args.s1['0']['enable_act_double_buffer'] = False
+    parameters.conv_args.s1['0']['deallocate_activation'] = True
+    parameters.conv_args.s1['0']['reshard_if_not_optimal'] = False
+    parameters.conv_args.s1['0']['shard_layout'] = None
+    parameters.conv_args.s1['0']['activation'] = 'relu'
+    parameters.conv_args.s1['0']['dtype'] = ttnn.DataType.BFLOAT16
+    # in_channels=16 matches the hardware: C=3 input is padded to C=16 by a Pad
+    # op before s1_0 (see Tt_vgg_unet.__call__).  Keeps Polaris aligned with the LUT.
+    parameters.conv_args.s1['0'].in_channels = 16
+    parameters.conv_args.s1['0'].out_channels = 64
+    parameters.conv_args.s1['0'].batch_size = 1
+    parameters.conv_args.s1['0'].input_height = 256
+    parameters.conv_args.s1['0'].input_width = 256
+
+    parameters.conv_args.s1['2']['act_block_h'] = None
+    parameters.conv_args.s1['2']['enable_act_double_buffer'] = False
+    parameters.conv_args.s1['2']['deallocate_activation'] = True
+    parameters.conv_args.s1['2']['reshard_if_not_optimal'] = False
+    parameters.conv_args.s1['2']['shard_layout'] = None
+    parameters.conv_args.s1['2']['activation'] = 'relu'
+    parameters.conv_args.s1['2']['dtype'] = ttnn.DataType.BFLOAT16
+    parameters.conv_args.s1['2'].in_channels = 64
+    parameters.conv_args.s1['2'].out_channels = 64
+    parameters.conv_args.s1['2'].batch_size = 1
+    parameters.conv_args.s1['2'].input_height = 256
+    parameters.conv_args.s1['2'].input_width = 256
+
+    # ----------------------------------------------------------------
+    # Stage 2  (128×128 after pool)
+    # ----------------------------------------------------------------
+    parameters.conv_args.s2['4'].in_channels = 64
+    parameters.conv_args.s2['4'].batch_size = 1
+    parameters.conv_args.s2['4'].input_height = 256
+    parameters.conv_args.s2['4'].input_width = 256
+    parameters.conv_args.s2['4'].kernel_size = 2  # type: ignore[assignment]
+    parameters.conv_args.s2['4'].stride = 2  # type: ignore[assignment]
+    parameters.conv_args.s2['4'].padding = 0  # type: ignore[assignment]
+    parameters.conv_args.s2['4'].dilation = 1
+    parameters.conv_args.s2['4'].dtype = ttnn.DataType.BFLOAT16
+
+    parameters.conv_args.s2['5']['act_block_h'] = None
+    parameters.conv_args.s2['5']['enable_act_double_buffer'] = False
+    parameters.conv_args.s2['5']['deallocate_activation'] = True
+    parameters.conv_args.s2['5']['reshard_if_not_optimal'] = False
+    parameters.conv_args.s2['5']['shard_layout'] = None
+    parameters.conv_args.s2['5']['activation'] = 'relu'
+    parameters.conv_args.s2['5']['dtype'] = ttnn.DataType.BFLOAT16
+    parameters.conv_args.s2['5'].in_channels = 64
+    parameters.conv_args.s2['5'].out_channels = 128
+    parameters.conv_args.s2['5'].batch_size = 1
+    parameters.conv_args.s2['5'].input_height = 128
+    parameters.conv_args.s2['5'].input_width = 128
+
+    parameters.conv_args.s2['7']['act_block_h'] = None
+    parameters.conv_args.s2['7']['enable_act_double_buffer'] = False
+    parameters.conv_args.s2['7']['deallocate_activation'] = True
+    parameters.conv_args.s2['7']['reshard_if_not_optimal'] = False
+    parameters.conv_args.s2['7']['shard_layout'] = None
+    parameters.conv_args.s2['7']['activation'] = 'relu'
+    parameters.conv_args.s2['7']['dtype'] = ttnn.DataType.BFLOAT16
+    parameters.conv_args.s2['7'].in_channels = 128
+    parameters.conv_args.s2['7'].out_channels = 128
+    parameters.conv_args.s2['7'].batch_size = 1
+    parameters.conv_args.s2['7'].input_height = 128
+    parameters.conv_args.s2['7'].input_width = 128
+
+    # ----------------------------------------------------------------
+    # Stage 3  (64×64 after pool)
+    # ----------------------------------------------------------------
+    parameters.conv_args.s3['9'].in_channels = 128
+    parameters.conv_args.s3['9'].input_height = 128
+    parameters.conv_args.s3['9'].input_width = 128
+    parameters.conv_args.s3['9'].kernel_size = 2  # type: ignore[assignment]
+    parameters.conv_args.s3['9'].stride = 2  # type: ignore[assignment]
+    parameters.conv_args.s3['9'].padding = 0  # type: ignore[assignment]
+    parameters.conv_args.s3['9'].dilation = 1
+    parameters.conv_args.s3['9'].batch_size = 1
+    parameters.conv_args.s3['9'].dtype = ttnn.DataType.BFLOAT16
+
+    parameters.conv_args.s3['10']['act_block_h'] = None
+    parameters.conv_args.s3['10']['enable_act_double_buffer'] = False
+    parameters.conv_args.s3['10']['deallocate_activation'] = True
+    parameters.conv_args.s3['10']['reshard_if_not_optimal'] = False
+    parameters.conv_args.s3['10']['shard_layout'] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
+    parameters.conv_args.s3['10']['activation'] = 'relu'
+    parameters.conv_args.s3['10']['dtype'] = ttnn.DataType.BFLOAT16
+    parameters.conv_args.s3['10'].in_channels = 128
+    parameters.conv_args.s3['10'].out_channels = 256
+    parameters.conv_args.s3['10'].batch_size = 1
+    parameters.conv_args.s3['10'].input_height = 64
+    parameters.conv_args.s3['10'].input_width = 64
+
+    parameters.conv_args.s3['12']['act_block_h'] = None
+    parameters.conv_args.s3['12']['enable_act_double_buffer'] = False
+    parameters.conv_args.s3['12']['deallocate_activation'] = True
+    parameters.conv_args.s3['12']['reshard_if_not_optimal'] = False
+    parameters.conv_args.s3['12']['shard_layout'] = None
+    parameters.conv_args.s3['12']['activation'] = 'relu'
+    parameters.conv_args.s3['12']['dtype'] = ttnn.DataType.BFLOAT16
+    parameters.conv_args.s3['12']['tile_layout'] = True
+    parameters.conv_args.s3['12']['emit_move_before_conv'] = False
+    parameters.conv_args.s3['12'].in_channels = 256
+    parameters.conv_args.s3['12'].out_channels = 256
+    parameters.conv_args.s3['12'].batch_size = 1
+    parameters.conv_args.s3['12'].input_height = 64
+    parameters.conv_args.s3['12'].input_width = 64
+
+    parameters.conv_args.s3['14']['act_block_h'] = None
+    parameters.conv_args.s3['14']['enable_act_double_buffer'] = False
+    parameters.conv_args.s3['14']['deallocate_activation'] = True
+    parameters.conv_args.s3['14']['reshard_if_not_optimal'] = False
+    parameters.conv_args.s3['14']['shard_layout'] = None
+    parameters.conv_args.s3['14']['activation'] = 'relu'
+    parameters.conv_args.s3['14']['dtype'] = ttnn.DataType.BFLOAT16
+    parameters.conv_args.s3['14']['tile_layout'] = True
+    parameters.conv_args.s3['14']['emit_move_before_conv'] = False
+    parameters.conv_args.s3['14'].in_channels = 256
+    parameters.conv_args.s3['14'].out_channels = 256
+    parameters.conv_args.s3['14'].batch_size = 1
+    parameters.conv_args.s3['14'].input_height = 64
+    parameters.conv_args.s3['14'].input_width = 64
+
+    parameters.conv_args.s3['16']['act_block_h'] = None
+    parameters.conv_args.s3['16']['enable_act_double_buffer'] = False
+    parameters.conv_args.s3['16']['deallocate_activation'] = True
+    parameters.conv_args.s3['16']['reshard_if_not_optimal'] = False
+    parameters.conv_args.s3['16']['shard_layout'] = None
+    parameters.conv_args.s3['16']['activation'] = 'relu'
+    parameters.conv_args.s3['16']['dtype'] = ttnn.DataType.BFLOAT16
+    parameters.conv_args.s3['16']['emit_move_before_conv'] = False
+    parameters.conv_args.s3['16'].in_channels = 256
+    parameters.conv_args.s3['16'].out_channels = 256
+    parameters.conv_args.s3['16'].batch_size = 1
+    parameters.conv_args.s3['16'].input_height = 64
+    parameters.conv_args.s3['16'].input_width = 64
+
+    # ----------------------------------------------------------------
+    # Stage 4  (32×32 after pool)
+    # ----------------------------------------------------------------
+    parameters.conv_args.s4['18'].in_channels = 256
+    parameters.conv_args.s4['18'].input_height = 64
+    parameters.conv_args.s4['18'].input_width = 64
+    parameters.conv_args.s4['18'].kernel_size = 2  # type: ignore[assignment]
+    parameters.conv_args.s4['18'].stride = 2  # type: ignore[assignment]
+    parameters.conv_args.s4['18'].padding = 0  # type: ignore[assignment]
+    parameters.conv_args.s4['18'].dilation = 1
+    parameters.conv_args.s4['18'].batch_size = 1
+    parameters.conv_args.s4['18'].dtype = ttnn.DataType.BFLOAT16
+
+    parameters.conv_args.s4['19']['act_block_h'] = None
+    parameters.conv_args.s4['19']['enable_act_double_buffer'] = False
+    parameters.conv_args.s4['19']['deallocate_activation'] = True
+    parameters.conv_args.s4['19']['reshard_if_not_optimal'] = False
+    parameters.conv_args.s4['19']['shard_layout'] = None
+    parameters.conv_args.s4['19']['activation'] = 'relu'
+    parameters.conv_args.s4['19']['dtype'] = ttnn.DataType.BFLOAT16
+    parameters.conv_args.s4['19']['tile_layout'] = True
+    parameters.conv_args.s4['19'].in_channels = 256
+    parameters.conv_args.s4['19'].out_channels = 512
+    parameters.conv_args.s4['19'].batch_size = 1
+    parameters.conv_args.s4['19'].input_height = 32
+    parameters.conv_args.s4['19'].input_width = 32
+
+    parameters.conv_args.s4['21']['act_block_h'] = None
+    parameters.conv_args.s4['21']['enable_act_double_buffer'] = False
+    parameters.conv_args.s4['21']['deallocate_activation'] = True
+    parameters.conv_args.s4['21']['reshard_if_not_optimal'] = False
+    parameters.conv_args.s4['21']['shard_layout'] = None
+    parameters.conv_args.s4['21']['activation'] = 'relu'
+    parameters.conv_args.s4['21']['dtype'] = ttnn.DataType.BFLOAT16
+    parameters.conv_args.s4['21']['tile_layout'] = True
+    parameters.conv_args.s4['21']['emit_move_before_conv'] = False
+    parameters.conv_args.s4['21'].in_channels = 512
+    parameters.conv_args.s4['21'].out_channels = 512
+    parameters.conv_args.s4['21'].batch_size = 1
+    parameters.conv_args.s4['21'].input_height = 32
+    parameters.conv_args.s4['21'].input_width = 32
+
+    parameters.conv_args.s4['23']['act_block_h'] = None
+    parameters.conv_args.s4['23']['enable_act_double_buffer'] = False
+    parameters.conv_args.s4['23']['deallocate_activation'] = True
+    parameters.conv_args.s4['23']['reshard_if_not_optimal'] = False
+    parameters.conv_args.s4['23']['shard_layout'] = None
+    parameters.conv_args.s4['23']['activation'] = 'relu'
+    parameters.conv_args.s4['23']['dtype'] = ttnn.DataType.BFLOAT16
+    parameters.conv_args.s4['23']['tile_layout'] = True
+    parameters.conv_args.s4['23']['emit_move_before_conv'] = False
+    parameters.conv_args.s4['23'].in_channels = 512
+    parameters.conv_args.s4['23'].out_channels = 512
+    parameters.conv_args.s4['23'].batch_size = 1
+    parameters.conv_args.s4['23'].input_height = 32
+    parameters.conv_args.s4['23'].input_width = 32
+
+    parameters.conv_args.s4['25']['act_block_h'] = None
+    parameters.conv_args.s4['25']['enable_act_double_buffer'] = False
+    parameters.conv_args.s4['25']['deallocate_activation'] = True
+    parameters.conv_args.s4['25']['reshard_if_not_optimal'] = False
+    parameters.conv_args.s4['25']['shard_layout'] = None
+    parameters.conv_args.s4['25']['activation'] = 'relu'
+    parameters.conv_args.s4['25']['dtype'] = ttnn.DataType.BFLOAT16
+    parameters.conv_args.s4['25']['emit_move_before_conv'] = False
+    parameters.conv_args.s4['25'].in_channels = 512
+    parameters.conv_args.s4['25'].out_channels = 512
+    parameters.conv_args.s4['25'].batch_size = 1
+    parameters.conv_args.s4['25'].input_height = 32
+    parameters.conv_args.s4['25'].input_width = 32
+
+    # ----------------------------------------------------------------
+    # Bottleneck  (16×16 after pool)
+    # ----------------------------------------------------------------
+    parameters.conv_args.b1['27'].in_channels = 512
+    parameters.conv_args.b1['27'].input_height = 32
+    parameters.conv_args.b1['27'].input_width = 32
+    parameters.conv_args.b1['27'].kernel_size = 2  # type: ignore[assignment]
+    parameters.conv_args.b1['27'].stride = 2  # type: ignore[assignment]
+    parameters.conv_args.b1['27'].padding = 0  # type: ignore[assignment]
+    parameters.conv_args.b1['27'].dilation = 1
+    parameters.conv_args.b1['27'].batch_size = 1
+    parameters.conv_args.b1['27'].dtype = ttnn.DataType.BFLOAT16
+
+    parameters.conv_args.b1['28']['act_block_h'] = None
+    parameters.conv_args.b1['28']['enable_act_double_buffer'] = False
+    parameters.conv_args.b1['28']['deallocate_activation'] = True
+    parameters.conv_args.b1['28']['reshard_if_not_optimal'] = False
+    parameters.conv_args.b1['28']['shard_layout'] = None
+    parameters.conv_args.b1['28']['activation'] = 'relu'
+    parameters.conv_args.b1['28']['dtype'] = ttnn.DataType.BFLOAT16
+    parameters.conv_args.b1['28']['tile_layout'] = True
+    parameters.conv_args.b1['28'].in_channels = 512
+    parameters.conv_args.b1['28'].out_channels = 512
+    parameters.conv_args.b1['28'].batch_size = 1
+    parameters.conv_args.b1['28'].input_height = 16
+    parameters.conv_args.b1['28'].input_width = 16
+
+    # Bottleneck convs b1_30, b1_32, b1_34 run at constant 16×16×512 shape.
+    # tt-metal's conv kernel reuses the input buffer (no reallocation needed)
+    # so MoveDeviceOperation is not dispatched for these positions — the HW
+    # profiler shows no Move row between consecutive b1 convs.  Set
+    # emit_move_before_conv=False so the Polaris shim doesn't emit a Move
+    # SimOp at shapes the LUT has no entry for.  b1_28 is already covered by
+    # the MaxPool-predecessor heuristic in _with_halo (Phase 1).
+    parameters.conv_args.b1['30']['act_block_h'] = None
+    parameters.conv_args.b1['30']['enable_act_double_buffer'] = False
+    parameters.conv_args.b1['30']['deallocate_activation'] = True
+    parameters.conv_args.b1['30']['reshard_if_not_optimal'] = False
+    parameters.conv_args.b1['30']['shard_layout'] = None
+    parameters.conv_args.b1['30']['activation'] = 'relu'
+    parameters.conv_args.b1['30']['dtype'] = ttnn.DataType.BFLOAT16
+    parameters.conv_args.b1['30']['emit_move_before_conv'] = False
+    parameters.conv_args.b1['30']['tile_layout'] = True
+    parameters.conv_args.b1['30'].in_channels = 512
+    parameters.conv_args.b1['30'].out_channels = 512
+    parameters.conv_args.b1['30'].batch_size = 1
+    parameters.conv_args.b1['30'].input_height = 16
+    parameters.conv_args.b1['30'].input_width = 16
+
+    parameters.conv_args.b1['32']['act_block_h'] = None
+    parameters.conv_args.b1['32']['enable_act_double_buffer'] = False
+    parameters.conv_args.b1['32']['deallocate_activation'] = True
+    parameters.conv_args.b1['32']['reshard_if_not_optimal'] = False
+    parameters.conv_args.b1['32']['shard_layout'] = None
+    parameters.conv_args.b1['32']['activation'] = 'relu'
+    parameters.conv_args.b1['32']['dtype'] = ttnn.DataType.BFLOAT16
+    parameters.conv_args.b1['32']['emit_move_before_conv'] = False
+    parameters.conv_args.b1['32']['tile_layout'] = True
+    parameters.conv_args.b1['32'].in_channels = 512
+    parameters.conv_args.b1['32'].out_channels = 512
+    parameters.conv_args.b1['32'].batch_size = 1
+    parameters.conv_args.b1['32'].input_height = 16
+    parameters.conv_args.b1['32'].input_width = 16
+
+    parameters.conv_args.b1['34']['act_block_h'] = None
+    parameters.conv_args.b1['34']['enable_act_double_buffer'] = False
+    parameters.conv_args.b1['34']['deallocate_activation'] = True
+    parameters.conv_args.b1['34']['reshard_if_not_optimal'] = False
+    parameters.conv_args.b1['34']['shard_layout'] = None
+    parameters.conv_args.b1['34']['activation'] = 'relu'
+    parameters.conv_args.b1['34']['dtype'] = ttnn.DataType.BFLOAT16
+    parameters.conv_args.b1['34']['emit_move_before_conv'] = False
+    parameters.conv_args.b1['34'].in_channels = 512
+    parameters.conv_args.b1['34'].out_channels = 512
+    parameters.conv_args.b1['34'].batch_size = 1
+    parameters.conv_args.b1['34'].input_height = 16
+    parameters.conv_args.b1['34'].input_width = 16
+
+    # ----------------------------------------------------------------
+    # Decoder 1  (16→32)
+    # ----------------------------------------------------------------
+    parameters.conv_args.d1.up['act_block_h'] = None
+    parameters.conv_args.d1.up['enable_act_double_buffer'] = False
+    parameters.conv_args.d1.up['deallocate_activation'] = False
+    parameters.conv_args.d1.up['reshard_if_not_optimal'] = False
+    parameters.conv_args.d1.up['shard_layout'] = None
+    parameters.conv_args.d1.up['dtype'] = ttnn.DataType.BFLOAT16
+    parameters.conv_args.d1.up.in_channels = 512
+    parameters.conv_args.d1.up.out_channels = 512
+    parameters.conv_args.d1.up.batch_size = 1
+    parameters.conv_args.d1.up.input_height = 16
+    parameters.conv_args.d1.up.input_width = 16
+    parameters.conv_args.d1.up.kernel_size = (2, 2)  # type: ignore[assignment]
+    parameters.conv_args.d1.up.stride = (2, 2)  # type: ignore[assignment]
+    parameters.conv_args.d1.up.padding = (0, 0)  # type: ignore[assignment]
+
+    parameters.conv_args.d1.conv_block.conv1['act_block_h'] = None
+    parameters.conv_args.d1.conv_block.conv1['enable_act_double_buffer'] = False
+    parameters.conv_args.d1.conv_block.conv1['deallocate_activation'] = True
+    parameters.conv_args.d1.conv_block.conv1['reshard_if_not_optimal'] = False
+    parameters.conv_args.d1.conv_block.conv1['shard_layout'] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
+    parameters.conv_args.d1.conv_block.conv1['activation'] = 'relu'
+    parameters.conv_args.d1.conv_block.conv1['padding'] = (1, 1)
+    parameters.conv_args.d1.conv_block.conv1['do_sharded_to_interleaved'] = True
+    parameters.conv_args.d1.conv_block.conv1['tile_layout'] = True
+    parameters.conv_args.d1.conv_block.conv1.in_channels = 1024
+    parameters.conv_args.d1.conv_block.conv1.out_channels = 512
+    parameters.conv_args.d1.conv_block.conv1.batch_size = 1
+    parameters.conv_args.d1.conv_block.conv1.input_height = 32
+    parameters.conv_args.d1.conv_block.conv1.input_width = 32
+
+    parameters.conv_args.d1.conv_block.conv2['act_block_h'] = None
+    parameters.conv_args.d1.conv_block.conv2['enable_act_double_buffer'] = False
+    parameters.conv_args.d1.conv_block.conv2['deallocate_activation'] = True
+    parameters.conv_args.d1.conv_block.conv2['reshard_if_not_optimal'] = False
+    parameters.conv_args.d1.conv_block.conv2['shard_layout'] = None
+    parameters.conv_args.d1.conv_block.conv2['activation'] = 'relu'
+    parameters.conv_args.d1.conv_block.conv2['padding'] = (1, 1)
+    parameters.conv_args.d1.conv_block.conv2['do_sharded_to_interleaved'] = False
+    parameters.conv_args.d1.conv_block.conv2['tile_layout'] = True
+    parameters.conv_args.d1.conv_block.conv2.in_channels = 512
+    parameters.conv_args.d1.conv_block.conv2.out_channels = 512
+    parameters.conv_args.d1.conv_block.conv2.batch_size = 1
+    parameters.conv_args.d1.conv_block.conv2.input_height = 32
+    parameters.conv_args.d1.conv_block.conv2.input_width = 32
+
+    # ----------------------------------------------------------------
+    # Decoder 2  (32→64)
+    # ----------------------------------------------------------------
+    parameters.conv_args.d2.up['act_block_h'] = None
+    parameters.conv_args.d2.up['enable_act_double_buffer'] = False
+    parameters.conv_args.d2.up['deallocate_activation'] = True
+    parameters.conv_args.d2.up['reshard_if_not_optimal'] = False
+    parameters.conv_args.d2.up['shard_layout'] = None
+    parameters.conv_args.d2.up['dtype'] = ttnn.DataType.BFLOAT16
+    parameters.conv_args.d2.up.in_channels = 512
+    parameters.conv_args.d2.up.out_channels = 256
+    parameters.conv_args.d2.up.batch_size = 1
+    parameters.conv_args.d2.up.input_height = 32
+    parameters.conv_args.d2.up.input_width = 32
+    parameters.conv_args.d2.up.kernel_size = (2, 2)  # type: ignore[assignment]
+    parameters.conv_args.d2.up.stride = (2, 2)  # type: ignore[assignment]
+    parameters.conv_args.d2.up.padding = (0, 0)  # type: ignore[assignment]
+
+    parameters.conv_args.d2.conv_block.conv1['act_block_h'] = None
+    parameters.conv_args.d2.conv_block.conv1['enable_act_double_buffer'] = False
+    parameters.conv_args.d2.conv_block.conv1['deallocate_activation'] = True
+    parameters.conv_args.d2.conv_block.conv1['reshard_if_not_optimal'] = False
+    parameters.conv_args.d2.conv_block.conv1['shard_layout'] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
+    parameters.conv_args.d2.conv_block.conv1['activation'] = 'relu'
+    parameters.conv_args.d2.conv_block.conv1['padding'] = (1, 1)
+    parameters.conv_args.d2.conv_block.conv1['do_sharded_to_interleaved'] = True
+    parameters.conv_args.d2.conv_block.conv1['tile_layout'] = True
+    parameters.conv_args.d2.conv_block.conv1.in_channels = 512
+    parameters.conv_args.d2.conv_block.conv1.out_channels = 256
+    parameters.conv_args.d2.conv_block.conv1.batch_size = 1
+    parameters.conv_args.d2.conv_block.conv1.input_height = 64
+    parameters.conv_args.d2.conv_block.conv1.input_width = 64
+
+    parameters.conv_args.d2.conv_block.conv2['act_block_h'] = None
+    parameters.conv_args.d2.conv_block.conv2['enable_act_double_buffer'] = False
+    parameters.conv_args.d2.conv_block.conv2['deallocate_activation'] = True
+    parameters.conv_args.d2.conv_block.conv2['reshard_if_not_optimal'] = False
+    parameters.conv_args.d2.conv_block.conv2['shard_layout'] = ttnn.TensorMemoryLayout.BLOCK_SHARDED
+    parameters.conv_args.d2.conv_block.conv2['activation'] = 'relu'
+    parameters.conv_args.d2.conv_block.conv2['padding'] = (1, 1)
+    parameters.conv_args.d2.conv_block.conv2['do_sharded_to_interleaved'] = False
+    parameters.conv_args.d2.conv_block.conv2['tile_layout'] = True
+    parameters.conv_args.d2.conv_block.conv2.in_channels = 256
+    parameters.conv_args.d2.conv_block.conv2.out_channels = 256
+    parameters.conv_args.d2.conv_block.conv2.batch_size = 1
+    parameters.conv_args.d2.conv_block.conv2.input_height = 64
+    parameters.conv_args.d2.conv_block.conv2.input_width = 64
+
+    # ----------------------------------------------------------------
+    # Decoder 3  (64→128)
+    # ----------------------------------------------------------------
+    parameters.conv_args.d3.up['act_block_h'] = None
+    parameters.conv_args.d3.up['enable_act_double_buffer'] = False
+    parameters.conv_args.d3.up['deallocate_activation'] = True
+    parameters.conv_args.d3.up['reshard_if_not_optimal'] = False
+    parameters.conv_args.d3.up['shard_layout'] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
+    parameters.conv_args.d3.up['dtype'] = ttnn.DataType.BFLOAT16
+    # HW emits no Move upstream of d3.up convtranspose (refrun has no Move row at
+    # y=24768).  Skip Polaris's auto-Move so the shim graph matches HW.
+    parameters.conv_args.d3.up['emit_move_before_conv'] = False
+    parameters.conv_args.d3.up.in_channels = 256
+    parameters.conv_args.d3.up.out_channels = 128
+    parameters.conv_args.d3.up.batch_size = 1
+    parameters.conv_args.d3.up.input_height = 64
+    parameters.conv_args.d3.up.input_width = 64
+    parameters.conv_args.d3.up.kernel_size = (2, 2)  # type: ignore[assignment]
+    parameters.conv_args.d3.up.stride = (2, 2)  # type: ignore[assignment]
+    parameters.conv_args.d3.up.padding = (0, 0)  # type: ignore[assignment]
+
+    # d3.conv1 takes its input directly from sharded_concat output without the
+    # explicit STS+ITS interleaving (do_sharded_to_interleaved=False), so the
+    # input buffer is fresh from Concat.  tt-metal's conv kernel doesn't need
+    # to reallocate; HW profiler shows no Move row before d3.conv1.  Set
+    # emit_move_before_conv=False so Polaris matches.
+    parameters.conv_args.d3.conv_block.conv1['act_block_h'] = None
+    parameters.conv_args.d3.conv_block.conv1['enable_act_double_buffer'] = False
+    parameters.conv_args.d3.conv_block.conv1['deallocate_activation'] = True
+    parameters.conv_args.d3.conv_block.conv1['reshard_if_not_optimal'] = False
+    parameters.conv_args.d3.conv_block.conv1['shard_layout'] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
+    parameters.conv_args.d3.conv_block.conv1['activation'] = 'relu'
+    parameters.conv_args.d3.conv_block.conv1['padding'] = (1, 1)
+    parameters.conv_args.d3.conv_block.conv1['do_sharded_to_interleaved'] = False
+    parameters.conv_args.d3.conv_block.conv1['emit_move_before_conv'] = False
+    parameters.conv_args.d3.conv_block.conv1['tile_layout'] = True
+    parameters.conv_args.d3.conv_block.conv1.in_channels = 256
+    parameters.conv_args.d3.conv_block.conv1.out_channels = 128
+    parameters.conv_args.d3.conv_block.conv1.batch_size = 1
+    parameters.conv_args.d3.conv_block.conv1.input_height = 128
+    parameters.conv_args.d3.conv_block.conv1.input_width = 128
+
+    parameters.conv_args.d3.conv_block.conv2['act_block_h'] = None
+    parameters.conv_args.d3.conv_block.conv2['enable_act_double_buffer'] = False
+    parameters.conv_args.d3.conv_block.conv2['deallocate_activation'] = True
+    parameters.conv_args.d3.conv_block.conv2['reshard_if_not_optimal'] = False
+    parameters.conv_args.d3.conv_block.conv2['shard_layout'] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
+    parameters.conv_args.d3.conv_block.conv2['activation'] = 'relu'
+    parameters.conv_args.d3.conv_block.conv2['padding'] = (1, 1)
+    parameters.conv_args.d3.conv_block.conv2['do_sharded_to_interleaved'] = False
+    parameters.conv_args.d3.conv_block.conv2.in_channels = 128
+    parameters.conv_args.d3.conv_block.conv2.out_channels = 128
+    parameters.conv_args.d3.conv_block.conv2.batch_size = 1
+    parameters.conv_args.d3.conv_block.conv2.input_height = 128
+    parameters.conv_args.d3.conv_block.conv2.input_width = 128
+
+    # ----------------------------------------------------------------
+    # Decoder 4  (128→256)
+    # ----------------------------------------------------------------
+    parameters.conv_args.d4.up['act_block_h'] = None
+    parameters.conv_args.d4.up['enable_act_double_buffer'] = False
+    parameters.conv_args.d4.up['deallocate_activation'] = True
+    parameters.conv_args.d4.up['reshard_if_not_optimal'] = False
+    parameters.conv_args.d4.up['shard_layout'] = None
+    parameters.conv_args.d4.up['dtype'] = ttnn.DataType.BFLOAT16
+    # HW emits no Move upstream of d4.up convtranspose (refrun has no Move row at
+    # y=88408).  Skip Polaris's auto-Move so the shim graph matches HW.
+    parameters.conv_args.d4.up['emit_move_before_conv'] = False
+    parameters.conv_args.d4.up.in_channels = 128
+    parameters.conv_args.d4.up.out_channels = 64
+    parameters.conv_args.d4.up.batch_size = 1
+    parameters.conv_args.d4.up.input_height = 128
+    parameters.conv_args.d4.up.input_width = 128
+    parameters.conv_args.d4.up.kernel_size = (2, 2)  # type: ignore[assignment]
+    parameters.conv_args.d4.up.stride = (2, 2)  # type: ignore[assignment]
+    parameters.conv_args.d4.up.padding = (0, 0)  # type: ignore[assignment]
+
+    parameters.conv_args.d4.conv_block.conv1['act_block_h'] = None
+    parameters.conv_args.d4.conv_block.conv1['enable_act_double_buffer'] = False
+    parameters.conv_args.d4.conv_block.conv1['deallocate_activation'] = True
+    parameters.conv_args.d4.conv_block.conv1['reshard_if_not_optimal'] = False
+    parameters.conv_args.d4.conv_block.conv1['shard_layout'] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
+    parameters.conv_args.d4.conv_block.conv1['activation'] = 'relu'
+    parameters.conv_args.d4.conv_block.conv1['padding'] = (1, 1)
+    parameters.conv_args.d4.conv_block.conv1['do_sharded_to_interleaved'] = False
+    parameters.conv_args.d4.conv_block.conv1['tile_layout'] = True
+    parameters.conv_args.d4.conv_block.conv1.in_channels = 128
+    parameters.conv_args.d4.conv_block.conv1.out_channels = 64
+    parameters.conv_args.d4.conv_block.conv1.batch_size = 1
+    parameters.conv_args.d4.conv_block.conv1.input_height = 256
+    parameters.conv_args.d4.conv_block.conv1.input_width = 256
+
+    parameters.conv_args.d4.conv_block.conv2['act_block_h'] = None
+    parameters.conv_args.d4.conv_block.conv2['enable_act_double_buffer'] = False
+    parameters.conv_args.d4.conv_block.conv2['deallocate_activation'] = True
+    parameters.conv_args.d4.conv_block.conv2['reshard_if_not_optimal'] = False
+    parameters.conv_args.d4.conv_block.conv2['shard_layout'] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
+    parameters.conv_args.d4.conv_block.conv2['activation'] = 'relu'
+    parameters.conv_args.d4.conv_block.conv2['padding'] = (1, 1)
+    parameters.conv_args.d4.conv_block.conv2['do_sharded_to_interleaved'] = False
+    parameters.conv_args.d4.conv_block.conv2['tile_layout'] = True
+    parameters.conv_args.d4.conv_block.conv2.in_channels = 64
+    parameters.conv_args.d4.conv_block.conv2.out_channels = 64
+    parameters.conv_args.d4.conv_block.conv2.batch_size = 1
+    parameters.conv_args.d4.conv_block.conv2.input_height = 256
+    parameters.conv_args.d4.conv_block.conv2.input_width = 256
+
+    # ----------------------------------------------------------------
+    # Output conv  (256×256, 1×1)
+    # ----------------------------------------------------------------
+    parameters.conv_args.out['act_block_h'] = None
+    parameters.conv_args.out['enable_act_double_buffer'] = False
+    parameters.conv_args.out['deallocate_activation'] = True
+    parameters.conv_args.out['reshard_if_not_optimal'] = False
+    parameters.conv_args.out['shard_layout'] = None
+    parameters.conv_args.out['activation'] = ''
+    parameters.conv_args.out['padding'] = (0, 0)
+    parameters.conv_args.out['dtype'] = ttnn.DataType.BFLOAT16
+    parameters.conv_args.out.in_channels = 64
+    parameters.conv_args.out.out_channels = 1
+    parameters.conv_args.out.batch_size = 1
+    parameters.conv_args.out.input_height = 256
+    parameters.conv_args.out.input_width = 256
+    parameters.conv_args.out.kernel_size = (1, 1)  # type: ignore[assignment]
+    parameters.conv_args.out.stride = (1, 1)  # type: ignore[assignment]
+    parameters.conv_args.out.padding = (0, 0)  # type: ignore[assignment]
+
+    return parameters

--- a/workloads/ttnn/vgg_unet/common/ttnn_vgg_unet.py
+++ b/workloads/ttnn/vgg_unet/common/ttnn_vgg_unet.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Polaris-side VGG UNet model — structurally aligned with the tt-metal canonical
+``models/demos/vision/segmentation/vgg_unet/common/ttnn/ttnn_vgg_unet.py``.
+
+Differences from the canonical (all deliberate for polaris analytical modeling):
+- No ``ttnn.permute`` / ``ttnn.reshape`` before the first conv: the polaris
+  ``conv_sinf`` shape-inference engine expects NCHW tensors; hardware-specific
+  channel-padding and memory reformatting are not modeled here.
+- ``sharded_concat`` uses ``dim=1`` (NCHW channel axis) rather than the canonical
+  ``dim=3`` (NHWC channel axis).  Polaris tensors are NCHW throughout because
+  the permute+reshape that converts to NHWC is skipped (see above).
+- ``ttnn.conv2d`` / ``ttnn.conv_transpose2d`` return a single ``Tensor`` in the
+  polaris shim (no list unpacking of output_dim / weight cache).
+- ``ttnn.sigmoid`` at the end uses no shard-spec introspection (the polaris Tensor
+  does not carry a live memory config).
+"""
+
+import ttsim.front.ttnn as ttnn
+
+
+# ---------------------------------------------------------------------------
+# sharded_concat — canonical HEIGHT-shard pattern, list-first calling convention
+# ---------------------------------------------------------------------------
+
+def sharded_concat(input_tensors, num_cores=64, dim=1, force_sti_its=False):
+    """Concatenate sharded tensors with optional per-input STI+ITS resharding.
+
+    The ``force_sti_its`` flag forces an explicit ShardedToInterleaved →
+    InterleavedToSharded sequence per sharded input, even when the input's
+    memory_config equals the target by value.  Set it True for decoder blocks
+    whose downstream conv issues ``do_sharded_to_interleaved`` (d1, d2 in VGG
+    UNet) — tt-metal emits STI+ITS for every input in that pattern.  Leave it
+    False (default) for blocks that consume the sharded output directly without
+    reshuffling (d3, d4).
+    """
+    # 8×8 grid matches upstream for both WH and BH (performant_runner_infra.py CoreGrid(y=8, x=8)).
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7))})
+    in_shard_width = input_tensors[0].shape[dim]  # use concat axis, not shape[-1] (would be W in NCHW)
+    shard_height = ((input_tensors[0].shape[2]) + num_cores - 1) // num_cores
+    input_sharded_memory_config = ttnn.create_sharded_memory_config(
+        (shard_height, in_shard_width),
+        core_grid=shard_grid,
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        use_height_and_width_as_shard_shape=True,
+    )
+    out_shard_width = 0
+    for i in range(len(input_tensors)):
+        out_shard_width += input_tensors[i].shape[dim]  # sum concat-axis sizes, not shape[-1]
+        src_mc = getattr(input_tensors[i], '_memory_config', None)
+        if force_sti_its and src_mc is not None and src_mc.is_sharded():
+            input_tensors[i] = ttnn.sharded_to_interleaved(input_tensors[i], ttnn.L1_MEMORY_CONFIG)
+            input_tensors[i] = ttnn.interleaved_to_sharded(input_tensors[i], memory_config=input_sharded_memory_config)
+        else:
+            input_tensors[i] = ttnn.to_memory_config(input_tensors[i], input_sharded_memory_config)
+    output_sharded_memory_config = ttnn.create_sharded_memory_config(
+        (shard_height, out_shard_width),
+        core_grid=shard_grid,
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        use_height_and_width_as_shard_shape=True,
+    )
+    return ttnn.concat(input_tensors, dim, memory_config=output_sharded_memory_config)
+
+
+# ---------------------------------------------------------------------------
+# Conv
+# ---------------------------------------------------------------------------
+
+class Conv:
+    def __init__(
+        self,
+        device,
+        conv_param,
+        conv_pth,
+    ) -> None:
+        self.conv_param = conv_param
+        self.conv_pth = conv_pth
+        self.device = device
+        self.cache = {}  # type: ignore[var-annotated]
+
+        self.compute_config = ttnn.init_device_compute_kernel_config(
+            device.arch(),
+            math_fidelity=ttnn.MathFidelity.LoFi,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=False,
+            math_approx_mode=True,
+        )
+        self.conv_output_dtype = conv_param.dtype
+        output_layout = ttnn.TILE_LAYOUT if hasattr(conv_param, 'tile_layout') else ttnn.ROW_MAJOR_LAYOUT
+
+        self.conv_config = ttnn.Conv2dConfig(
+            weights_dtype=ttnn.bfloat8_b,
+            activation=conv_param.activation,
+            shard_layout=conv_param.shard_layout,
+            reshard_if_not_optimal=conv_param.reshard_if_not_optimal,
+            deallocate_activation=conv_param.deallocate_activation,
+            enable_act_double_buffer=conv_param.enable_act_double_buffer,
+            enable_weights_double_buffer=True,
+            output_layout=output_layout,
+        )
+        if conv_param.act_block_h is not None:
+            self.conv_config.act_block_h_override = conv_param.act_block_h
+
+        self.bias = conv_pth.bias
+        self.weight = conv_pth.weight
+
+        self.conv_kwargs = {
+            'in_channels': conv_param.in_channels,
+            'out_channels': conv_param.out_channels,
+            'batch_size': conv_param.batch_size,
+            'input_height': conv_param.input_height,
+            'input_width': conv_param.input_width,
+            'kernel_size': conv_param.kernel_size,
+            'stride': conv_param.stride,
+            'padding': conv_param.padding,
+            'dilation': conv_param.dilation,
+            'groups': conv_param.groups,
+            'device': device,
+            'conv_config': self.conv_config,
+            # emit_move_before_conv is a Polaris-side hint (no effect on HW); the
+            # shim's _with_halo wrapper consults this kwarg and skips its Move
+            # SimOp emission when False.  Default True preserves the
+            # deallocate_activation → Move behavior for positions where HW does
+            # emit Move.  See model_preprocessing.py for the rationale at each
+            # position where this is set False.
+            'emit_move_before_conv': getattr(conv_param, 'emit_move_before_conv', True),
+        }
+
+    def __str__(self) -> str:
+        return f'Conv: {self.weight.shape} {self.bias.shape} {self.conv_kwargs["kernel_size"]}'
+
+    def __call__(self, x):
+        # Polaris shim returns a single Tensor; canonical HW form unpacks 3-element list.
+        x = ttnn.conv2d(
+            input_tensor=x,
+            weight_tensor=self.weight,
+            bias_tensor=self.bias,
+            **self.conv_kwargs,
+            compute_config=self.compute_config,
+            return_output_dim=True,
+            return_weights_and_bias=True,
+            dtype=self.conv_output_dtype,
+        )
+        return x
+
+
+# ---------------------------------------------------------------------------
+# Conv_transpose
+# ---------------------------------------------------------------------------
+
+class Conv_transpose:
+    def __init__(
+        self,
+        device,
+        conv_param,
+        conv_pth,
+    ) -> None:
+        self.conv_param = conv_param
+        self.conv_pth = conv_pth
+        self.device = device
+        self.cache = {}  # type: ignore[var-annotated]
+
+        self.compute_config = ttnn.init_device_compute_kernel_config(
+            device.arch(),
+            math_fidelity=ttnn.MathFidelity.LoFi,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=False,
+            math_approx_mode=True,
+        )
+        output_layout = ttnn.TILE_LAYOUT if hasattr(conv_param, 'tile_layout') else ttnn.ROW_MAJOR_LAYOUT
+
+        self.conv_config = ttnn.Conv2dConfig(
+            weights_dtype=ttnn.bfloat8_b,
+            shard_layout=conv_param.shard_layout,
+            reshard_if_not_optimal=conv_param.reshard_if_not_optimal,
+            deallocate_activation=conv_param.deallocate_activation,
+            enable_act_double_buffer=conv_param.enable_act_double_buffer,
+            enable_weights_double_buffer=True,
+            output_layout=output_layout,
+        )
+        if conv_param.act_block_h is not None:
+            self.conv_config.act_block_h_override = conv_param.act_block_h
+
+        self.bias = conv_pth.bias
+        self.weight = conv_pth.weight
+
+        self.conv_kwargs = {
+            'in_channels': conv_param.in_channels,
+            'out_channels': conv_param.out_channels,
+            'batch_size': conv_param.batch_size,
+            'input_height': conv_param.input_height,
+            'input_width': conv_param.input_width,
+            'kernel_size': conv_param.kernel_size,
+            'stride': conv_param.stride,
+            'padding': conv_param.padding,
+            'dilation': conv_param.dilation,
+            'groups': conv_param.groups,
+            'device': device,
+            'conv_config': self.conv_config,
+            'output_padding': conv_param.output_padding,
+            # Polaris-side hint (no effect on real ttnn) — when False, the shim
+            # skips the auto-Move after Halo.  HW emits no Move at d3.up / d4.up
+            # convtranspose halo outputs (ttnn::move is no-op'd when the tensor
+            # is already in optimal layout), so the workload sets this False
+            # via conv_args.dN.up['emit_move_before_conv'] = False.
+            'emit_move_before_conv': getattr(conv_param, 'emit_move_before_conv', True),
+        }
+
+    def __str__(self) -> str:
+        return f'Conv_transpose: {self.weight.shape} {self.bias.shape} {self.conv_kwargs["kernel_size"]}'
+
+    def __call__(self, x):
+        # Polaris shim returns a single Tensor; canonical HW form unpacks [x, [w, b]].
+        x = ttnn.conv_transpose2d(
+            input_tensor=x,
+            weight_tensor=self.weight,
+            bias_tensor=self.bias,
+            **self.conv_kwargs,
+            compute_config=self.compute_config,
+            return_weights_and_bias=True,
+            mirror_kernel=True,
+            dtype=self.conv_param.dtype,
+        )
+        return x
+
+
+# ---------------------------------------------------------------------------
+# Tt_decoder_block
+# ---------------------------------------------------------------------------
+
+class Tt_decoder_block:
+    def __init__(self, device, conv_args, parameters) -> None:
+        self.conv_args = conv_args
+        self.up = Conv_transpose(device, conv_args.up, parameters.up)
+        self.conv1 = Conv(device, conv_args.conv_block.conv1, parameters.conv1)
+        self.conv2 = Conv(device, conv_args.conv_block.conv2, parameters.conv2)
+
+    def __call__(self, x, cat_in):
+        x = self.up(x)
+        # For decoder blocks whose conv1 follows with do_sharded_to_interleaved=True
+        # (d1, d2 on VGG UNet WH), tt-metal's sharded_concat reshuffles every input
+        # through STI+ITS — even when source and target memory configs are equal by
+        # value.  Pass force_sti_its so Polaris emits the same STI+ITS pairs that
+        # the HW profiler records for these decoder blocks.  d3/d4 don't follow
+        # that pattern (the explicit STS happens before the decoder block itself).
+        force_sti_its = bool(self.conv_args.conv_block.conv1.do_sharded_to_interleaved)
+        x = sharded_concat([x, cat_in], force_sti_its=force_sti_its)
+        if self.conv_args.conv_block.conv1.do_sharded_to_interleaved:
+            x = ttnn.sharded_to_interleaved(x, ttnn.L1_MEMORY_CONFIG)
+        x = self.conv1(x)
+        if self.conv_args.conv_block.conv2.do_sharded_to_interleaved:
+            x = ttnn.sharded_to_interleaved(x, ttnn.L1_MEMORY_CONFIG)
+        x = self.conv2(x)
+        return x
+
+
+# ---------------------------------------------------------------------------
+# Tt_vgg_unet
+# ---------------------------------------------------------------------------
+
+class Tt_vgg_unet:
+    def __init__(self, device, parameters, conv_args) -> None:
+        self.conv_args = conv_args
+        self.parameters = parameters
+        self.s1_0 = Conv(device, conv_args.s1['0'], parameters['0'])
+        self.s1_2 = Conv(device, conv_args.s1['2'], parameters['2'])
+        self.s2_5 = Conv(device, conv_args.s2['5'], parameters['5'])
+        self.s2_7 = Conv(device, conv_args.s2['7'], parameters['7'])
+        self.s3_10 = Conv(device, conv_args.s3['10'], parameters['10'])
+        self.s3_12 = Conv(device, conv_args.s3['12'], parameters['12'])
+        self.s3_14 = Conv(device, conv_args.s3['14'], parameters['14'])
+        self.s3_16 = Conv(device, conv_args.s3['16'], parameters['16'])
+        self.s4_19 = Conv(device, conv_args.s4['19'], parameters['19'])
+        self.s4_21 = Conv(device, conv_args.s4['21'], parameters['21'])
+        self.s4_23 = Conv(device, conv_args.s4['23'], parameters['23'])
+        self.s4_25 = Conv(device, conv_args.s4['25'], parameters['25'])
+        self.b1_28 = Conv(device, conv_args.b1['28'], parameters['28'])
+        self.b1_30 = Conv(device, conv_args.b1['30'], parameters['30'])
+        self.b1_32 = Conv(device, conv_args.b1['32'], parameters['32'])
+        self.b1_34 = Conv(device, conv_args.b1['34'], parameters['34'])
+        self.d1 = Tt_decoder_block(device, conv_args.d1, parameters.d1)
+        self.d2 = Tt_decoder_block(device, conv_args.d2, parameters.d2)
+        self.d3 = Tt_decoder_block(device, conv_args.d3, parameters.d3)
+        self.d4 = Tt_decoder_block(device, conv_args.d4, parameters.d4)
+        self.out = Conv(device, conv_args.out, parameters.out)
+
+    def __call__(self, input):
+        # Canonical HW entry path: Pad (C=3 → C=16) → 2× Transpose (NCHW → NHWC-flat) → first Halo/Conv.
+        # Both Transposes have LUT entries; emitting them as tracking-only SimOps gives +2 LUT hits.
+        # Logical (NCHW) shape is preserved through the transposes — only ``hw_shape`` advances —
+        # so conv_sinf continues to operate in NCHW with the right C=16 channel count.
+        x = ttnn.pad_channels_nchw(input, target_channels=16)
+        x = ttnn.permute_reshape_to_nhwc_flat(x)
+
+        x = self.s1_0(x)
+        x = self.s1_2(x)
+        s1 = x
+
+        x = ttnn.max_pool2d(
+            input_tensor=x,
+            batch_size=self.conv_args.s2['4'].batch_size,
+            input_h=self.conv_args.s2['4'].input_height,
+            input_w=self.conv_args.s2['4'].input_width,
+            channels=x.shape[1],  # type: ignore[index]
+            kernel_size=[self.conv_args.s2['4'].kernel_size, self.conv_args.s2['4'].kernel_size],
+            stride=[self.conv_args.s2['4'].stride, self.conv_args.s2['4'].stride],
+            padding=[self.conv_args.s2['4'].padding, self.conv_args.s2['4'].padding],
+            dilation=[self.conv_args.s2['4'].dilation, self.conv_args.s2['4'].dilation],
+        )
+        x = self.s2_5(x)
+        x = self.s2_7(x)
+        s2 = x
+
+        x = ttnn.max_pool2d(
+            input_tensor=x,
+            batch_size=self.conv_args.s3['9'].batch_size,
+            input_h=self.conv_args.s3['9'].input_height,
+            input_w=self.conv_args.s3['9'].input_width,
+            channels=x.shape[1],  # type: ignore[index]
+            kernel_size=[self.conv_args.s3['9'].kernel_size, self.conv_args.s3['9'].kernel_size],
+            stride=[self.conv_args.s3['9'].stride, self.conv_args.s3['9'].stride],
+            padding=[self.conv_args.s3['9'].padding, self.conv_args.s3['9'].padding],
+            dilation=[self.conv_args.s3['9'].dilation, self.conv_args.s3['9'].dilation],
+        )
+
+        x = self.s3_10(x)
+
+        # 8×8 grid matches upstream for both WH and BH (same hard-coding in ttnn_vgg_unet.py).
+        shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7))})
+        sharded_memory_config = ttnn.create_sharded_memory_config(
+            [512, 32],
+            core_grid=shard_grid,
+            strategy=ttnn.ShardStrategy.BLOCK,
+            use_height_and_width_as_shard_shape=True,
+        )
+        x = ttnn.to_memory_config(x, sharded_memory_config)
+
+        x = self.s3_12(x)
+        x = self.s3_14(x)
+        x = self.s3_16(x)
+        s3 = x
+
+        x = ttnn.max_pool2d(
+            input_tensor=x,
+            batch_size=self.conv_args.s4['18'].batch_size,
+            input_h=self.conv_args.s4['18'].input_height,
+            input_w=self.conv_args.s4['18'].input_width,
+            channels=x.shape[1],  # type: ignore[index]
+            kernel_size=[self.conv_args.s4['18'].kernel_size, self.conv_args.s4['18'].kernel_size],
+            stride=[self.conv_args.s4['18'].stride, self.conv_args.s4['18'].stride],
+            padding=[self.conv_args.s4['18'].padding, self.conv_args.s4['18'].padding],
+            dilation=[self.conv_args.s4['18'].dilation, self.conv_args.s4['18'].dilation],
+        )
+
+        x = self.s4_19(x)
+        x = self.s4_21(x)
+        x = self.s4_23(x)
+        x = self.s4_25(x)
+        s4 = x
+
+        x = ttnn.max_pool2d(
+            input_tensor=x,
+            batch_size=self.conv_args.b1['27'].batch_size,
+            input_h=self.conv_args.b1['27'].input_height,
+            input_w=self.conv_args.b1['27'].input_width,
+            channels=x.shape[1],  # type: ignore[index]
+            kernel_size=[self.conv_args.b1['27'].kernel_size, self.conv_args.b1['27'].kernel_size],
+            stride=[self.conv_args.b1['27'].stride, self.conv_args.b1['27'].stride],
+            padding=[self.conv_args.b1['27'].padding, self.conv_args.b1['27'].padding],
+            dilation=[self.conv_args.b1['27'].dilation, self.conv_args.b1['27'].dilation],
+        )
+
+        x = self.b1_28(x)
+        x = self.b1_30(x)
+        x = self.b1_32(x)
+        x = self.b1_34(x)
+
+        x = self.d1(x, s4)
+        ttnn.deallocate(s4)
+        x = self.d2(x, s3)
+        ttnn.deallocate(s3)
+        x = ttnn.sharded_to_interleaved(x, ttnn.L1_MEMORY_CONFIG)
+        x = self.d3(x, s2)
+        ttnn.deallocate(s2)
+        x = ttnn.sharded_to_interleaved(x, ttnn.L1_MEMORY_CONFIG)
+        x = self.d4(x, s1)
+        ttnn.deallocate(s1)
+        x = self.out(x)
+
+        x = ttnn.sigmoid(x)
+        return x

--- a/workloads/ttnn/vgg_unet/wh/__init__.py
+++ b/workloads/ttnn/vgg_unet/wh/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0

--- a/workloads/ttnn/vgg_unet/wh/test_vgg_unet_device_perf_wh.py
+++ b/workloads/ttnn/vgg_unet/wh/test_vgg_unet_device_perf_wh.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import os
+import sys
+
+sys.path.append('.')
+
+IS_POLARIS = os.getenv('IRD_ARCH_NAME', '') == ''
+
+from loguru import logger  # noqa: E402
+
+if not IS_POLARIS:
+    import time  # noqa: E402
+    import torch  # type: ignore[import-not-found]  # noqa: E402
+    import ttnn  # type: ignore[no-redef, import]  # noqa: E402
+    from models.demos.vision.segmentation.vgg_unet.common.runner.performant_runner import (  # type: ignore[import]  # noqa: E402
+        VggUnetTrace2CQ,
+    )
+    from models.perf.device_perf_utils import (  # type: ignore[import]  # noqa: E402
+        check_device_perf,
+        prep_device_perf_report,
+        run_device_perf,
+    )
+else:
+    import ttsim.front.ttnn as ttnn  # type: ignore[no-redef]
+    import ttsim.front.ttnn.minitorch_shim as torch  # type: ignore[no-redef]
+    from workloads.ttnn.vgg_unet.wh.vgg_unet_test_infra_polaris_wh import VggUnetTrace2CQ  # type: ignore[no-redef]
+
+
+# ---------------------------------------------------------------------------
+# run_vgg_unet_e2e — mirrors run_vgg_unet_e2e from test_e2e_performant.py
+# ---------------------------------------------------------------------------
+
+def run_vgg_unet_e2e(device, batch_size: int = 1):
+    # `batch_size` matches the (device, batch_size)->device contract documented on
+    # run_device_perf_polaris; pass-through to the inner trace as device_batch_size.
+    vgg_unet_trace_2cq = VggUnetTrace2CQ()
+    vgg_unet_trace_2cq.initialize_vgg_unet_trace_2cqs_inference(
+        device,
+        model_location_generator=None,
+        device_batch_size=batch_size,
+    )
+
+    if not IS_POLARIS:
+        batch_size = batch_size * device.get_num_devices()
+        input_shape = (batch_size, 3, 256, 256)
+        torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+        inference_iter_count = 3
+        t0 = time.time()
+        for _ in range(inference_iter_count):
+            output = vgg_unet_trace_2cq.run(torch_input_tensor)
+        ttnn.synchronize_device(device)
+        t1 = time.time()
+        vgg_unet_trace_2cq.release_vgg_unet_trace_2cqs_inference()
+        inference_time_avg = round((t1 - t0) / inference_iter_count, 6)
+        logger.info(
+            f'ttnn_vgg_unet_256x256_batch_size_{batch_size}. '
+            f'One inference iteration time (sec): {inference_time_avg}, '
+            f'FPS: {round(batch_size / inference_time_avg)}'
+        )
+    else:
+        output = vgg_unet_trace_2cq.run()
+        vgg_unet_trace_2cq.release_vgg_unet_trace_2cqs_inference()
+        output_torch = ttnn.to_torch(output)
+        expected_shape = [batch_size, 1, 256, 256]
+        assert output_torch.shape == expected_shape, (
+            f'Expected output shape {expected_shape}, but got {output_torch.shape}'
+        )
+        logger.info(f'run_vgg_unet_e2e: obtained expected output shape {expected_shape}')
+
+    return device
+
+
+def run_vgg_unet_e2e_entry(wlname: str, device: ttnn.device.Device, cfg: dict):
+    batch_size = cfg.get('bs', 1)
+    return run_vgg_unet_e2e(device, batch_size=batch_size)
+
+
+def run_vgg_unet_perf_device(wlname: str, device: ttnn.device.Device, cfg: dict):
+    """Workload-yaml entry point for analytical device perf reporting (WH).
+
+    Builds the graph on the polproj-provided *device* (so polproj's back-end
+    pipeline can run its own stats), and also produces a standalone JSON perf
+    report via the Polaris analytical path.
+    """
+    batch_size = cfg.get('bs', 1)
+    run_vgg_unet_e2e(device, batch_size=batch_size)
+    test_vgg_unet_perf_device(batch_size=batch_size)
+
+
+# ---------------------------------------------------------------------------
+# test_vgg_unet_perf_device — dual-mode device profiling
+# HW path: Tracy via subprocess wrapping test_e2e_performant.py.
+# Polaris path: analytical projection via run_device_perf_polaris.
+# ---------------------------------------------------------------------------
+
+def test_vgg_unet_perf_device(batch_size: int = 1, expected_kernel_samples_per_sec: int = 198):
+    cols = ['DEVICE FW', 'DEVICE KERNEL', 'DEVICE BRISC KERNEL']
+
+    if IS_POLARIS:
+        from workloads.common.polaris_device_perf import (
+            run_device_perf_polaris,
+            prep_device_perf_report_polaris,
+        )
+
+        post_processed_results = run_device_perf_polaris(
+            test_fn=run_vgg_unet_e2e,
+            batch_size=batch_size,
+            cols=cols,
+        )
+        prep_device_perf_report_polaris(
+            model_name=f'vgg-unet-wh-{batch_size}',
+            batch_size=batch_size,
+            post_processed_results=post_processed_results,
+        )
+        return
+
+    command = (
+        f'pytest models/demos/vision/segmentation/vgg_unet/wormhole/tests/perf/'
+        f'test_e2e_performant.py::test_vgg_unet_e2e[{batch_size}-device_params0]'
+    )
+
+    inference_time_key = 'AVG DEVICE KERNEL SAMPLES/S'
+    post_processed_results = run_device_perf(
+        command, subdir='vgg_unet', num_iterations=3, cols=cols, batch_size=batch_size,
+    )
+
+    expected_results = check_device_perf(
+        post_processed_results,
+        margin=0.03,
+        expected_perf_cols={inference_time_key: expected_kernel_samples_per_sec},
+        assert_on_fail=True,
+    )
+    prep_device_perf_report(
+        model_name=f'vgg-unet-wh-{batch_size}',
+        batch_size=batch_size,
+        post_processed_results=post_processed_results,
+        expected_results=expected_results,
+        comments='',
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry and CLI
+# ---------------------------------------------------------------------------
+
+_STANDALONE_RUN_SPECS: list[tuple[str, object, str]] = [
+    ('e2e', run_vgg_unet_e2e_entry, 'vgg-unet-wh-e2e'),
+]
+
+_STANDALONE_VALID_SHORT_NAMES = frozenset(s[0] for s in _STANDALONE_RUN_SPECS)
+
+
+def run_one(callback, wlname: str, cfg: dict):
+    if IS_POLARIS:
+        from ttsim.front.ttnn.device import close_device, open_device
+        device = open_device()
+    else:
+        from ttnn import close_device, open_device  # type: ignore[no-redef]
+        device = open_device(device_id=0, l1_small_size=32768, trace_region_size=6434816, num_command_queues=2)
+    callback(wlname, device, cfg)
+    close_device(device)
+
+
+def standalone(test_name: str | None = None) -> None:
+    """Run standalone WH e2e VGG UNet tests, or a single test by short name."""
+    all_names = _STANDALONE_VALID_SHORT_NAMES | {'device-perf'}
+
+    if test_name == 'device-perf':
+        test_vgg_unet_perf_device()
+        return
+
+    if test_name is None:
+        for _short, fn, wlname in _STANDALONE_RUN_SPECS:
+            run_one(fn, wlname, {})
+        return
+    if test_name not in all_names:
+        valid = ', '.join(sorted(all_names))
+        logger.error(f'Unknown test {test_name}. Valid names: {valid}')
+        sys.exit(1)
+    for short, fn, wlname in _STANDALONE_RUN_SPECS:
+        if short == test_name:
+            run_one(fn, wlname, {})
+            return
+
+
+if __name__ == '__main__':
+    logger.remove()
+    logger.add(sys.stdout, level='INFO')
+    parser = argparse.ArgumentParser(
+        description='Run VGG UNet (Wormhole) e2e standalone tests.'
+    )
+    parser.add_argument(
+        'test',
+        nargs='?',
+        metavar='TEST',
+        default='e2e',
+        help=(
+            'Run only this test by short name, '
+            'e.g. e2e, device-perf. If omitted, runs e2e.'
+        ),
+    )
+    _args = parser.parse_args()
+    standalone(_args.test)

--- a/workloads/ttnn/vgg_unet/wh/vgg_unet_test_infra_polaris_wh.py
+++ b/workloads/ttnn/vgg_unet/wh/vgg_unet_test_infra_polaris_wh.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Polaris-side equivalent of vgg_unet_test_infra.py from tt-metal (WH variant).
+
+Provides ``create_test_infra`` with the same interface so that
+``test_vgg_unet_device_perf_wh.py`` can run in dual-mode.
+"""
+
+import ttsim.front.ttnn as ttnn
+import ttsim.front.ttnn.minitorch_shim as torch  # type: ignore[no-redef]
+
+from ttsim.front.ttnn.device import set_default_device
+from ttsim.front.ttnn.tensor import ttnn_random
+from ttsim.front.ttnn.buffer import BufferType, TensorMemoryLayout
+from ttsim.front.ttnn.memory import MemoryConfig
+
+from workloads.ttnn.vgg_unet.common.model_preprocessing import create_vgg_unet_model_parameters
+from workloads.ttnn.vgg_unet.common.ttnn_vgg_unet import Tt_vgg_unet
+
+
+class VggUnetTestInfra:
+    """Polaris mirror of the upstream VggUnetTestInfra.
+
+    Builds synthetic parameters and a random [B, 3, 256, 256] input tensor.
+    The model is the polaris-native ``Tt_vgg_unet`` which expects NCHW input
+    and returns a segmentation mask of shape [B, 1, 256, 256].
+    """
+
+    def __init__(
+        self,
+        device,
+        batch_size,
+        inputs_mesh_mapper=None,
+        weights_mesh_mapper=None,
+        output_mesh_composer=None,
+        use_random_input_tensor: bool = False,
+        model_location_generator=None,
+    ):
+        torch.manual_seed(0)
+        set_default_device(device)
+
+        self.device = device
+        self.batch_size = batch_size
+
+        parameters = create_vgg_unet_model_parameters(device)
+        self.model = Tt_vgg_unet(device, parameters, parameters.conv_args)
+
+        self.torch_input = ttnn_random(
+            (batch_size, 3, 256, 256), -1, 1, dtype=torch.bfloat16,
+        )
+        self.input_tensor = None
+
+    def setup_l1_sharded_input(self, device, torch_input=None, mesh_mapper=None, mesh_composer=None):
+        if torch_input is None:
+            torch_input = self.torch_input
+        tt_inputs_host = ttnn.from_torch(
+            torch_input, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        input_mem_config = MemoryConfig(TensorMemoryLayout.HEIGHT_SHARDED, BufferType.L1)
+        return tt_inputs_host, input_mem_config
+
+    def setup_dram_sharded_input(self, device, _torch_input_tensor=None, mesh_mapper=None, mesh_composer=None):
+        tt_inputs_host, input_mem_config = self.setup_l1_sharded_input(
+            device, mesh_mapper=mesh_mapper, mesh_composer=mesh_composer,
+        )
+        sharded_mem_config_DRAM = MemoryConfig.DRAM
+        return tt_inputs_host, sharded_mem_config_DRAM, input_mem_config
+
+    def run(self, tt_input_tensor=None):
+        self.output_tensor = None
+        input_tensor = tt_input_tensor if tt_input_tensor is not None else self.input_tensor
+        self.output_tensor = self.model(input_tensor)
+        return self.output_tensor
+
+
+def create_test_infra(
+    device,
+    batch_size,
+    inputs_mesh_mapper=None,
+    weights_mesh_mapper=None,
+    output_mesh_composer=None,
+    use_random_input_tensor: bool = False,
+    model_location_generator=None,
+):
+    return VggUnetTestInfra(
+        device,
+        batch_size,
+        inputs_mesh_mapper,
+        weights_mesh_mapper,
+        output_mesh_composer,
+        use_random_input_tensor,
+        model_location_generator=model_location_generator,
+    )
+
+
+class VggUnetTrace2CQ:
+    """Polaris stub matching the interface of ``VggUnetTrace2CQ`` from
+    ``common/runner/performant_runner.py``.
+
+    On polaris there is no 2CQ / trace — initialize just builds the model and
+    prepares the input; run executes one forward pass.
+    """
+
+    def initialize_vgg_unet_trace_2cqs_inference(
+        self, device, model_location_generator=None, device_batch_size=1
+    ):
+        self._infra = create_test_infra(
+            device, device_batch_size, model_location_generator=model_location_generator
+        )
+        tt_inputs_host, _, input_mem_config = self._infra.setup_dram_sharded_input(device)
+        self._infra.input_tensor = ttnn.to_memory_config(tt_inputs_host, input_mem_config)
+
+    def run(self, torch_input_tensor=None):
+        """Run a forward pass and return the output tensor.
+
+        ``torch_input_tensor`` is accepted to match the upstream tt-metal
+        ``VggUnetTrace2CQ.run()`` interface but is currently IGNORED in
+        polaris mode — the input tensor initialised in
+        ``initialize_vgg_unet_trace_2cqs_inference`` is used instead.
+        Polaris doesn't execute kernels, so tensor *values* don't drive
+        the SimOp graph; only the input *shape* matters.
+
+        TODO(honor-input): to honor ``torch_input_tensor`` in polaris mode,
+        extract its shape, rebuild ``self._infra.input_tensor`` via
+        ``ttnn._rand(shape=..., dtype=..., device=...)``, then re-run the
+        to_memory_config path from ``initialize_*``. Leaving as no-op until
+        a real caller exercises this — current polaris test entries pass
+        no ``torch_input_tensor`` (they reuse the pre-init random input).
+        """
+        self._infra.run()
+        return self._infra.output_tensor
+
+    def release_vgg_unet_trace_2cqs_inference(self):
+        pass


### PR DESCRIPTION
## Summary

Adds the VGG UNet WH/BH dual-mode workload to Polaris and brings its LUT-hit rate to **100% on both SKUs** with network-total gaps of **+0.72% (WH n150)** and **+1.69% (BH p100a)** against silicon-captured profiler traces.

Scope grew in-place: started as a workload registration PR (issue #428), then absorbed (1) the Polaris-side shim / model / op-canonical changes to match the HW profiler op-for-op, (2) the per-op variant LUT key work (#45), and (3) a modeling-floor audit that closed the residual gaps on BH p100a.

## Final results (4-combo verification, all post-current-HEAD)

| Combo | Polaris (ms) | Profiler (ms) | Gap | LUT hits |
|---|---|---|---|---|
| ViT WH n150 (bs=8) | 5.0428 | 5.0924 | +0.98% | 204/204 |
| ViT BH p100a (bs=10) | 3.2423 | 3.2795 | +1.15% | 192/192 |
| VGG WH n150 (bs=1) | 3.2675 | 3.2911 | **+0.72%** | **102/102** |
| VGG BH p100a (bs=1) | 2.4738 | 2.5156 | **+1.69%** | **102/102** |

VGG BH journey (this PR's scope): **+7.83% (pre-#45) → +1.69% (HEAD)** — 6.14pp closure. WH journey: **+1.95% → +0.72%** (\|gap\| improved 1.23pp).

## Changes

### Workload registration (original scope)
- `workloads/ttnn/vgg_unet/common/` — Polaris-native TTNN model (`ttnn_vgg_unet.py`) and synthetic parameter tree (`model_preprocessing.py`), structurally aligned with the canonical tt-metal implementation.
- `workloads/ttnn/vgg_unet/wh/` and `workloads/ttnn/vgg_unet/bh/` — dual-mode test-infra and device-perf runners.
- `config/all_workloads.yaml` — `vgg_unet_{wh,bh}_b1_{device_perf,perf_report}` instances.

### Shim / op-canonical fidelity work
- **Conv weight/bias HW preprocessing** in `conv_sinf` (NHWC-flat, TILE BFLOAT8_B, DRAM) — both Conv and 1×1-conv → MatMul paths.
- **Halo geometry** — base `_HALO_EXT_Y` table calibrated against WH n150 trace.
- **Move emission semantics** — `_with_halo` reordered to ITS → Halo → Move → Conv (matching HW); Move suppressed via `emit_move_before_conv=False` when HW doesn't emit one (s3/s4/b1 encoder convs; **d3.up + d4.up convtranspose** added today).
- **C=3 → C=16 channel pad + entry-path Transposes** — `pad_channels_nchw` + `permute_reshape_to_nhwc_flat` in the shim.
- **sharded_concat force_sti_its** — explicit STS+ITS per input for decoder blocks d1 / d2.
- **op_canonical refinements** — `maxpool → pool2d` synonym, `PREALLOC_OUTPUT_AS_INPUT1_OPS` rule.
- **LUT lookup fallback ladders** in `lookup_operator_perf.py` (Halo / Move / Conv HEIGHT→BLOCK; ITS L1→DRAM; ROW_MAJOR→TILE).
- **shim audit divergences fixed** today vs canonical tt-metal source: Conv2dConfig `output_layout` propagation (15 tile_layout convs), auto-ITS `shard_layout` (8 decoder positions, was hardcoded HEIGHT), Move auto-emission alignment with HW behavior (consecutive encoder convs).

### Today's session — #45 schema work landed + #428 modeling-floor audit

**#45 (per-op variant LUT keys) — cherry-picked from branch 437 (PR #438):**

| Commit | Scope |
|---|---|
| `5c4b99e` | schema v3 — per-op variant key tuples (halo 15-field, ITS 10-field) |
| `a83fee8` | mapper extracts `SlidingWindowConfig` / `OUTPUT_0_MEMORY` |
| `253bd96` | lookup builds variant keys |
| `99ee358` | show_layers_profiler matches |
| `9083b3b` | `--cv-threshold` CLI knob for tt_perf_mapper |
| `3702bb8` | schema v4 — halo gains `is_transpose` (disambiguates Conv vs ConvTranspose halos that previously collided 5.3× on hardware) |
| `520ccea` | bump WH/BH configs to `_v5.yaml` LUTs (schema v4) |

**#428 modeling-floor audit — new this session:**

| Commit | Scope |
|---|---|
| `ba515d1` | Pre-commit pipeline unblock (language:system + .git pointer file skip) |
| `1bf103a` | `lut_hit_source` diagnostic column on opstats CSV (12 enumerated values: `direct` + 9 named fallbacks + `analytical` + null) |
| `c955831` | **D.2a** — arch-aware channel padding for BLOCK_SHARDED conv2d: new `compute_grid_size` arch-config field; new `tools/perf_lookup/conv_parallel_config.py` (port of tt-metal's `determine_parallel_config`); `SimTensor.x_pad_logical` attr; graph annotation pass at `Device.execute_graph`; `_shape_wzyx` prefers `x_pad_logical` |
| `a2374ab` | **D.2b** — per-device `_HALO_EXT_Y_OVERRIDES_BY_DEVICE` table for halo y values that diverge from base table; `SimTensor.y_pad_logical` + new annotation pass with forward-propagation through Move/ITS/STS/Reshard |
| `aaa47f2` | **D.2c** — BH-specific halo y override for d4 up convtranspose (mapper normalizes Conv2dDeviceOperation w/ is_transpose=true to `op_code=convtranspose` during LUT generation) |
| `f8498ef` | **D.3.2** — backward-propagate `x_pad_logical` through Move-class passthroughs (Halo excluded; Halo's LUT key uses pre-halo shape) |
| `c27679f` | **D.3.3** — skip auto-Move at d3.up + d4.up convtranspose; plumb `emit_move_before_conv` through Conv_transpose call site (was missing) |

## Architecture additions exposed for reuse

- `tools/perf_lookup/conv_parallel_config.py` — Polaris-side mimic of tt-metal's `determine_parallel_config` for BLOCK_SHARDED. Future workloads with BLOCK_SHARDED convs get correct channel padding automatically.
- `compute_grid_size: [x, y]` field on `PackageInstanceModel` (`ttsim/config/simconfig.py`). Currently populated for p100a (`[12, 10]`) and n150 (`[8, 9]`); add per-SKU for new arches.
- `SimTensor.x_pad_logical` + `y_pad_logical` attrs + LUT-key consumer in `_shape_wzyx` — the annotation-pass pattern for arch-aware LUT key overrides (extensible to other arch divergences).
- `lut_hit_source` opstats CSV column — diagnostic for distinguishing direct hits vs fallback hits vs analytical fallback. Future audit work uses this to isolate root causes per op.

## Known limitations / deferred

- **math_fidelity refactor (deferred)** — `_MATH_FIDELITY_CALLER_CONTROLLED_OPS = frozenset({"layernorm"})` was shown to be too narrow against tt-metal (conv2d/matmul/pool also caller-controlled). VGG UNet currently uses LoFi everywhere so the present 100% hit rate works, but a future workload mixing LoFi + HiFi4 at the same conv shape would silently get wrong perf. Long-term: expand the set, plumb real `math_fidelity` through emit sites, repopulate LUT with per-fidelity entries. Captured in memory `project_math_fidelity_set_too_narrow.md`. Should land after this PR to avoid scope mixing.
- **D.4 — ViT Reshard under-emission (deferred)** — ViT polaris emits 2 fewer Reshards than HW (BH; 1 fewer on WH). tt-metal's `ttnn.to_memory_config()` after fold dispatches to reshards on HW; polaris's `to_memory_config` shim is a no-op (just updates `_memory_config` attr). Generic fix: make the shim emit appropriate Reshard/STI SimOps for layout transitions. ~0.024ms gap absolute (<1% of network total). Not blocking.
- **VGG BH residual conv2d +0.0286ms** — modeling diff between polaris analytical and HW measurement for the 24 conv2d that DO hit the LUT directly. Sub-1% impact.
- **VGG BH missing HW Reshards (+0.0097ms)** — symmetric to D.4 on the VGG side. Same `to_memory_config` shim work would close this.

## Dependencies

- **PR #438** (issue #437) — bundles the #45 schema work + compare_layers same-type comparison support. Cherry-picked here; will deduplicate at merge time.
- **PR #443** (issue #442) — `ops_perf_three_csv_merge` tool. Cherry-picked; will deduplicate at merge time.
- **PR #450** (issue #449) — spdxchecker worktree fix. Cherry-picked as `d0775d6` equivalent.

## LFC

References `lfc://hlm-lut/{whb0_n150,bh_p100a}_lut_v5.yaml` (schema v4). Both uploaded 2026-05-24.

## Test plan

- [x] `pytest -m "unit and not slow"` — full suite passes on branch HEAD (101 tests in `tests/test_tools/`; 8 new tests for `conv_parallel_config`; new test `test_halo_key_distinguishes_conv_from_conv_transpose` locks in schema v4 Conv ≠ ConvTranspose property)
- [x] `mypy` — clean
- [x] Polaris VGG UNet WH device-perf: 102/102 LUT hits, +0.72% gap
- [x] Polaris VGG UNet BH device-perf: 102/102 LUT hits, +1.69% gap
- [x] Polaris ViT WH device-perf: 204/204 LUT hits, +0.98% gap
- [x] Polaris ViT BH device-perf: 192/192 LUT hits, +1.15% gap
- [x] `tools/profiling/compare_layers.py --perf --by-lut-key` end-to-end against HW merged CSV for all 4 combos
- [x] Pre-commit hooks (SPDX, static, unit) pass on every commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
