### PR TITLE
Dynamic sizes for ONNX graphs

### DIFF
--- a/config/ip_workloads.yaml
+++ b/config/ip_workloads.yaml
@@ -44,13 +44,13 @@ workloads:
     name: model_20240914_fp16
     basedir: workloads
     instances:
-      model_20240914_fp16 : { path: 'onnx/mlexp_header_model_fp16_20240914_003924.onnx', bs: 1 }
+      model_20240914_fp16 : { path: 'onnx/mlexp_header_model_fp16_20240914_003924.onnx', bs: 1, data_dynamic_axes_2: 128 }
 
   - api: ONNX
     name: model_20240914_base
     basedir: workloads
     instances:
-      model_20240914_base : { path: 'onnx/mlexp_header_model_20240914_003924.onnx', bs: 1 }
+      model_20240914_base : { path: 'onnx/mlexp_header_model_20240914_003924.onnx', bs: 1, data_dynamic_axes_2: 128 }
 
   - api: TTSIM
     name: DeformableDETR

--- a/polaris.py
+++ b/polaris.py
@@ -10,7 +10,7 @@ import time
 import tracemalloc
 from itertools import product
 from pathlib import Path
-from typing import Any, Set
+from typing import Any, Set, Optional
 
 from ttsim.config import TTSimHLRunSummary, get_arspec_from_yaml, get_wlmapspec_from_yaml, get_wlspec_from_yaml
 from ttsim.front.onnx.onnx2nx import onnx2graph  # NOTE: import from ttsim.front had potential cyclic dependency
@@ -129,19 +129,56 @@ def get_wlgraph(TBL, wlg, wln, wli, gcfg, wpath, enable_memalloc):
                 close_device(ttnn_device)
         elif wlg == 'ONNX':
             logger.info(">>onnx-wl = {}.{}.{}.b{} = {}", wlg, wln, wli, wlb, wpath)
-            onnx_graph = onnx2graph(wli, wpath)
+            dim_overrides: dict = {}
+            if isinstance(gcfg, dict):
+                for k, v in gcfg.items():
+                    if k == 'path':
+                        continue
+                    coerced: Optional[int] = None
+                    if isinstance(v, bool):
+                        pass
+                    elif isinstance(v, int):
+                        coerced = v
+                    elif isinstance(v, str) and v.strip().lstrip('-').isdigit():
+                        coerced = int(v)
+                    if coerced is not None:
+                        dim_overrides[k] = coerced
+                    elif isinstance(v, (float, str)):
+                        logger.debug(
+                            "ONNX dim_overrides: skipping non-integer cfg key "
+                            "'{}' = {!r} for {}.{}.{}.b{}",
+                            k, v, wlg, wln, wli, wlb,
+                        )
+
+                for legacy_key in ('dim_overrides', 'onnx_params'):
+                    legacy_val = gcfg.get(legacy_key)
+                    if isinstance(legacy_val, dict) and legacy_val:
+                        logger.warning(
+                            "ONNX cfg for {}.{}.{}.b{} uses unsupported '{}:' "
+                            "block with keys {}. Lift those keys to the top of "
+                            "the instance dict, e.g. `bs: 1, data_dynamic_axes_2: 128`. "
+                            "They will NOT be applied as written.",
+                            wlg, wln, wli, wlb,
+                            legacy_key, list(legacy_val.keys()),
+                        )
+
+            logger.debug("ONNX dim_overrides for {}.{}.{}.b{} = {}",
+                         wlg, wln, wli, wlb, dim_overrides)
+
+            onnx_graph = onnx2graph(wli, wpath, dim_overrides=dim_overrides)
             TBL[(wlg,wln,wli,wlb)] = (None, onnx_graph)
             for _,op in onnx_graph._ops.items():
                 itensors = [onnx_graph._tensors[x] for x in op.inList]
                 otensors = [onnx_graph._tensors[x] for x in op.outList]
                 logger.info("CALLING get_perf_counts for: {}", op.name)
-                #for x in itensors: print(x)
-                #for x in otensors: print(x)
                 op.get_perf_counts(itensors, otensors)
                 op.update_tensor_counts(itensors,otensors)
-                #logger.info(op.perf_stats)
+
         else:
-            assert False, f"Workload Group: {wlg} is not supported; Current Support only for (TTSIM,TTNN,ONNX)"
+            assert False, (
+                    f"Workload Group: {wlg} is not supported; "
+                    f"Current Support only for (TTSIM, TTNN, ONNX)"
+            )
 
     return TBL[(wlg,wln,wli,wlb)]
 

--- a/tests/test_workloads/test_onnx_dynamic_shapes.py
+++ b/tests/test_workloads/test_onnx_dynamic_shapes.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for YAML-driven dynamic shape support in onnx2nx.py."""
+
+import os
+import tempfile
+
+import onnx
+import pytest
+from onnx import TensorProto, helper
+
+from ttsim.front.onnx.onnx2nx import (
+    _resolve_symbolic_dim,
+    onnx2graph,
+)
+
+def _build_symbolic_onnx(path: str) -> None:
+    """Build a tiny ONNX model with a symbolic batch dim.
+
+    Graph: input X[batch_size, 4]  --MatMul-->  Y[batch_size, 2]
+    where W is a (4, 2) initializer.
+    """
+    X = helper.make_tensor_value_info(
+        "X", TensorProto.FLOAT, ["batch_size", 4]
+    )
+    Y = helper.make_tensor_value_info(
+        "Y", TensorProto.FLOAT, ["batch_size", 2]
+    )
+    W = helper.make_tensor(
+        "W", TensorProto.FLOAT, [4, 2], [0.0] * 8,
+    )
+    node = helper.make_node("MatMul", ["X", "W"], ["Y"], name="mm")
+    graph = helper.make_graph([node], "g", [X], [Y], initializer=[W])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 14)])
+    model.ir_version = 8
+    onnx.save(model, path)
+
+def _build_unmapped_symbolic_onnx(path: str) -> None:
+    """Build a tiny ONNX model with a symbolic dim no override will cover."""
+    X = helper.make_tensor_value_info(
+        "X", TensorProto.FLOAT, [1, "weird_axis_42"]
+    )
+    Y = helper.make_tensor_value_info(
+        "Y", TensorProto.FLOAT, [1, "weird_axis_42"]
+    )
+    node = helper.make_node("Identity", ["X"], ["Y"], name="id")
+    graph = helper.make_graph([node], "g", [X], [Y])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 14)])
+    model.ir_version = 8
+    onnx.save(model, path)
+
+def test_resolve_exact_name_match():
+    assert _resolve_symbolic_dim("data_dynamic_axes_2", {"data_dynamic_axes_2": 128}) == 128
+
+def test_resolve_alias_match():
+    assert _resolve_symbolic_dim("batch_size", {"bs": 8}) == 8
+    assert _resolve_symbolic_dim("sequence_length", {"seq_len": 1024}) == 1024
+    assert _resolve_symbolic_dim("H", {"img_height": 224}) == 224
+
+def test_resolve_axis0_batch_heuristic():
+    assert _resolve_symbolic_dim("custom_name", {"bs": 4}, axis=0) == 4
+
+def test_resolve_fallback_to_1():
+    """Unmapped symbolic dim falls back to 1 (legacy behavior)."""
+    assert _resolve_symbolic_dim(
+        "unmapped_dim", {"bs": 8}, tensor_name="t", axis=2,
+    ) == 1
+
+def test_onnx2graph_resolves_symbolic_via_alias():
+    """batch_size symbolic dim → resolved via 'bs' alias to concrete int."""
+    with tempfile.TemporaryDirectory() as td:
+        path = os.path.join(td, "sym.onnx")
+        _build_symbolic_onnx(path)
+
+        g = onnx2graph("sym_test", path, dim_overrides={"bs": 8})
+
+        x_tensor = g._tensors["X"]
+        assert x_tensor.shape == [8, 4], f"expected [8, 4], got {x_tensor.shape}"
+        y_tensor = g._tensors["Y"]
+        assert y_tensor.shape == [8, 2], f"expected [8, 2], got {y_tensor.shape}"
+
+def test_onnx2graph_exact_name_override():
+    """Direct symbolic-name override (no alias) works."""
+    with tempfile.TemporaryDirectory() as td:
+        path = os.path.join(td, "sym.onnx")
+        _build_symbolic_onnx(path)
+        g = onnx2graph("sym_test", path, dim_overrides={"batch_size": 16})
+        assert g._tensors["X"].shape == [16, 4]
+        assert g._tensors["Y"].shape == [16, 2]
+
+def test_onnx2graph_no_overrides_falls_back_to_1():
+    """Without dim_overrides, symbolic dims fall back to 1 (legacy behavior)."""
+    with tempfile.TemporaryDirectory() as td:
+        path = os.path.join(td, "sym.onnx")
+        _build_symbolic_onnx(path)
+        g = onnx2graph("sym_test", path)
+        assert g._tensors["X"].shape == [1, 4]
+        assert g._tensors["Y"].shape == [1, 2]
+
+def test_onnx2graph_unmapped_symbolic_falls_back_to_1():
+    """Unmapped symbolic dim with no matching override → 1 + warning."""
+    with tempfile.TemporaryDirectory() as td:
+        path = os.path.join(td, "sym.onnx")
+        _build_unmapped_symbolic_onnx(path)
+        g = onnx2graph("sym_test", path, dim_overrides={"bs": 99})
+        assert g._tensors["X"].shape == [1, 1]
+
+def test_onnx2graph_fixed_shape_unaffected():
+    """Models with no symbolic dims behave identically with or without overrides."""
+    with tempfile.TemporaryDirectory() as td:
+        path = os.path.join(td, "fixed.onnx")
+        X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [3, 4])
+        Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [3, 2])
+        W = helper.make_tensor("W", TensorProto.FLOAT, [4, 2], [0.0] * 8)
+        node = helper.make_node("MatMul", ["X", "W"], ["Y"], name="mm")
+        graph = helper.make_graph([node], "g", [X], [Y], initializer=[W])
+        model = helper.make_model(
+            graph, opset_imports=[helper.make_opsetid("", 14)]
+        )
+        model.ir_version = 8
+        onnx.save(model, path)
+
+        g1 = onnx2graph("fixed_test", path, dim_overrides={"bs": 99})
+        assert g1._tensors["X"].shape == [3, 4]
+        g2 = onnx2graph("fixed_test", path)
+        assert g2._tensors["X"].shape == [3, 4]

--- a/ttsim/config/simconfig.py
+++ b/ttsim/config/simconfig.py
@@ -223,9 +223,11 @@ class WorkloadTTNN(WorkloadCfgBlk):
 class WorkloadONNX(WorkloadCfgBlk):
     # Type declarations for INSTANCE attributes
     instances: dict
+    params: dict
     basedir: str
     # Class attributes
     required_fields = ['basedir', 'instances']
+    optional_fields: dict[str, Any] = {'params': {}}
 
     def __init__(self, wlname, **kwargs):
         super().__init__(wlname, **kwargs)
@@ -234,7 +236,11 @@ class WorkloadONNX(WorkloadCfgBlk):
     def get_instances(self):
         result = {}
         for iname, icfg in self.instances.items():
-            xcfg = {xx: icfg[xx] for xx in icfg}
+            xcfg = {}
+            if self.params:
+                xcfg.update(self.params)
+            for xx, xv in icfg.items():
+                xcfg[xx] = xv
             result[iname] = {'group': self.name, 'cfg': xcfg}
             result[iname]['path'] = os.path.join(self.basedir, xcfg['path'])
         return result

--- a/ttsim/config/validators.py
+++ b/ttsim/config/validators.py
@@ -85,12 +85,17 @@ class PYDWorkloadONNXModelValidator(PYDWorkloadBaseModel):
     name: str
     basedir: str
     instances: dict
+    params: Optional[dict] = {}
 
     def get_instances(self):
         result = {}
         for iname, icfg in self.instances.items():
-            xcfg = {xx: icfg[xx] for xx in icfg}
-            result[iname] = {'group': self.name, 'cfg': xcfg }
+            xcfg = {}
+            if self.params:
+                xcfg.update(self.params)
+            for xx, xv in icfg.items():
+                xcfg[xx] = xv
+            result[iname] = {'group': self.name, 'cfg': xcfg}
             result[iname]['path'] = os.path.join(self.basedir, xcfg['path'])
         return result
 

--- a/ttsim/front/onnx/onnx2nx.py
+++ b/ttsim/front/onnx/onnx2nx.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any
+from typing import Any, Optional
 from collections import defaultdict
 
 import onnx
@@ -12,6 +12,45 @@ from loguru import logger
 from ttsim.graph import WorkloadGraph
 from ttsim.ops import SimOp, SimTensor
 
+_DIM_NAME_ALIASES: dict[str, str] = {
+    "batch_size": "bs", "batch": "bs", "N": "bs",
+    "sequence_length": "seq_len", "S": "seq_len",
+    "height": "img_height", "H": "img_height",
+    "width":  "img_width",  "W": "img_width",
+    "channels": "img_channels", "C": "img_channels",
+}
+
+def _resolve_symbolic_dim(name: str,
+                          dim_overrides: Optional[dict],
+                          tensor_name: str = "<unknown>",
+                          axis: int = -1) -> int:
+    """Resolve a single symbolic ONNX dim name to an int using YAML overrides.
+
+    Lookup order:
+      1. Exact match in dim_overrides (e.g. data_dynamic_axes_2: 128).
+      2. Canonical alias match (e.g. batch_size -> bs -> 8).
+      3. If axis == 0 and 'bs' is in overrides, use it (batch heuristic).
+      4. Fallback: 1, with a warning (matches legacy behavior).
+    """
+    if dim_overrides:
+        if name in dim_overrides:
+            return int(dim_overrides[name])
+        canonical = _DIM_NAME_ALIASES.get(name)
+        if canonical and canonical in dim_overrides:
+            return int(dim_overrides[canonical])
+        if axis == 0 and "bs" in dim_overrides:
+            logger.info(
+                "Resolving symbolic dim '{}' on axis 0 of tensor '{}' to bs={} "
+                "(axis-0 batch heuristic — no exact/alias match found).",
+                name, tensor_name, dim_overrides["bs"],
+            )
+            return int(dim_overrides["bs"])
+    logger.warning(
+        "No override for symbolic dim '{}' in tensor '{}' (axis={}), defaulting to 1",
+        name, tensor_name, axis,
+    )
+    return 1
+
 def get_io_errstr(xarg, xdim, xdim1, is_init, is_val, is_in, is_out, ginfo):
     errstr  = f"shape mismatch: {xarg} : {xdim} != {xdim1}\n"
     errstr += f"initializer: {ginfo['initializer'][xarg]}\n" if is_init else ""
@@ -20,7 +59,7 @@ def get_io_errstr(xarg, xdim, xdim1, is_init, is_val, is_in, is_out, ginfo):
     errstr += f"output     : {ginfo['output'][xarg]}\n"      if is_out  else ""
     return errstr
 
-def parse_onnx_model(wlname, wlpath):
+def parse_onnx_model(wlname, wlpath, dim_overrides: Optional[dict] = None):
     """
     #Follows spec at https://github.com/onnx/onnx/blob/main/docs/IR.md
     # ir_version        int64                The ONNX version assumed by the model.
@@ -51,6 +90,21 @@ def parse_onnx_model(wlname, wlpath):
             )
         else:
             raise
+
+    # Apply YAML-driven overrides to the model graph inputs *before* shape inference
+    if dim_overrides:
+        for ginput in modelpb.graph.input:
+            tname = ginput.name
+            shape = ginput.type.tensor_type.shape
+            for axis, dim in enumerate(shape.dim):
+                if dim.HasField("dim_param"):
+                    new_val = _resolve_symbolic_dim(
+                        dim.dim_param, dim_overrides,
+                        tensor_name=tname, axis=axis,
+                    )
+                    dim.Clear()
+                    dim.dim_value = int(new_val)
+        del modelpb.graph.value_info[:]
 
     modelpb_inferred = shape_inference.infer_shapes(modelpb)
     modelpb = modelpb_inferred
@@ -158,7 +212,7 @@ def parse_onnx_model(wlname, wlpath):
         onnxgraphinfo['node'].append(nodeinfo)
 
     #resolve graph tensors
-    tensorinfo = get_resolved_tensors(onnxgraphinfo)
+    tensorinfo = get_resolved_tensors(onnxgraphinfo, dim_overrides=dim_overrides)
     #add_edges(onnxgraphinfo)
 
     ##############################################
@@ -190,18 +244,17 @@ def parse_value_info(vinfo):
             }
 
 def get_tensor_type_info(t):
-    dims: list[int] = []
+    dims: list = []
     for dim in t.tensor_type.shape.dim:
-        value = getattr(dim, dim.WhichOneof("value"))
         if dim.HasField("dim_param"):
-            value = 1 if not dims else str(value)
+            value: Any = str(dim.dim_param)
         elif dim.HasField("dim_value"):
-            value = int(value)
+            value = int(dim.dim_value)
         else:
             raise ValueError(f"Unknown field type for dim {dim}")
         dims.append(value)
     dtype = helper.tensor_dtype_to_np_dtype(t.tensor_type.elem_type)
-    return { 'dtype': dtype, 'dims': dims }
+    return {'dtype': dtype, 'dims': dims}
 
 def onnx_get_value_from_attrs(attr, **kwargs):
     """
@@ -239,7 +292,7 @@ def onnx_get_value_from_attrs(attr, **kwargs):
     else:
         raise ValueError(f"Found some unknown type of attribute for key {attr.name}\n{dir(attr)}\n{attr}")
 
-def resolve_tensor(_tname, _info):
+def resolve_tensor(_tname, _info, dim_overrides: Optional[dict] = None):
     INIT_TBL    = _info['initializer']
     VALINFO_TBL = _info['value_info']
     IN_TBL      = _info['input']
@@ -336,17 +389,16 @@ def resolve_tensor(_tname, _info):
         )
         dims = [1]
 
-    # Dynamic or symbolic dimensions (non-integer) are not supported.
-    # If we see them, coerce to 1 with a warning .
     if any(not isinstance(d, int) for d in dims):
-        logger.warning(
-            "Dynamic/symbolic dimensions {} in tensor '{}', "
-            "coercing all non-int dims to 1 for shape-only Polaris mode.",
-            dims,
-            _tname,
+        logger.info(
+            "Resolving symbolic dims {} in tensor '{}' using YAML overrides.",
+            dims, _tname,
         )
-        # data_dynamic_axes_2 is an input size parameter for PANW model. For Polaris simulation, this is being set to 128.
-        dims = [d if isinstance(d, int) else 128 if d == 'data_dynamic_axes_2' else 1 for d in dims]
+        dims = [
+            d if isinstance(d, int)
+            else _resolve_symbolic_dim(str(d), dim_overrides, tensor_name=_tname, axis=i)
+            for i, d in enumerate(dims)
+        ]
 
     dims = [int(d) for d in dims]
     return {
@@ -360,7 +412,7 @@ def resolve_tensor(_tname, _info):
     }
 
 
-def get_resolved_tensors(G):
+def get_resolved_tensors(G, dim_overrides: Optional[dict] = None):
     """
     # The occurrence of a name as a graph input, a graph initializer, or as a node output is said to be a definition
     # and the occurrence of a name as a node input or as a graph output is said to be a use.
@@ -384,7 +436,7 @@ def get_resolved_tensors(G):
     TENSORS = {}
     for node in G['node']:
         for itensor in node['inList']:
-            itensor_info = resolve_tensor(itensor, G)
+            itensor_info = resolve_tensor(itensor, G, dim_overrides=dim_overrides)
             if itensor not in TENSORS:
                 TENSORS[itensor] = itensor_info
             else:
@@ -397,7 +449,7 @@ def get_resolved_tensors(G):
             TENSORS[itensor]['op_in'].append(node['name'])
 
         for otensor in node['outList']:
-            itensor_info = resolve_tensor(otensor, G)
+            itensor_info = resolve_tensor(otensor, G, dim_overrides=dim_overrides)
             if otensor not in TENSORS:
                 TENSORS[otensor] = itensor_info
             else:
@@ -411,8 +463,8 @@ def get_resolved_tensors(G):
     return TENSORS
 
 
-def onnx2graph(_wlname, _wlpath):
-    H,G,T = parse_onnx_model(_wlname, _wlpath)
+def onnx2graph(_wlname, _wlpath, dim_overrides: Optional[dict] = None):
+    H, G, T = parse_onnx_model(_wlname, _wlpath, dim_overrides=dim_overrides)
 
     gg = WorkloadGraph(H['name'])
 


### PR DESCRIPTION
## ONNX: support dynamic shapes via YAML config

Enables dynamic shapes for ONNX graphs in Polaris by driving symbolic dim values from YAML instead of hardcoded constants. Any symbolic ONNX dim — batch, sequence length, image size, or model-specific dims — can now be overridden by a flat cfg key on a workload instance.

### Changes
- **`polaris.py`**: ONNX dispatch forwards the merged YAML cfg keys to the ONNX importer so symbolic dims can be resolved from YAML. 
- **`ttsim/front/onnx/onnx2nx.py`**: symbolic dim names are preserved through parsing; graph inputs are rewritten with concrete YAML-supplied values *before* shape inference.
- **`ttsim/config/{simconfig,validators}.py`**: `WorkloadONNX` now accepts a workload-level `params:` block and merges it into each instance cfg, matching `WorkloadTTSIM` / `WorkloadTTNN`.
- **`config/ip_workloads.yaml`**: ONNX entries can now declare any symbolic dim as a flat key (e.g. `bs: 1, data_dynamic_axes_2: 128`) — no code change needed for new models.