### PR TITLE
feat(437): support same-type comparisons in compare_layers; fix op_canonical profiler rules

### DIFF
--- a/checkin_tests.py
+++ b/checkin_tests.py
@@ -113,8 +113,8 @@ def check_environment_sanity() -> tuple[bool, str]:
         )
 
     # Check critical dependencies
-    missing_packages = []
-    broken_packages = []
+    missing_packages: list[str] = []
+    broken_packages: list[str] = []
     critical_imports = {
         'pydantic': 'pydantic',
         'loguru': 'loguru',

--- a/config/tt_bh.yaml
+++ b/config/tt_bh.yaml
@@ -62,6 +62,10 @@ packages:
         instances:
         -   name: p100a
             operator_lookup_file: lfc://hlm-lut/bh_p100a_lut_v2.yaml
+            # Logical tensix grid (x, y) — see doc/TTNN_SHIM_ARCHITECTURE.md §17.
+            # Source: tt-metal/tt_metal/core_descriptors/blackhole_140_arch.yaml (end=[12, 9] inclusive → 13×10).
+            # p100a has one column reserved → effective 12×10 = 120 cores (matches num_units below).
+            compute_grid_size: [12, 10]
             ipgroups:
             -   ipname: tensix
                 iptype: compute

--- a/config/tt_wh.yaml
+++ b/config/tt_wh.yaml
@@ -51,6 +51,11 @@ packages:
         -   name: n150
             # operator_lookup_file can be a local path or LFC path starting with lfc://
             operator_lookup_file: lfc://hlm-lut/whb0_n150_lut_v2.yaml
+            # Logical tensix grid (x, y) — see doc/TTNN_SHIM_ARCHITECTURE.md §17.
+            # Source: tt-metal/tt_metal/core_descriptors/wormhole_b0_80_arch_eth_dispatch.yaml
+            # (end=[7, 9] → 8×10 physical). n150 has one row harvested → 8×9 = 72 cores
+            # (matches num_units below).
+            compute_grid_size: [8, 9]
             ipgroups:
             -   ipname: tensix
                 iptype: compute

--- a/tests/test_tools/test_compare_layers.py
+++ b/tests/test_tools/test_compare_layers.py
@@ -335,3 +335,247 @@ def test_compare_layers_empty_lists():
     assert stats.total_matches == 0
     assert stats.unmatched_polaris == 0
     assert stats.unmatched_profiler == 0
+
+
+# ── _aggregate_by_lut_key tests ───────────────────────────────────────────
+
+@pytest.mark.unit
+def test_aggregate_by_lut_key_prefers_resolved_over_literal():
+    """Polaris-side rows present both ``lut_key`` (literal) and ``lut_key_resolved``;
+    aggregation must group by the resolved tuple so polaris/profiler rows that
+    semantically share a LUT entry land in the same bucket.
+    """
+    from tools.profiling.compare_layers import _aggregate_by_lut_key
+
+    literal_a = ('halo', 1, 1, 1024, 512, 'ROW_MAJOR', 'BFLOAT16', 'DEV_1_L1_HEIGHT_SHARDED', 'N/A')
+    resolved_a = ('halo', 1, 1, 1024, 512, 'ROW_MAJOR', 'BFLOAT16', 'DEV_1_L1_BLOCK_SHARDED', 'N/A')
+    literal_b = ('move', 1, 1, 1024, 512, 'ROW_MAJOR', 'BFLOAT16', 'DEV_1_L1_HEIGHT_SHARDED', 'N/A')
+    resolved_b = ('move', 1, 1, 1024, 512, 'ROW_MAJOR', 'BFLOAT16', 'DEV_1_L1_HEIGHT_SHARDED', 'N/A',
+                   1, 1, 1024, 512, 'ROW_MAJOR', 'BFLOAT16', 'DEV_1_L1_HEIGHT_SHARDED')
+    layers = [
+        # Row 1: HEIGHT→BLOCK shard fallback resolved the lookup.
+        {'optype': 'halo', 'lut_key': literal_a, 'lut_key_resolved': resolved_a,
+         'duration_ms': 0.05, 'uses_perf_lookup': True},
+        # Row 2: arity-1→arity-2 dup fallback resolved the lookup.
+        {'optype': 'move', 'lut_key': literal_b, 'lut_key_resolved': resolved_b,
+         'duration_ms': 0.01, 'uses_perf_lookup': True},
+    ]
+    by_key = _aggregate_by_lut_key(layers)
+    keys = list(by_key.keys())
+    # Two distinct resolved keys → two buckets, each with count 1.
+    assert len(keys) == 2
+    resolved_a_str = tuple(str(f) for f in resolved_a)
+    resolved_b_str = tuple(str(f) for f in resolved_b)
+    assert resolved_a_str in by_key
+    assert resolved_b_str in by_key
+    # Literal-only keys must NOT appear when a resolved key is present.
+    literal_a_str = tuple(str(f) for f in literal_a)
+    literal_b_str = tuple(str(f) for f in literal_b)
+    assert literal_a_str not in by_key
+    assert literal_b_str not in by_key
+
+
+@pytest.mark.unit
+def test_aggregate_by_lut_key_falls_back_to_literal_when_no_resolved():
+    """Profiler-side rows only carry ``lut_key`` (their literal key IS a LUT entry).
+    Aggregation must fall back to it when ``lut_key_resolved`` is absent or None.
+    """
+    from tools.profiling.compare_layers import _aggregate_by_lut_key
+
+    key = ('halo', 1, 1, 1024, 512, 'ROW_MAJOR', 'BFLOAT16', 'DEV_1_L1_BLOCK_SHARDED', 'N/A')
+    layers_no_resolved = [
+        {'optype': 'halo', 'lut_key': key, 'duration_ms': 0.05, 'uses_perf_lookup': False},
+    ]
+    layers_none_resolved = [
+        {'optype': 'halo', 'lut_key': key, 'lut_key_resolved': None,
+         'duration_ms': 0.05, 'uses_perf_lookup': False},
+    ]
+    key_str = tuple(str(f) for f in key)
+    for layers in (layers_no_resolved, layers_none_resolved):
+        by_key = _aggregate_by_lut_key(layers)
+        assert key_str in by_key
+        cnt, ms, lut = by_key[key_str]
+        assert cnt == 1
+        assert ms == pytest.approx(0.05)
+
+
+@pytest.mark.unit
+def test_aggregate_by_lut_key_skips_rows_without_any_key():
+    """Rows lacking both ``lut_key`` and ``lut_key_resolved`` are skipped (no key to group by)."""
+    from tools.profiling.compare_layers import _aggregate_by_lut_key
+
+    layers = [
+        {'optype': 'halo', 'duration_ms': 0.05},
+        {'optype': 'move', 'lut_key': None, 'lut_key_resolved': None, 'duration_ms': 0.01},
+    ]
+    by_key = _aggregate_by_lut_key(layers)
+    assert by_key == {}
+
+
+# ── _lut_key_n_slots / _lut_key_slot_field tests ──────────────────────────
+
+@pytest.mark.unit
+def test_lut_key_n_slots_halo_v4_is_one_slot():
+    """Halo v4 16-tuple must be treated as 1 input slot, not 2 (binary)."""
+    from tools.profiling.compare_layers import _lut_key_n_slots
+
+    halo_v4 = ('halo', 1, 1, 16384, 128, 'ROW_MAJOR', 'BFLOAT16', 'DEV_1_L1_HEIGHT_SHARDED',
+                'N/A', 2, 2, 0, 0, 0, 0, False)
+    assert len(halo_v4) == 16
+    assert _lut_key_n_slots(halo_v4) == 1
+
+
+@pytest.mark.unit
+def test_lut_key_n_slots_binary_is_two_slots():
+    """Standard binary 16-tuple (two operands) must report 2 slots."""
+    from tools.profiling.compare_layers import _lut_key_n_slots
+
+    binary = ('add', 1, 1, 1024, 512, 'TILE', 'BFLOAT16', 'DEV_1_L1_HEIGHT_SHARDED',
+              'N/A', 1, 1, 1024, 512, 'TILE', 'BFLOAT16', 'DEV_1_L1_HEIGHT_SHARDED')
+    assert len(binary) == 16
+    assert _lut_key_n_slots(binary) == 2
+
+
+@pytest.mark.unit
+def test_lut_key_slot_field_binary_slot1_memory():
+    """Slot-1 field-6 (memory) of a binary 16-tuple must return index 15, not ''."""
+    from tools.profiling.compare_layers import _lut_key_slot_field
+
+    binary = ('add', 1, 1, 1024, 512, 'TILE', 'BFLOAT16', 'MEM_A',
+              'HiFi4', 1, 1, 1024, 512, 'TILE', 'BFLOAT16', 'MEM_B')
+    assert _lut_key_slot_field(binary, 1, 6) == 'MEM_B'
+
+
+@pytest.mark.unit
+def test_lut_key_slot_field_binary_mf_not_in_slot():
+    """math_fidelity at index 8 must not appear as a slot-1 field."""
+    from tools.profiling.compare_layers import _lut_key_slot_field
+
+    binary = ('add', 1, 1, 1024, 512, 'TILE', 'BFLOAT16', 'MEM_A',
+              'HiFi4', 11, 22, 33, 44, 'TILE', 'BFLOAT16', 'MEM_B')
+    # slot-1 field-0 must be w1=11, not MF='HiFi4' (index 8)
+    assert _lut_key_slot_field(binary, 1, 0) == '11'
+
+
+# ── _lut_key_variant_tail / _lut_key_variant_col_names tests ─────────────
+
+@pytest.mark.unit
+def test_lut_key_variant_tail_halo_v3():
+    from tools.profiling.compare_layers import _lut_key_variant_tail
+
+    key = ('halo', 1, 1, 512, 128, 'ROW_MAJOR', 'BFLOAT16', 'L1', 'N/A',
+           3, 3, 1, 1, 1, 1)
+    assert len(key) == 15
+    tail = _lut_key_variant_tail(key)
+    assert tail == [
+        ('kernel_h', '3'), ('kernel_w', '3'),
+        ('stride_h', '1'), ('stride_w', '1'),
+        ('padding_h', '1'), ('padding_w', '1'),
+    ]
+
+
+@pytest.mark.unit
+def test_lut_key_variant_tail_halo_v4():
+    from tools.profiling.compare_layers import _lut_key_variant_tail
+
+    key = ('halo', 1, 1, 512, 128, 'ROW_MAJOR', 'BFLOAT16', 'L1', 'N/A',
+           2, 2, 2, 2, 0, 0, True)
+    assert len(key) == 16
+    tail = _lut_key_variant_tail(key)
+    assert tail == [
+        ('kernel_h', '2'), ('kernel_w', '2'),
+        ('stride_h', '2'), ('stride_w', '2'),
+        ('padding_h', '0'), ('padding_w', '0'),
+        ('is_transpose', 'True'),
+    ]
+
+
+@pytest.mark.unit
+def test_lut_key_variant_tail_its():
+    from tools.profiling.compare_layers import _lut_key_variant_tail
+
+    key = ('interleavedtosharded', 1, 1, 512, 128, 'TILE', 'BFLOAT16', 'DRAM', 'N/A',
+           'L1_BLOCK_SHARDED')
+    assert len(key) == 10
+    assert _lut_key_variant_tail(key) == [('output_0_memory', 'L1_BLOCK_SHARDED')]
+
+
+@pytest.mark.unit
+def test_lut_key_variant_tail_standard_empty():
+    from tools.profiling.compare_layers import _lut_key_variant_tail
+
+    key = ('conv2d', 1, 1, 512, 128, 'TILE', 'BFLOAT16', 'L1', 'N/A')
+    assert _lut_key_variant_tail(key) == []
+
+
+@pytest.mark.unit
+def test_lut_key_variant_col_names_ordering():
+    """Union of variant fields across mixed keys preserves insertion order."""
+    from tools.profiling.compare_layers import _lut_key_variant_col_names
+
+    halo_v3 = ('halo', 1, 1, 512, 128, 'ROW_MAJOR', 'BFLOAT16', 'L1', 'N/A',
+                3, 3, 1, 1, 1, 1)
+    its = ('interleavedtosharded', 1, 1, 512, 128, 'TILE', 'BFLOAT16', 'DRAM', 'N/A',
+           'L1_BLOCK_SHARDED')
+    standard = ('conv2d', 1, 1, 512, 128, 'TILE', 'BFLOAT16', 'L1', 'N/A')
+
+    names = _lut_key_variant_col_names([halo_v3, its, standard])
+    assert names == ['kernel_h', 'kernel_w', 'stride_h', 'stride_w', 'padding_h', 'padding_w', 'output_0_memory']
+
+
+# ── _print_perf_comparison LUT column split tests ─────────────────────────
+
+
+def _make_layer(optype: str, duration_ms: float, uses_perf_lookup: bool = False) -> dict:
+    return {'optype': optype, 'duration_ms': duration_ms, 'uses_perf_lookup': uses_perf_lookup}
+
+
+@pytest.mark.unit
+def test_perf_comparison_mixed_mode_shows_only_lut1(capsys):
+    """In mixed mode (polaris-vs-profiler) only side-1 has LUT hits.
+    Output must show LUT1 column but NOT LUT2, so the hit rate is not
+    diluted by the profiler-side zero count."""
+    from tools.profiling.compare_layers import _print_perf_comparison
+
+    layers1 = [_make_layer('conv2d', 1.0, uses_perf_lookup=True)]
+    layers2 = [_make_layer('conv2d', 1.1, uses_perf_lookup=False)]
+
+    _print_perf_comparison(layers1, layers2, label1='Polaris', label2='Profiler')
+    out = capsys.readouterr().out
+
+    assert 'LUT1' in out
+    assert 'LUT2' not in out
+    # Hit ratio must be 1/1, not 1/2
+    assert '1/1' in out
+    assert '1/2' not in out
+
+
+@pytest.mark.unit
+def test_perf_comparison_same_type_shows_both_lut_columns(capsys):
+    """In same-type mode (e.g. polaris-vs-polaris) both sides carry LUT hits.
+    Output must show both LUT1 and LUT2 columns."""
+    from tools.profiling.compare_layers import _print_perf_comparison
+
+    layers1 = [_make_layer('conv2d', 1.0, uses_perf_lookup=True)]
+    layers2 = [_make_layer('conv2d', 1.1, uses_perf_lookup=True)]
+
+    _print_perf_comparison(layers1, layers2, label1='RunA', label2='RunB')
+    out = capsys.readouterr().out
+
+    assert 'LUT1' in out
+    assert 'LUT2' in out
+
+
+@pytest.mark.unit
+def test_perf_comparison_no_lut_hides_all_lut_columns(capsys):
+    """When neither side has LUT hits, no LUT columns appear."""
+    from tools.profiling.compare_layers import _print_perf_comparison
+
+    layers1 = [_make_layer('conv2d', 1.0, uses_perf_lookup=False)]
+    layers2 = [_make_layer('conv2d', 1.1, uses_perf_lookup=False)]
+
+    _print_perf_comparison(layers1, layers2)
+    out = capsys.readouterr().out
+
+    assert 'LUT1' not in out
+    assert 'LUT2' not in out

--- a/tests/test_tools/test_conv_parallel_config.py
+++ b/tests/test_tools/test_conv_parallel_config.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the polaris-side mimic of tt-metal's conv2d parallel-config picker.
+
+Ground-truth values come from cross-referencing the VGG UNet BH p100a refrun CSV
+(``__refrun_cache/vgg_unet/bh/p100a/merged_ops_dualref_260519.csv``): each HW
+``Conv2dDeviceOperation`` row reports ``CORE COUNT`` and ``INPUT_0_X_PAD[LOGICAL]``,
+which together pin ``(num_cores_nhw * num_cores_c, padded_input_channels)``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.perf_lookup.conv_parallel_config import (
+    determine_block_sharded_channel_padding,
+    find_closest_largest_divisor_with_num_padding,
+    find_closest_largest_divisor_with_num_padding_and_mult,
+)
+
+
+@pytest.mark.unit
+def test_find_closest_largest_divisor_with_num_padding_no_padding_needed():
+    # 32 / 8 = 4 with no remainder — divisor 8 returned immediately.
+    assert find_closest_largest_divisor_with_num_padding(32, 8) == 8
+
+
+@pytest.mark.unit
+def test_find_closest_largest_divisor_with_num_padding_walks_down_to_11():
+    # Start at 13: round_up(32, 13)=39, padding 7, shard 3 -> 7 >= 3 → step.
+    # Try 12: round_up(32, 12)=36, padding 4, shard 3 -> step.
+    # Try 11: round_up(32, 11)=33, padding 1, shard 3 -> stop, return 11.
+    assert find_closest_largest_divisor_with_num_padding(32, 13) == 11
+
+
+@pytest.mark.unit
+def test_find_closest_largest_divisor_with_num_padding_and_mult_basic():
+    # Same as the BH p100a num_cores_nhw case in d1.conv1: nhw_ntiles=32, grid_y=10, mult=1.
+    # Result 8 (matches HW cores=88=8x11).
+    assert find_closest_largest_divisor_with_num_padding_and_mult(32, 10, 1) == 8
+
+
+@pytest.mark.unit
+def test_determine_block_sharded_d1_conv1_bh_p100a():
+    """BH p100a d1.conv1 — the case that drove this whole audit.
+
+    HW refrun row: ``Conv2dDeviceOperation`` input ``y=1632, x=1056, cores=88,
+    BLOCK_SHARDED``. The output spatial volume is 1024 (out_y), so
+    ``out_nhw_ntiles = 1024 / 32 = 32``. Channels in = 1024 → 32 blocks of 32.
+    Compute grid 12x10. Expected: (8, 11, 1056), total 88 cores.
+    """
+    result = determine_block_sharded_channel_padding(
+        input_channels=1024,
+        output_nhw=1024,
+        compute_grid_size=(12, 10),
+    )
+    assert result == (8, 11, 1056)
+    assert result[0] * result[1] == 88
+
+
+@pytest.mark.unit
+def test_determine_block_sharded_512ch_no_padding():
+    """Most BH p100a convs with 512 channels land on a clean 8x8 = 64-core grid."""
+    result = determine_block_sharded_channel_padding(
+        input_channels=512,
+        output_nhw=256,
+        compute_grid_size=(12, 10),
+    )
+    assert result == (8, 8, 512)
+
+
+@pytest.mark.unit
+def test_determine_block_sharded_wh_n150_no_padding_at_1024ch():
+    """WH n150's smaller grid (8x9) divides 32 blocks cleanly → no padding."""
+    result = determine_block_sharded_channel_padding(
+        input_channels=1024,
+        output_nhw=1024,
+        compute_grid_size=(8, 9),
+    )
+    assert result == (8, 8, 1024)
+
+
+@pytest.mark.unit
+def test_determine_block_sharded_rejects_zero_grid():
+    with pytest.raises(ValueError, match="compute_grid_size"):
+        determine_block_sharded_channel_padding(1024, 1024, (0, 10))
+
+
+@pytest.mark.unit
+def test_determine_block_sharded_rejects_zero_alignment():
+    with pytest.raises(ValueError, match="input_channels_alignment"):
+        determine_block_sharded_channel_padding(
+            1024, 1024, (12, 10), input_channels_alignment=0
+        )

--- a/tests/test_tools/test_master_operator_perf_lookup.py
+++ b/tests/test_tools/test_master_operator_perf_lookup.py
@@ -149,6 +149,38 @@ def test_build_master_key_tuple_8():
 
 
 @pytest.mark.unit
+def test_halo_key_distinguishes_conv_from_conv_transpose():
+    """Schema v4: Halo emitted by conv2d and conv_transpose2d must produce different LUT keys.
+
+    Confirmed in the BH refrun: two halos with identical input shape, window, stride, and
+    padding but different ``is_transpose`` run 5.3x apart on hardware (1550ns Conv vs
+    8253ns ConvTranspose) — the LUT must be able to discriminate them.
+    """
+    from tools.perf_lookup.lookup_operator_perf import build_master_key_tuple_halo
+
+    t0 = SimTensor(
+        {"name": "x", "shape": [1, 1, 1024, 512], "op_in": [], "op_out": []}
+    )
+    common_attrs = {"kernel_size": (2, 2), "stride": (2, 2), "padding": (0, 0)}
+    op_conv = SimpleNamespace(
+        optype="Halo", precision="BF16", inList=["x"],
+        attrs={**common_attrs, "is_transpose": False},
+    )
+    op_ct = SimpleNamespace(
+        optype="Halo", precision="BF16", inList=["x"],
+        attrs={**common_attrs, "is_transpose": True},
+    )
+    k_conv = build_master_key_tuple_halo(op_conv, t0)
+    k_ct = build_master_key_tuple_halo(op_ct, t0)
+    assert k_conv is not None and k_ct is not None
+    assert len(k_conv) == 16 and len(k_ct) == 16
+    assert k_conv[:15] == k_ct[:15]
+    assert k_conv[15] is False
+    assert k_ct[15] is True
+    assert k_conv != k_ct
+
+
+@pytest.mark.unit
 def test_reshape_master_key_packs_input0_wzyx():
     """LUT uses (1, 1, w*z*y, x) for reshape input_0 vs raw rank-4 logical shape."""
     from tools.perf_lookup.lookup_operator_perf import build_master_key_tuple_8, build_master_key_tuple_15

--- a/tests/test_tools/test_op_canonical.py
+++ b/tests/test_tools/test_op_canonical.py
@@ -226,3 +226,30 @@ def test_polaris_synonyms_are_lowercase():
     for key, canonical in POLARIS_SYNONYMS.items():
         assert key == key.lower(), f"POLARIS_SYNONYMS key {key!r} not lowercase"
         assert canonical == canonical.lower(), f"POLARIS_SYNONYMS value {canonical!r} not lowercase"
+
+
+@pytest.mark.unit
+def test_resolve_conv_subtype_dict_attrs_true():
+    """Dict attrs with is_transpose=True must return 'convtranspose' without relying on str()."""
+    from tools.profiling.op_canonical import _resolve_conv_subtype
+
+    assert _resolve_conv_subtype({'is_transpose': True}) == 'convtranspose'
+
+
+@pytest.mark.unit
+def test_resolve_conv_subtype_dict_attrs_false():
+    from tools.profiling.op_canonical import _resolve_conv_subtype
+
+    assert _resolve_conv_subtype({'is_transpose': False}) == 'conv2d'
+    assert _resolve_conv_subtype({}) == 'conv2d'
+
+
+@pytest.mark.unit
+def test_resolve_conv_subtype_string_attrs():
+    """String ATTRIBUTES from profiler CSV still resolve correctly via regex."""
+    from tools.profiling.op_canonical import _resolve_conv_subtype
+
+    sliding_window_false = 'SlidingWindowConfig { kernel_size: [3, 3], is_transpose = false }'
+    sliding_window_true = 'SlidingWindowConfig { kernel_size: [2, 2], is_transpose = true }'
+    assert _resolve_conv_subtype(sliding_window_false) == 'conv2d'
+    assert _resolve_conv_subtype(sliding_window_true) == 'convtranspose'

--- a/tests/test_tools/test_show_layers_polaris.py
+++ b/tests/test_tools/test_show_layers_polaris.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for tools.profiling.show_layers_polaris."""
+
+import pytest
+
+from tools.profiling.show_layers_polaris import _parse_lut_key_cell
+
+
+@pytest.mark.unit
+def test_parse_lut_key_cell_none_and_empty_return_none():
+    assert _parse_lut_key_cell(None) is None
+    assert _parse_lut_key_cell('') is None
+    assert _parse_lut_key_cell('   ') is None
+
+
+@pytest.mark.unit
+def test_parse_lut_key_cell_string_none_variants_return_none():
+    """Cells that hold the literal string ``None`` / ``NA`` / ``null`` (CSV null sentinels)
+    must parse back to None, matching how the polaris CSV writer renders missing values.
+    """
+    assert _parse_lut_key_cell('None') is None
+    assert _parse_lut_key_cell('none') is None
+    assert _parse_lut_key_cell('NA') is None
+    assert _parse_lut_key_cell('null') is None
+
+
+@pytest.mark.unit
+def test_parse_lut_key_cell_arity1_tuple_roundtrip():
+    """str(tuple) → tuple round-trip for a 9-tuple arity-1 LUT key."""
+    key = ('halo', 1, 1, 65536, 16, 'ROW_MAJOR', 'BFLOAT16', 'DEV_1_L1_HEIGHT_SHARDED', 'N/A')
+    parsed = _parse_lut_key_cell(repr(key))
+    assert parsed == key
+
+
+@pytest.mark.unit
+def test_parse_lut_key_cell_arity2_tuple_roundtrip():
+    """str(tuple) → tuple round-trip for a 16-tuple arity-2 LUT key (Move dup form)."""
+    key = (
+        'move', 1, 1, 99072, 16, 'ROW_MAJOR', 'BFLOAT16', 'DEV_1_L1_HEIGHT_SHARDED', 'N/A',
+        1, 1, 99072, 16, 'ROW_MAJOR', 'BFLOAT16', 'DEV_1_L1_HEIGHT_SHARDED',
+    )
+    parsed = _parse_lut_key_cell(repr(key))
+    assert parsed == key
+
+
+@pytest.mark.unit
+def test_parse_lut_key_cell_invalid_returns_none():
+    """Malformed cells degrade gracefully — round-trip is best-effort, not a hard contract."""
+    assert _parse_lut_key_cell('not a tuple') is None
+    assert _parse_lut_key_cell('(unterminated') is None
+    # Lists are not tuples — they're a valid Python literal but the wrong shape.
+    assert _parse_lut_key_cell('[1, 2, 3]') is None
+    # Plain int / string don't roundtrip to a tuple either.
+    assert _parse_lut_key_cell('42') is None

--- a/tools/perf_lookup/conv_parallel_config.py
+++ b/tools/perf_lookup/conv_parallel_config.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Polaris-side mimic of tt-metal's conv2d parallel-config picker.
+
+Used by the conv-input channel-padding annotation pass (see
+``doc/TTNN_SHIM_ARCHITECTURE.md`` §17). Given a conv's input shape and the
+device's logical compute grid, returns the same ``(num_cores_nhw, num_cores_c,
+padded_channels)`` that ``determine_parallel_config`` in
+``tt-metal/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp`` would pick.
+
+Only the BLOCK_SHARDED path is implemented for now — that's the layout where
+HW pads channels in a way polaris currently doesn't model.  HEIGHT_SHARDED and
+WIDTH_SHARDED are no-ops here (channel padding doesn't apply); callers should
+fall through to existing polaris behavior for those layouts.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+# Mirror tt-metal constants. TILE_WIDTH from tt::constants; input_channels_alignment
+# defaults to TILE_WIDTH=32 for the BLOCK_SHARDED case polaris cares about (see
+# tt-metal get_input_channels_alignment fallback for non-WIDTH_SHARDED inputs).
+TILE_WIDTH = 32
+TILE_HEIGHT = 32
+DEFAULT_INPUT_CHANNELS_ALIGNMENT = TILE_WIDTH
+
+
+def _div_up(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+def _round_up(a: int, b: int) -> int:
+    return _div_up(a, b) * b
+
+
+def find_closest_largest_divisor_with_num_padding(num: int, start_divisor: int) -> int:
+    """Port of ``find_closest_largest_divisor_with_num_padding`` (conv2d_utils.cpp:55).
+
+    Walks divisors downward from ``start_divisor`` until the padding overhead
+    becomes less than one shard's worth. Returns the picked divisor (which
+    becomes ``num_cores_c`` for the channel axis or ``num_cores_nhw`` for the
+    spatial axis under various paths).
+    """
+    if start_divisor <= 0:
+        raise ValueError(f"start_divisor must be positive, got {start_divisor}")
+    divisor = start_divisor
+    padded_num = _round_up(num, divisor)
+    while divisor > 1 and (padded_num - num) >= (padded_num // divisor):
+        divisor -= 1
+        padded_num = _round_up(num, divisor)
+    return divisor
+
+
+def find_closest_largest_divisor_with_num_padding_and_mult(
+    num: int, start_divisor: int, mult: int
+) -> int:
+    """Port of ``find_closest_largest_divisor_with_num_padding_and_mult`` (conv2d_utils.cpp:65)."""
+    if start_divisor <= 0:
+        raise ValueError(f"start_divisor must be positive, got {start_divisor}")
+    if mult <= 0:
+        raise ValueError(f"mult must be positive, got {mult}")
+    divisor = start_divisor
+    big_divisor = divisor * mult
+    padded_num = _round_up(num, big_divisor)
+    while divisor > 1 and (padded_num - num) >= (padded_num // divisor):
+        divisor -= 1
+        big_divisor = divisor * mult
+        padded_num = _round_up(num, big_divisor)
+    return divisor
+
+
+def determine_block_sharded_channel_padding(
+    input_channels: int,
+    output_nhw: int,
+    compute_grid_size: Tuple[int, int],
+    *,
+    input_channels_alignment: int = DEFAULT_INPUT_CHANNELS_ALIGNMENT,
+    act_block_h_override: int = 0,
+    shard_orientation_row_major: bool = True,
+) -> Tuple[int, int, int]:
+    """Return ``(num_cores_nhw, num_cores_c, padded_input_channels)`` for BLOCK_SHARDED conv2d.
+
+    Mirrors the BLOCK_SHARDED branch of ``determine_parallel_config`` in
+    ``conv2d_utils.cpp:188-204``. Only the *padding* values are returned (callers
+    don't need the full ``ParallelConfig`` struct yet).
+
+    Args:
+        input_channels: Logical channel count of the conv's input tensor (pre-padding).
+        output_nhw: ``batch * output_height * output_width`` — the conv's output spatial volume.
+        compute_grid_size: ``(x, y)`` logical tensix grid for this SKU (see arch YAML).
+        input_channels_alignment: Per-stick channel-byte alignment.  32 (= ``TILE_WIDTH``)
+            for the BLOCK_SHARDED path tt-metal takes here.
+        act_block_h_override: ``act_block_h_override / TILE_HEIGHT``.  Defaults to 0 → mult=1.
+        shard_orientation_row_major: When True (the tt-metal default for our workloads),
+            ``start_divisor_c = compute_grid_size.x`` and ``start_divisor_nhw =
+            compute_grid_size.y``.
+
+    Returns:
+        ``(num_cores_nhw, num_cores_c, padded_input_channels)``.
+    """
+    if input_channels_alignment <= 0:
+        raise ValueError(
+            f"input_channels_alignment must be positive, got {input_channels_alignment}"
+        )
+    grid_x, grid_y = compute_grid_size
+    if grid_x <= 0 or grid_y <= 0:
+        raise ValueError(f"compute_grid_size must be positive, got {compute_grid_size}")
+
+    out_nhw_ntiles = _div_up(output_nhw, TILE_HEIGHT)
+    act_block_h_override_ntiles = (
+        1 if act_block_h_override == 0 else act_block_h_override // TILE_HEIGHT
+    )
+    input_channels_blocks = _div_up(input_channels, input_channels_alignment)
+
+    start_divisor_nhw = grid_y if shard_orientation_row_major else grid_x
+    start_divisor_c = grid_x if shard_orientation_row_major else grid_y
+
+    num_cores_nhw = find_closest_largest_divisor_with_num_padding_and_mult(
+        out_nhw_ntiles, start_divisor_nhw, act_block_h_override_ntiles
+    )
+    num_cores_c = find_closest_largest_divisor_with_num_padding(
+        input_channels_blocks, start_divisor_c
+    )
+
+    padded_blocks = _round_up(input_channels_blocks, num_cores_c)
+    padded_input_channels = padded_blocks * input_channels_alignment
+    return num_cores_nhw, num_cores_c, padded_input_channels

--- a/tools/perf_lookup/lookup_operator_perf.py
+++ b/tools/perf_lookup/lookup_operator_perf.py
@@ -6,8 +6,10 @@
 Operator performance lookup: tt-perf **master** YAML only (``correqn.tt-perf-master``).
 
 Loads via ``tools.perf_lookup.tt_perf_master_loader.load_existing_yaml``. Maps workload ops + tensors to a
-logical **9-tuple** (one input), **16-tuple** (two inputs), or **23-tuple** (three inputs) key. Resolves ``single`` (flat
-``num_cores`` + stat scalars), ``curve``, and ``hybrid``. For hybrid rows, whether ``curve`` is used
+logical **9-tuple** (one input), **16-tuple** (two inputs), or **23-tuple** (three inputs) key, or to a per-op
+variant: **16-tuple** for ``halo`` (standard 9 + kernel_h/w, stride_h/w, padding_h/w, is_transpose from op.attrs) and
+**10-tuple** for ``interleavedtosharded`` (standard 9 + ``output_0_memory`` from the output tensor). Resolves
+``single`` (flat ``num_cores`` + stat scalars), ``curve``, and ``hybrid``. For hybrid rows, whether ``curve`` is used
 is controlled by :class:`OperatorPerfMap` ``use_hybrid_curve`` (default ``False``: ``single`` only).
 See ``doc/tools/perf_lookup/LOOKUP_TABLE_MASTER.md``.
 
@@ -292,12 +294,33 @@ def _op_code(op: Any) -> str:
 
 
 def _shape_wzyx(tensor: Any) -> Tuple[int, int, int, int]:
-    """Rank-4 WZYX shape for LUT key construction."""
-    raw = getattr(tensor, "shape", None)
-    if raw is None:
-        raise ValueError("tensor has no shape")
-    raw_list = coerce_shape_to_list(raw)
-    return promote_to_rank4(raw_list)
+    """Rank-4 WZYX shape for LUT key construction.
+
+    Prefers tensor.hw_shape (NHWC-flattened [1, 1, N*H*W, C] set by conv/pool
+    shape-inference) over tensor.shape (logical NCHW [N, C, H, W]).  hw_shape
+    matches the representation hardware profiler output uses so LUT keys agree.
+    Falls back to promoting the logical shape when hw_shape is absent.
+
+    When ``tensor.x_pad_logical`` or ``tensor.y_pad_logical`` is set (tagged by the
+    arch-aware annotation pass in ``ttsim/back/device.py``), the returned X / Y
+    dimension is replaced with the HW-matching value.  See doc/TTNN_SHIM_ARCHITECTURE.md §17.
+    """
+    hw = getattr(tensor, 'hw_shape', None)
+    if hw is not None:
+        w, z, y, x = promote_to_rank4(hw)
+    else:
+        raw = getattr(tensor, 'shape', None)
+        if raw is None:
+            raise ValueError('tensor has no shape')
+        raw_list = coerce_shape_to_list(raw)
+        w, z, y, x = promote_to_rank4(raw_list)
+    y_pad = getattr(tensor, 'y_pad_logical', None)
+    if y_pad is not None:
+        y = int(y_pad)
+    x_pad = getattr(tensor, 'x_pad_logical', None)
+    if x_pad is not None:
+        x = int(x_pad)
+    return (w, z, y, x)
 
 
 def _input0_wzyx_for_master_key(op: Any, tensor_0: Any) -> Tuple[int, int, int, int]:
@@ -412,6 +435,43 @@ def build_master_key_tuple_22(
     )
 
 
+def build_master_key_tuple_halo(op: Any, tensor_0: Any) -> Optional[Tuple[Any, ...]]:
+    """Logical 16-tuple for halo: standard 9 + kernel_h/w, stride_h/w, padding_h/w, is_transpose.
+
+    Reads ``op.attrs['kernel_size']``, ``op.attrs['stride']``, ``op.attrs['padding']``,
+    ``op.attrs['is_transpose']`` — set by the ``_with_halo`` shim wrapper (conv_transpose2d
+    sets is_transpose=True; conv2d/pool2d set False). Returns ``None`` when geometry attrs
+    are missing; callers treat that as a lookup miss.
+    """
+    base = build_master_key_tuple_8(op, tensor_0)
+    attrs = getattr(op, "attrs", None)
+    if not isinstance(attrs, dict):
+        return None
+    ks = attrs.get("kernel_size")
+    st = attrs.get("stride")
+    pd = attrs.get("padding")
+    if ks is None or st is None or pd is None:
+        return None
+    try:
+        kH, kW = int(ks[0]), int(ks[1])
+        sH, sW = int(st[0]), int(st[1])
+        pH, pW = int(pd[0]), int(pd[1])
+    except (TypeError, IndexError, ValueError):
+        return None
+    is_transpose = bool(attrs.get("is_transpose", False))
+    return base + (kH, kW, sH, sW, pH, pW, is_transpose)
+
+
+def build_master_key_tuple_its(
+    op: Any,
+    tensor_0: Any,
+    output_tensor: Any,
+) -> Tuple[Any, ...]:
+    """Logical 10-tuple for InterleavedToSharded: standard 9 + output_0_memory."""
+    base = build_master_key_tuple_8(op, tensor_0)
+    return base + (tensor_memory_str(output_tensor),)
+
+
 def build_master_key_tuple_15_add_broadcast_duplicate_full(
     op: Any,
     tensor_0: Any,
@@ -504,19 +564,21 @@ def _wzyx_int_tuple(t4: tuple) -> tuple:
 def _lut_keys_matching_op_and_wzyx(entries: Dict[tuple, dict], key_t: tuple) -> Tuple[tuple, ...]:
     """
     LUT keys with same ``op_code`` and WZYX as ``key_t``
-    (input 0 for 8-tuple; inputs 0 and 1 for 15-tuple; inputs 0, 1, and 2 for 22-tuple).
+    (input 0 for 9/10/15-tuple and halo 16-tuple; inputs 0 and 1 for binary 16-tuple;
+    inputs 0, 1, and 2 for 23-tuple).
 
     Layout, datatype, and memory may differ — useful diagnostics when the full key misses.
     """
     n = len(key_t)
-    if n not in (9, 16, 23):
+    if n not in (9, 10, 15, 16, 23):
         return ()
     oc = key_t[0]
     matched: list[tuple] = []
-    if n == 9:
+    if n in (9, 10, 15) or (n == 16 and oc == 'halo'):
+        # Halo v4 16-tuple has one input slot at [1:5]; positions [9:] are geometry+is_transpose.
         w0 = _wzyx_int_tuple(key_t[1:5])
         for k in entries:
-            if len(k) != 9 or k[0] != oc:
+            if len(k) != n or k[0] != oc:
                 continue
             if _wzyx_int_tuple(k[1:5]) == w0:
                 matched.append(k)
@@ -546,13 +608,13 @@ def _lut_keys_matching_op_and_wzyx(entries: Dict[tuple, dict], key_t: tuple) -> 
 
 def _lut_keys_matching_op_code_only(entries: Dict[tuple, dict], key_t: tuple) -> Tuple[tuple, ...]:
     """
-    All LUT keys with the same ``op_code`` and tuple length as ``key_t`` (unary vs binary).
+    All LUT keys with the same ``op_code`` and tuple length as ``key_t`` (unary vs binary vs halo/ITS).
 
     Listed on full-key miss when no row matches operator type and all key attributes; contrasts
     with :func:`_lut_keys_matching_op_and_wzyx` which also requires WZYX match.
     """
     n = len(key_t)
-    if n not in (9, 16, 23):
+    if n not in (9, 10, 15, 16, 23):
         return ()
     oc = key_t[0]
     matched = [k for k in entries if len(k) == n and k[0] == oc]
@@ -720,7 +782,30 @@ class OperatorPerfMap:
             if t0.shape is None:
                 return None
             try:
-                key_t = build_master_key_tuple_8(op, t0)
+                op_code_norm = _op_code(op)
+                if op_code_norm == "halo":
+                    halo_key = build_master_key_tuple_halo(op, t0)
+                    if halo_key is None:
+                        logger.debug(
+                            "Perf lookup: halo op {} missing kernel/stride/padding "
+                            "attrs; cannot form 16-tuple key (treating as miss)",
+                            getattr(op, "name", "?"),
+                        )
+                        return None
+                    key_t = halo_key
+                elif op_code_norm == "interleavedtosharded":
+                    out_list = getattr(op, "outList", [])
+                    t_out = tensors.get(out_list[0]) if out_list else None
+                    if t_out is None or getattr(t_out, "shape", None) is None:
+                        logger.debug(
+                            "Perf lookup: ITS op {} has no resolvable output tensor; "
+                            "cannot form 10-tuple key (treating as miss)",
+                            getattr(op, "name", "?"),
+                        )
+                        return None
+                    key_t = build_master_key_tuple_its(op, t0, t_out)
+                else:
+                    key_t = build_master_key_tuple_8(op, t0)
             except Exception as e:
                 logger.debug("Perf lookup key build failed for op {}: {}", getattr(op, "name", "?"), e)
                 return None

--- a/tools/perf_lookup/tt_perf_mapper.py
+++ b/tools/perf_lookup/tt_perf_mapper.py
@@ -8,9 +8,11 @@ After load, OP CODE cells are normalized to Polaris-style layer *types* (e.g. ma
 ``TilizeWithValPadding*`` → ``tilizewithvalpadding`` (other ``Tilize*`` → ``tilize``); ``UntilizeWithUnpadding*``
 → ``untilizewithunpadding`` (other ``Untilize*`` → ``untilize``). ``BinaryNgDeviceOperation`` and ``UnaryDeviceOperation`` rows use
 ``ATTRIBUTES`` (``binary_op_type`` / ``UnaryOpType::…`` in ``op_chain``) when present; all keys, grouping, and mode checks use these types — not
-full profiler class names. Key tuple length is **9** if all INPUT_1_* and INPUT_2_* are blank, **16** if
+full profiler class names. Standard key tuple length is **9** if all INPUT_1_* and INPUT_2_* are blank, **16** if
 INPUT_1_* is all set and INPUT_2_* all blank, **23** if INPUT_1_* and INPUT_2_* are all set (ternary ops
-e.g. LayerNorm). The key includes ``MATH FIDELITY`` after the INPUT_0 slot. Matmul uses ``entry_type:
+e.g. LayerNorm). The key includes ``MATH FIDELITY`` after the INPUT_0 slot. Per-op variants (schema v3/v4):
+``halo`` rows extend to **15** fields in schema v3 (kernel_h/w, stride_h/w, padding_h/w from ``SlidingWindowConfig``) or **16** fields in schema v4 (adds is_transpose to distinguish ConvTranspose halos);
+``interleavedtosharded`` rows extend to **10** fields (``output_0_memory`` from the OUTPUT_0_MEMORY column). Matmul uses ``entry_type:
 hybrid`` in YAML (``single`` + ``curve`` branches) when combining model and sweep data; see
 ``doc/YAML_MASTER_FORMAT.md``. CLI: repeatable ``--model-run`` and ``--sweep-run`` to merge Excel or CSV in one
 invocation (CSV is read with stdlib ``csv``; Excel ``.xlsx`` / ``.xlsm`` with **openpyxl**). Writes ``schema_name`` ``correqn.tt-perf-master``, ``schema_version`` (``tt_perf_master_schema.MASTER_YAML_SCHEMA_VERSION``, **1** until first release).
@@ -47,7 +49,10 @@ import yaml
 from loguru import logger
 from scipy.optimize import curve_fit  # type: ignore[import-untyped]
 
-from tools.profiling.op_canonical import normalize_profiler_opcode
+from tools.profiling.op_canonical import (
+    PREALLOC_OUTPUT_AS_INPUT1_OPS,
+    normalize_profiler_opcode,
+)
 
 from tools.perf_lookup.tt_perf_master_loader import load_existing_yaml
 from tools.perf_lookup.tt_perf_master_schema import (
@@ -204,6 +209,59 @@ EXCEL_ATTRIBUTES_COLUMN = "ATTRIBUTES"
 
 # PAD column suffix pattern: value like "224[224]" -> use 224
 PAD_PATTERN = re.compile(r"^\s*(\d+)\s*\[\s*(\d+)\s*\]\s*$")
+
+# Halo extension (schema v3+v4): SlidingWindowConfig fields in profiler ATTRIBUTES.
+# Raw format: window_hw=(3;3); stride_hw=(1;1); padding=((1; 1); (1; 1)); is_transpose=false.
+# Whitespace and ';'/',' separators both tolerated (depending on whether the cell was already substituted).
+_HALO_WINDOW_RE = re.compile(r"window_hw\s*=\s*\(\s*(\d+)\s*[;,]\s*(\d+)\s*\)")
+_HALO_STRIDE_RE = re.compile(r"stride_hw\s*=\s*\(\s*(\d+)\s*[;,]\s*(\d+)\s*\)")
+_HALO_PADDING_RE = re.compile(
+    r"padding\s*=\s*\(\s*\(\s*(\d+)\s*[;,]\s*\d+\s*\)\s*[;,]\s*\(\s*(\d+)\s*[;,]\s*\d+\s*\)\s*\)"
+)
+_HALO_ISTRANSPOSE_RE = re.compile(r"is_transpose\s*=\s*(true|false)")
+
+# Per-op variant op codes (after normalize_profiler_opcode).
+_HALO_OP_CODE = "halo"
+_ITS_OP_CODE = "interleavedtosharded"
+
+# Profiler CSV column holding the destination memory string for ITS.
+_OUTPUT_0_MEMORY_COLUMN = "OUTPUT_0_MEMORY"
+
+
+def _extract_halo_geometry(row: Mapping[str, Any]) -> tuple | None:
+    """Parse (kernel_h, kernel_w, stride_h, stride_w, padding_h, padding_w, is_transpose) from a halo row.
+
+    Reads the ``SlidingWindowConfig`` substring inside the ``ATTRIBUTES`` cell. Returns
+    ``None`` if any of window_hw / stride_hw / padding / is_transpose can't be parsed.
+    """
+    attrs_cell = row.get(EXCEL_ATTRIBUTES_COLUMN)
+    if attrs_cell is None or is_na(attrs_cell):
+        return None
+    raw = str(attrs_cell)
+    win = _HALO_WINDOW_RE.search(raw)
+    stride = _HALO_STRIDE_RE.search(raw)
+    pad = _HALO_PADDING_RE.search(raw)
+    istr = _HALO_ISTRANSPOSE_RE.search(raw)
+    if not (win and stride and pad and istr):
+        return None
+    return (
+        int(win.group(1)),
+        int(win.group(2)),
+        int(stride.group(1)),
+        int(stride.group(2)),
+        int(pad.group(1)),
+        int(pad.group(2)),
+        istr.group(1) == "true",
+    )
+
+
+def _extract_its_output_memory(row: Mapping[str, Any]) -> str | None:
+    """Return the OUTPUT_0_MEMORY string for an ITS row's LUT key, or ``None`` if missing."""
+    val = row.get(_OUTPUT_0_MEMORY_COLUMN)
+    if val is None or is_na(val):
+        return None
+    s = str(val).strip()
+    return s or None
 
 
 def _parse_attributes_cell(raw) -> dict | None:
@@ -480,10 +538,22 @@ def build_key_tuple(
         if err is not None:
             return None, err
 
-    i1_blank = _all_input1_blank(row, input1_cols)
-    i1_filled = _all_input1_non_blank(row, input1_cols, pad_suffixes)
-    i2_blank = _all_input1_blank(row, input2_cols)
-    i2_filled = _all_input1_non_blank(row, input2_cols, pad_suffixes)
+    # Op codes in PREALLOC_OUTPUT_AS_INPUT1_OPS treat any populated INPUT_1_* as
+    # the optional preallocated output tensor — not a real operand.  Force arity-1
+    # (drop INPUT_1, and INPUT_2) so the LUT key is consistent across rows that
+    # do/don't pre-allocate the output buffer.  See op_canonical.py for the rule
+    # and its reference in tt-metal source.
+    op_code_canon = str(values[0]).strip().lower() if values else ""
+    if op_code_canon in PREALLOC_OUTPUT_AS_INPUT1_OPS:
+        i1_blank = True
+        i1_filled = False
+        i2_blank = True
+        i2_filled = False
+    else:
+        i1_blank = _all_input1_blank(row, input1_cols)
+        i1_filled = _all_input1_non_blank(row, input1_cols, pad_suffixes)
+        i2_blank = _all_input1_blank(row, input2_cols)
+        i2_filled = _all_input1_non_blank(row, input2_cols, pad_suffixes)
 
     if i1_blank:
         if not i2_blank and not i2_filled:
@@ -1241,6 +1311,7 @@ def process_excel_to_master(
     input_spec: str,
     mode: str,
     dram_bw_gbps: float,
+    cv_threshold: float = CV_THRESHOLD,
 ) -> tuple[int, dict[tuple, dict], dict[tuple, dict], Path]:
     """Load one Excel or CSV input spec and build master dict.
 
@@ -1308,6 +1379,26 @@ def process_excel_to_master(
                 key_tuple_field_values(row, key_cols),
             )
             continue
+        op_code_lc = str(key_t[0]).strip().lower() if key_t else ""
+        if op_code_lc == _HALO_OP_CODE:
+            halo_geom = _extract_halo_geometry(row)
+            if halo_geom is None:
+                logger.warning(
+                    "Skipping halo row index={} (couldn't parse SlidingWindowConfig "
+                    "window_hw/stride_hw/padding/is_transpose from ATTRIBUTES)",
+                    idx,
+                )
+                continue
+            key_t = key_t + halo_geom
+        elif op_code_lc == _ITS_OP_CODE:
+            out_mem = _extract_its_output_memory(row)
+            if out_mem is None:
+                logger.warning(
+                    "Skipping ITS row index={} (missing OUTPUT_0_MEMORY)",
+                    idx,
+                )
+                continue
+            key_t = key_t + (out_mem,)
         if is_na(row.get(duration_col)) or (
             isinstance(row.get(duration_col), str)
             and not str(row.get(duration_col)).strip()
@@ -1355,7 +1446,7 @@ def process_excel_to_master(
         logger.error("No rows after parsing.")
         return 1, {}, {}, excel_path
 
-    accepted = group_and_sanitize(rows, MASTER_DURATION_MS_KEY, CV_THRESHOLD)
+    accepted = group_and_sanitize(rows, MASTER_DURATION_MS_KEY, cv_threshold)
     master, curve_meta = build_master_dict(accepted, mode)
     return 0, master, curve_meta, excel_path
 
@@ -1411,6 +1502,18 @@ def parse_args() -> argparse.Namespace:
         help=(
             "Write merged master to the output YAML file. If omitted, only report what "
             "would be added/updated (no file write)."
+        ),
+    )
+    parser.add_argument(
+        "--cv-threshold",
+        dest="cv_threshold",
+        type=float,
+        default=CV_THRESHOLD,
+        help=(
+            f"Per-group coefficient-of-variation gate for duration outliers (default "
+            f"{CV_THRESHOLD}). Groups whose duration CV exceeds this are dropped entirely. "
+            f"Raise (e.g. 0.80) to retain high-variance entries (useful for ops like "
+            f"halo/pool2d whose timings can vary across runs)."
         ),
     )
     args = parser.parse_args()
@@ -1472,7 +1575,7 @@ def main() -> int:
 
     for spec in args.model_run:
         code, master, cm, _ = process_excel_to_master(
-            spec, "single", args.dram_bw_gbps
+            spec, "single", args.dram_bw_gbps, args.cv_threshold
         )
         if code != 0:
             return code
@@ -1489,7 +1592,7 @@ def main() -> int:
 
     for spec in args.sweep_run:
         code, master, cm, _ = process_excel_to_master(
-            spec, "curve", args.dram_bw_gbps
+            spec, "curve", args.dram_bw_gbps, args.cv_threshold
         )
         if code != 0:
             return code

--- a/tools/perf_lookup/tt_perf_master_loader.py
+++ b/tools/perf_lookup/tt_perf_master_loader.py
@@ -4,7 +4,7 @@
 """Load tt-perf master YAML into ``dict[tuple, dict]`` (logical key → entry payload).
 
 Contract: ``doc/YAML_MASTER_FORMAT.md``. CLI and Excel pipeline: ``tools/perf_lookup/tt_perf_mapper.py``. Accepts
-``schema_version`` 1 (legacy, emits deprecation warning) or 2 (current); matmul entries must use ``entry_type: hybrid``.
+``schema_version`` 1–3 (legacy, emits deprecation warning) or 4 (current); matmul entries must use ``entry_type: hybrid``.
 """
 
 from __future__ import annotations

--- a/tools/perf_lookup/tt_perf_master_schema.py
+++ b/tools/perf_lookup/tt_perf_master_schema.py
@@ -45,6 +45,23 @@ KEY_TUPLE_YAML_KEYS = [
 
 _KEY_TUPLE_YAML_KEYS_SET = frozenset(KEY_TUPLE_YAML_KEYS)
 
+# Per-op variant key tuples.
+# Halo v3: standard 9 fields + 6 sliding-window geometry fields = 15 fields.
+# Halo v4: adds is_transpose to disambiguate ConvTranspose halos = 16 fields.
+_HALO_V3_EXTRA_YAML_KEYS = ["kernel_h", "kernel_w", "stride_h", "stride_w", "padding_h", "padding_w"]
+HALO_V3_KEY_TUPLE_YAML_KEYS = KEY_TUPLE_YAML_KEYS[:9] + _HALO_V3_EXTRA_YAML_KEYS
+HALO_KEY_TUPLE_YAML_KEYS = KEY_TUPLE_YAML_KEYS[:9] + _HALO_V3_EXTRA_YAML_KEYS + ["is_transpose"]
+
+# InterleavedToSharded: standard 9 fields + destination memory = 10 fields.
+ITS_KEY_TUPLE_YAML_KEYS = KEY_TUPLE_YAML_KEYS[:9] + [
+    "output_0_memory",
+]
+
+# Field names that uniquely identify each per-op variant (used for detection on load).
+# Any halo key (v3 or v4) has kernel_h; is_transpose distinguishes v4 from v3.
+_HALO_EXTRA_KEY_NAMES: frozenset[str] = frozenset(HALO_KEY_TUPLE_YAML_KEYS[9:])
+_ITS_EXTRA_KEY_NAMES: frozenset[str] = frozenset(ITS_KEY_TUPLE_YAML_KEYS[9:])
+
 # Device kernel duration in master YAML (milliseconds). Excel uses nanoseconds column title.
 MASTER_DURATION_MS_KEY = "msecs"
 
@@ -96,7 +113,9 @@ MATH_FIDELITY_NA = "N/A"
 MASTER_YAML_SCHEMA_NAME = "correqn.tt-perf-master"
 MASTER_YAML_SCHEMA_NAME_KEY = "schema_name"
 # v2: math_fidelity added to key tuple (v1 files still load via default-fill in labeled_key_map_to_tuple).
-MASTER_YAML_SCHEMA_VERSION = 2
+# v3: per-op variant tuples — halo (15-field) and interleavedtosharded (10-field).
+# v4: halo gains is_transpose (16-field) so ConvTranspose halos don't collide with Conv halos.
+MASTER_YAML_SCHEMA_VERSION = 4
 MASTER_YAML_SCHEMA_VERSION_KEY = "schema_version"
 MASTER_YAML_ENTRIES_KEY = "entries"
 MASTER_YAML_RECORD_KEY_FIELD = "key"
@@ -106,8 +125,25 @@ MASTER_YAML_ENTRY_VALUE_FIELD = "value"
 def tuple_to_labeled_key_map(key_t: tuple) -> dict:
     """Serialize logical key tuple to YAML mapping (under ``entries[i]['key']``)."""
     n = len(key_t)
+    # Per-op variants are disambiguated by op_code (key_t[0]) — schema v4's halo
+    # is 16-field which collides on length with the standard binary-op tuple.
+    if n >= 1 and key_t[0] == "halo":
+        if n == len(HALO_KEY_TUPLE_YAML_KEYS):
+            return dict(zip(HALO_KEY_TUPLE_YAML_KEYS, key_t))
+        if n == len(HALO_V3_KEY_TUPLE_YAML_KEYS):
+            return dict(zip(HALO_V3_KEY_TUPLE_YAML_KEYS, key_t))
+        raise ValueError(
+            f"Halo key tuple length must be {len(HALO_V3_KEY_TUPLE_YAML_KEYS)} (v3) "
+            f"or {len(HALO_KEY_TUPLE_YAML_KEYS)} (v4), got {n}"
+        )
+    if n >= 1 and key_t[0] == "interleavedtosharded":
+        if n != len(ITS_KEY_TUPLE_YAML_KEYS):
+            raise ValueError(
+                f"ITS key tuple length must be {len(ITS_KEY_TUPLE_YAML_KEYS)}, got {n}"
+            )
+        return dict(zip(ITS_KEY_TUPLE_YAML_KEYS, key_t))
     if n not in (9, 16, 23):
-        raise ValueError(f"Key tuple length must be 9, 16, or 23, got {n}")
+        raise ValueError(f"Key tuple length must be 9, 16, or 23 for standard ops (or use halo/its variant), got {n}")
     return dict(zip(KEY_TUPLE_YAML_KEYS[:n], key_t))
 
 
@@ -115,16 +151,45 @@ def labeled_key_map_to_tuple(d: dict) -> tuple:
     """Parse YAML labeled mapping back to logical key tuple."""
     if not isinstance(d, dict):
         raise TypeError(f"Labeled key must be a dict, got {type(d)}")
+    str_keys = {k if isinstance(k, str) else str(k) for k in d}
+
+    # Per-op variant detection: unique extra fields identify halo and ITS.
+    if str_keys & _HALO_EXTRA_KEY_NAMES:
+        # Detect schema version by presence of is_transpose (v4) or absence (v3 legacy).
+        if "is_transpose" in str_keys:
+            halo_keys = HALO_KEY_TUPLE_YAML_KEYS  # 16-field v4
+        else:
+            halo_keys = HALO_V3_KEY_TUPLE_YAML_KEYS  # 15-field v3 legacy
+        expected = frozenset(halo_keys)
+        missing = [nm for nm in halo_keys if nm not in d]
+        if missing:
+            raise ValueError(f"Halo labeled key missing fields: {missing}")
+        unknown = sorted(str_keys - expected)
+        if unknown:
+            raise ValueError(f"Unknown halo labeled-key field(s): {unknown}")
+        return tuple(d[nm] for nm in halo_keys)
+
+    if str_keys & _ITS_EXTRA_KEY_NAMES:
+        expected = frozenset(ITS_KEY_TUPLE_YAML_KEYS)
+        missing = [nm for nm in ITS_KEY_TUPLE_YAML_KEYS if nm not in d]
+        if missing:
+            raise ValueError(f"ITS labeled key missing fields: {missing}")
+        unknown = sorted(str_keys - expected)
+        if unknown:
+            raise ValueError(f"Unknown ITS labeled-key field(s): {unknown}")
+        return tuple(d[nm] for nm in ITS_KEY_TUPLE_YAML_KEYS)
+
+    # Standard 9/16/23 path.
     filtered: dict = {}
-    unknown: list = []
+    unknown_list: list = []
     for k, v in d.items():
         ks = k if isinstance(k, str) else str(k)
         if ks in _KEY_TUPLE_YAML_KEYS_SET:
             filtered[ks] = v
         else:
-            unknown.append(k)
-    if unknown:
-        raise ValueError(f"Unknown labeled-key field(s): {unknown}")
+            unknown_list.append(k)
+    if unknown_list:
+        raise ValueError(f"Unknown labeled-key field(s): {unknown_list}")
     if "math_fidelity" not in filtered:
         filtered["math_fidelity"] = MATH_FIDELITY_NA
     has_i2 = any(str(k).startswith("input_2_") for k in filtered)
@@ -160,8 +225,8 @@ def yaml_labeled_key_to_tuple(k: dict) -> tuple:
         raise TypeError(f"Entry key must be a mapping, got {type(k)!r}")
     key_t = labeled_key_map_to_tuple(k)
     n = len(key_t)
-    if n not in (9, 16, 23):
-        raise ValueError(f"Key tuple length must be 9, 16, or 23, got {n}")
+    if n not in (9, 10, 15, 16, 23):
+        raise ValueError(f"Key tuple length must be 9, 10, 15, 16, or 23, got {n}")
     return key_t
 
 

--- a/tools/profiling/compare_layers.py
+++ b/tools/profiling/compare_layers.py
@@ -156,6 +156,7 @@ class ComparisonStats:
     unmatched_polaris: int = 0
     unmatched_profiler: int = 0
     ambiguous: int = 0
+    lut_key_mismatches: int = 0
 
 
 def parse_args() -> argparse.Namespace:
@@ -223,17 +224,47 @@ def parse_args() -> argparse.Namespace:
              'is grouped by type+signature instead of by optype alone.',
     )
     parser.add_argument(
+        '--by-lut-key',
+        action='store_true',
+        help='Print a rollup table grouped by full LUT key (optype + per-input-slot '
+             'padded shape, layout, dtype, memory + math_fidelity), with columns '
+             'exploded.  Works for both profiler CSV (literal LUT entry key per row) '
+             'and polaris CSV (uses the resolved key — the LUT entry the runtime '
+             'lookup chain matched after any HEIGHT→BLOCK / L1→DRAM / arity-dup '
+             'fallback — so polaris and profiler rows that share a LUT entry land '
+             'in the same bucket).  With one file, prints a single-file count table. '
+             'With two files, prints a side-by-side count table.  With --perf, adds '
+             'summed duration columns and absolute/percent gap.',
+    )
+    parser.add_argument(
         '--xlsx',
         type=str,
         default=None,
         metavar='PATH',
-        help='Also write an .xlsx report with three sheets: '
+        help='Also write an .xlsx report with four sheets: '
              '"Summary" (network-wide totals + shape/attr counts), '
-             '"By Layer Type" (per canonical optype), and '
-             '"By Layer Signature" (per optype + normalized in/out shape signature). '
-             'In two-file mode each sheet includes Profiler vs Polaris columns and gap; '
+             '"By Layer Type" (per canonical optype), '
+             '"By Layer Signature" (per optype + normalized in/out shape signature), and '
+             '"By LUT Key" (per full LUT key tuple with columns exploded). '
+             'In two-file mode each sheet includes file1 vs file2 columns and gap; '
              'in single-file mode only that source\'s counts/ms are emitted. '
              'Requires openpyxl (already a polarisdev dep).',
+    )
+    parser.add_argument(
+        '--label1',
+        type=str,
+        default=None,
+        metavar='LABEL',
+        help='Display label for the first file (default: auto-detected type, e.g. "Polaris" '
+             'or "Profiler"; for same-type comparisons defaults to "Polaris 1" / "Profiler 1")',
+    )
+    parser.add_argument(
+        '--label2',
+        type=str,
+        default=None,
+        metavar='LABEL',
+        help='Display label for the second file (default: auto-detected type, e.g. "Polaris" '
+             'or "Profiler"; for same-type comparisons defaults to "Polaris 2" / "Profiler 2")',
     )
     return parser.parse_args()
 
@@ -319,74 +350,77 @@ def format_shapes(shapes: List[str]) -> str:
 
 
 def compare_layers(
-    polaris_layers: List[Dict[str, Any]],
-    profiler_layers: List[Dict[str, Any]],
+    layers1: List[Dict[str, Any]],
+    layers2: List[Dict[str, Any]],
     max_search_distance: int = DEFAULT_MAX_SEARCH_DISTANCE,
     strip_leading_ones: bool = False,
     strip_singleton_dims: bool = False,
     ignore_attrs: bool = False,
+    label1: str = 'File1',
+    label2: str = 'File2',
 ) -> ComparisonStats:
     """
     Compare two layer sequences and print results.
+
+    layers1 is the pivot (iterated in order); layers2 is searched for matches.
+    label1/label2 are used in diagnostic output.
 
     Returns:
         ComparisonStats object with statistics
     """
     stats = ComparisonStats()
-    ndx_polaris = 0
-    ndx_profiler = 0
+    ndx1 = 0
+    ndx2 = 0
 
-    while ndx_polaris < len(polaris_layers) or ndx_profiler < len(profiler_layers):
+    while ndx1 < len(layers1) or ndx2 < len(layers2):
         # Case 3: One sequence exhausted
-        if ndx_polaris >= len(polaris_layers):
-            # Profiler has remaining entries
-            layer = profiler_layers[ndx_profiler]
-            print(f"⊘ [F:{layer['seqno']}] {layer['optype']} (skipped in polaris)")
+        if ndx1 >= len(layers1):
+            layer = layers2[ndx2]
+            print(f"⊘ [2:{layer['seqno']}] {layer['optype']} (not in {label1})")
             stats.unmatched_profiler += 1
-            ndx_profiler += 1
+            ndx2 += 1
             continue
 
-        if ndx_profiler >= len(profiler_layers):
-            # Polaris has remaining entries
-            layer = polaris_layers[ndx_polaris]
-            print(f"⊘ [P:{layer['seqno']}] {layer['optype']} (skipped in profiler)")
+        if ndx2 >= len(layers2):
+            layer = layers1[ndx1]
+            print(f"⊘ [1:{layer['seqno']}] {layer['optype']} (not in {label2})")
             stats.unmatched_polaris += 1
-            ndx_polaris += 1
+            ndx1 += 1
             continue
 
         # Get current layers
-        p_layer = polaris_layers[ndx_polaris]
-        f_layer = profiler_layers[ndx_profiler]
+        l1 = layers1[ndx1]
+        l2 = layers2[ndx2]
 
         # Normalize optypes for comparison
-        p_optype_norm = normalize_optype(p_layer['optype'])
-        f_optype_norm = normalize_optype(f_layer['optype'])
+        l1_optype_norm = normalize_optype(l1['optype'])
+        l2_optype_norm = normalize_optype(l2['optype'])
 
         # Case 1: optypes match (after normalization)
-        if p_optype_norm == f_optype_norm:
+        if l1_optype_norm == l2_optype_norm:
             # Compare shapes
             input_match, input_details = compare_tensor_shapes(
-                p_layer.get('input_tensors', []),
-                f_layer.get('input_tensors', []),
+                l1.get('input_tensors', []),
+                l2.get('input_tensors', []),
                 strip_leading_ones,
-                p_layer['optype'],
+                l1['optype'],
                 strip_singleton_dims=strip_singleton_dims,
             )
             output_match, output_details = compare_tensor_shapes(
-                p_layer.get('output_tensors', []),
-                f_layer.get('output_tensors', []),
+                l1.get('output_tensors', []),
+                l2.get('output_tensors', []),
                 strip_leading_ones,
-                p_layer['optype'],
+                l1['optype'],
                 strip_singleton_dims=strip_singleton_dims,
             )
 
             # Special handling for binary ops (add/mul/sub) if input counts
             # or shapes don't match — one side may use scalar/untracked operands
-            p_canonical = normalize_polaris_optype(p_layer['optype'])
-            if not input_match and to_comparison_group(p_canonical) == 'binary':
+            l1_canonical = normalize_polaris_optype(l1['optype'])
+            if not input_match and to_comparison_group(l1_canonical) == 'binary':
                 bin_valid, bin_details = validate_binary_compatibility(
-                    p_layer.get('input_tensors', []),
-                    f_layer.get('input_tensors', []),
+                    l1.get('input_tensors', []),
+                    l2.get('input_tensors', []),
                     strip_leading_ones,
                     strip_singleton_dims=strip_singleton_dims,
                 )
@@ -395,11 +429,11 @@ def compare_layers(
                     input_details = bin_details
 
             # Special handling for reshape if standard comparison fails
-            if p_canonical == 'reshape' and (not input_match or not output_match):
+            if l1_canonical == 'reshape' and (not input_match or not output_match):
                 reshape_valid, reshape_details = validate_reshape_compatibility(
-                    p_layer.get('input_tensors', []),
-                    p_layer.get('output_tensors', []),
-                    f_layer.get('output_tensors', []),
+                    l1.get('input_tensors', []),
+                    l1.get('output_tensors', []),
+                    l2.get('output_tensors', []),
                     strip_leading_ones,
                     strip_singleton_dims=strip_singleton_dims,
                 )
@@ -413,8 +447,8 @@ def compare_layers(
             attr_ok = True
             attr_details_parts = []
             if input_match and output_match and not ignore_attrs:
-                in_attr_ok, in_attr_det = compare_tensor_attributes(p_layer, f_layer, 'input')
-                out_attr_ok, out_attr_det = compare_tensor_attributes(p_layer, f_layer, 'output')
+                in_attr_ok, in_attr_det = compare_tensor_attributes(l1, l2, 'input')
+                out_attr_ok, out_attr_det = compare_tensor_attributes(l1, l2, 'output')
                 if not in_attr_ok:
                     attr_ok = False
                     attr_details_parts.append(f"input attrs: {in_attr_det}")
@@ -423,51 +457,55 @@ def compare_layers(
                     attr_details_parts.append(f"output attrs: {out_attr_det}")
 
             if input_match and output_match and attr_ok:
-                print(f"✓ [P:{p_layer['seqno']}] [F:{f_layer['seqno']}] {p_layer['optype']}  "
-                      f"in: {format_shapes(p_layer.get('input_tensors', []))} | "
-                      f"out: {format_shapes(p_layer.get('output_tensors', []))}")
+                print(f"✓ [1:{l1['seqno']}] [2:{l2['seqno']}] {l1['optype']}  "
+                      f"in: {format_shapes(l1.get('input_tensors', []))} | "
+                      f"out: {format_shapes(l1.get('output_tensors', []))}")
                 stats.total_matches += 1
             elif input_match and output_match and not attr_ok:
-                print(f"✗ attr [P:{p_layer['seqno']}] [F:{f_layer['seqno']}] {p_layer['optype']}")
+                print(f"✗ attr [1:{l1['seqno']}] [2:{l2['seqno']}] {l1['optype']}")
                 for part in attr_details_parts:
                     print(f"  {part}")
                 stats.attr_mismatches += 1
             else:
-                print(f"✗ shape [P:{p_layer['seqno']}] [F:{f_layer['seqno']}] {p_layer['optype']}")
+                print(f"✗ shape [1:{l1['seqno']}] [2:{l2['seqno']}] {l1['optype']}")
                 if not input_match:
-                    print(f"  input: polaris={format_shapes(p_layer.get('input_tensors', []))} "
-                          f"profiler={format_shapes(f_layer.get('input_tensors', []))} ({input_details})")
+                    print(f"  input: {label1}={format_shapes(l1.get('input_tensors', []))} "
+                          f"{label2}={format_shapes(l2.get('input_tensors', []))} ({input_details})")
                     stats.input_shape_mismatches += 1
                 if not output_match:
-                    print(f"  output: polaris={format_shapes(p_layer.get('output_tensors', []))} "
-                          f"profiler={format_shapes(f_layer.get('output_tensors', []))} ({output_details})")
+                    print(f"  output: {label1}={format_shapes(l1.get('output_tensors', []))} "
+                          f"{label2}={format_shapes(l2.get('output_tensors', []))} ({output_details})")
                     stats.output_shape_mismatches += 1
                 stats.shape_mismatches += 1
 
-            ndx_polaris += 1
-            ndx_profiler += 1
+            # LUT key comparison (for all matched pairs, both profiler outputs)
+            lk1 = l1.get('lut_key_resolved') or l1.get('lut_key')
+            lk2 = l2.get('lut_key_resolved') or l2.get('lut_key')
+            if lk1 is not None and lk2 is not None and lk1 != lk2:
+                print(f"  lut_key mismatch [1:{l1['seqno']}] [2:{l2['seqno']}] {l1['optype']}")
+                print(f"    {label1}: {lk1}")
+                print(f"    {label2}: {lk2}")
+                stats.lut_key_mismatches += 1
+
+            ndx1 += 1
+            ndx2 += 1
             continue
 
-        # Case 2: optypes don't match - search forward in profiler only (polaris is pivot)
-        profiler_match_idx = find_next_match(
-            profiler_layers, ndx_profiler + 1, p_optype_norm, max_search_distance
+        # Case 2: optypes don't match — search forward in layers2 (layers1 is pivot)
+        match_idx2 = find_next_match(
+            layers2, ndx2 + 1, l1_optype_norm, max_search_distance
         )
 
-        # If found in profiler, skip profiler entries to get there
-        if profiler_match_idx is not None:
-            for i in range(ndx_profiler, profiler_match_idx):
-                layer = profiler_layers[i]
-                print(f"⊘ [F:{layer['seqno']}] {layer['optype']} (skipped in polaris)")
+        if match_idx2 is not None:
+            for i in range(ndx2, match_idx2):
+                layer = layers2[i]
+                print(f"⊘ [2:{layer['seqno']}] {layer['optype']} (not in {label1})")
                 stats.unmatched_profiler += 1
-
-            # Move profiler to matched position, polaris stays to compare
-            ndx_profiler = profiler_match_idx
-            # Continue to compare at this position (will be handled in next iteration)
+            ndx2 = match_idx2
         else:
-            # Polaris entry not found in profiler - mark and advance polaris only
-            print(f"✗ name [P:{p_layer['seqno']}] --- {p_layer['optype']} (not in profiler)")
+            print(f"✗ name [1:{l1['seqno']}] --- {l1['optype']} (not in {label2})")
             stats.name_mismatches += 1
-            ndx_polaris += 1
+            ndx1 += 1
 
     return stats
 
@@ -573,7 +611,7 @@ def _print_signature_summary(
     print()
 
 
-def print_summary(stats: ComparisonStats) -> None:
+def print_summary(stats: ComparisonStats, label1: str = 'File1', label2: str = 'File2') -> None:
     """Print summary statistics."""
     print("\n=== Summary ===")
     print(f"Total matches: {stats.total_matches}")
@@ -581,8 +619,9 @@ def print_summary(stats: ComparisonStats) -> None:
     print(f"Shape mismatches: {stats.shape_mismatches} "
           f"({stats.input_shape_mismatches} input, {stats.output_shape_mismatches} output)")
     print(f"Attribute mismatches: {stats.attr_mismatches}")
+    print(f"LUT key mismatches: {stats.lut_key_mismatches}")
     print(f"Unmatched entries: {stats.unmatched_polaris + stats.unmatched_profiler} "
-          f"({stats.unmatched_polaris} polaris, {stats.unmatched_profiler} profiler)")
+          f"({stats.unmatched_polaris} {label1}, {stats.unmatched_profiler} {label2})")
     print(f"Ambiguous: {stats.ambiguous}")
 
 
@@ -780,49 +819,59 @@ def _print_perf_standalone(
 
 
 def _print_perf_comparison(
-    profiler_layers: List[Dict[str, Any]],
-    polaris_layers: List[Dict[str, Any]],
+    layers1: List[Dict[str, Any]],
+    layers2: List[Dict[str, Any]],
     *,
     by_signature: bool = False,
     strip_leading_ones: bool = False,
     strip_singleton_dims: bool = False,
+    label1: str = 'File1',
+    label2: str = 'File2',
 ) -> None:
-    """Print side-by-side performance comparison with gap w.r.t. profiler."""
-    prof_by: Union[Dict[Tuple[str, str], Tuple[int, float, int]], Dict[str, Tuple[int, float, int]]]
-    pol_by: Union[Dict[Tuple[str, str], Tuple[int, float, int]], Dict[str, Tuple[int, float, int]]]
+    """Print side-by-side performance comparison; gap is (file2 − file1) / file1."""
+    by1: Union[Dict[Tuple[str, str], Tuple[int, float, int]], Dict[str, Tuple[int, float, int]]]
+    by2: Union[Dict[Tuple[str, str], Tuple[int, float, int]], Dict[str, Tuple[int, float, int]]]
 
     if by_signature:
-        prof_by = _aggregate_duration_by_optype_signature(
-            profiler_layers, strip_leading_ones, strip_singleton_dims
-        )
-        pol_by = _aggregate_duration_by_optype_signature(
-            polaris_layers, strip_leading_ones, strip_singleton_dims
-        )
+        by1 = _aggregate_duration_by_optype_signature(layers1, strip_leading_ones, strip_singleton_dims)
+        by2 = _aggregate_duration_by_optype_signature(layers2, strip_leading_ones, strip_singleton_dims)
         title = "Performance Summary (by layer type + signature)"
     else:
-        prof_by = _aggregate_duration_by_optype(profiler_layers)
-        pol_by = _aggregate_duration_by_optype(polaris_layers)
+        by1 = _aggregate_duration_by_optype(layers1)
+        by2 = _aggregate_duration_by_optype(layers2)
         title = "Performance Summary"
 
-    prof_total_ms = sum(ms for _, ms, _ in prof_by.values())
-    pol_total_ms = sum(ms for _, ms, _ in pol_by.values())
-    prof_total_cnt = sum(cnt for cnt, _, _ in prof_by.values())
-    pol_total_cnt = sum(cnt for cnt, _, _ in pol_by.values())
-    pol_total_lut = sum(lut for _, _, lut in pol_by.values())
+    total_ms1 = sum(ms for _, ms, _ in by1.values())
+    total_ms2 = sum(ms for _, ms, _ in by2.values())
+    total_cnt1 = sum(cnt for cnt, _, _ in by1.values())
+    total_cnt2 = sum(cnt for cnt, _, _ in by2.values())
+    total_lut1 = sum(lut for _, _, lut in by1.values())
+    total_lut2 = sum(lut for _, _, lut in by2.values())
 
     print(f"\n{'=' * 82}")
     print(f"  {title}")
     print(f"{'=' * 82}")
 
     print("\n  Network total:")
-    print(f"    Profiler:  {prof_total_ms:.4f} ms")
-    print(f"    Polaris:   {pol_total_ms:.4f} ms")
-    print(f"    Gap:       {_pct_gap(prof_total_ms, pol_total_ms)} (w.r.t. profiler)")
-    print(f"    Polaris LUT hits: {pol_total_lut}/{pol_total_cnt}")
+    print(f"    {label1}:  {total_ms1:.4f} ms")
+    print(f"    {label2}:  {total_ms2:.4f} ms")
+    print(f"    Gap:  {_pct_gap(total_ms1, total_ms2)} (w.r.t. {label1})")
+    if total_lut1 > 0:
+        print(f"    {label1} LUT hits: {total_lut1}/{total_cnt1}")
+    if total_lut2 > 0:
+        print(f"    {label2} LUT hits: {total_lut2}/{total_cnt2}")
     print()
 
-    all_keys: List[Any] = list(dict.fromkeys(list(prof_by.keys()) + list(pol_by.keys())))
-    all_keys.sort(key=lambda k: prof_by.get(k, (0, 0.0, 0))[1], reverse=True)
+    all_keys: List[Any] = list(dict.fromkeys(list(by1.keys()) + list(by2.keys())))
+    all_keys.sort(key=lambda k: by1.get(k, (0, 0.0, 0))[1], reverse=True)
+
+    lbl1 = label1[:10]
+    lbl2 = label2[:10]
+    hdr_ms1 = f"{lbl1}(ms)"
+    hdr_ms2 = f"{lbl2}(ms)"
+    col_ms = max(13, len(hdr_ms1), len(hdr_ms2))
+    has_lut1 = total_lut1 > 0
+    has_lut2 = total_lut2 > 0
 
     if by_signature:
         col_w_op = max(10, max((len(k[0]) for k in all_keys), default=10))
@@ -830,87 +879,424 @@ def _print_perf_comparison(
         hdr = (
             f"  {'Layer type':<{col_w_op}}"
             f"  {'Signature':<{col_w_sig}}"
-            f"  {'#Prof':>6}  {'Profiler(ms)':>13}"
-            f"  {'#Pol':>6}  {'Polaris(ms)':>13}"
-            f"  {'LUT':>8}"
-            f"  {'Abs Gap(ms)':>12}"
-            f"  {'Gap%':>9}"
+            f"  {'#1':>6}  {hdr_ms1:>{col_ms}}"
+            f"  {'#2':>6}  {hdr_ms2:>{col_ms}}"
         )
     else:
         col_w_op = max(10, max((len(str(op)) for op in all_keys), default=10))
         col_w_sig = 0
         hdr = (
             f"  {'Layer Type':<{col_w_op}}"
-            f"  {'#Prof':>6}  {'Profiler(ms)':>13}"
-            f"  {'#Pol':>6}  {'Polaris(ms)':>13}"
-            f"  {'LUT':>8}"
-            f"  {'Abs Gap(ms)':>12}"
-            f"  {'Gap%':>9}"
+            f"  {'#1':>6}  {hdr_ms1:>{col_ms}}"
+            f"  {'#2':>6}  {hdr_ms2:>{col_ms}}"
         )
+    if has_lut1:
+        hdr += f"  {'LUT1':>8}"
+    if has_lut2:
+        hdr += f"  {'LUT2':>8}"
+    hdr += f"  {'Abs Gap(ms)':>12}  {'Gap%':>9}"
     print(hdr)
-    rule_len = col_w_op + 6 + 13 + 6 + 13 + 8 + 12 + 9 + 14 + (col_w_sig + 2 if by_signature else 0)
+    rule_len = (col_w_op + 6 + col_ms + 6 + col_ms + 12 + 9 + 16
+                + (col_w_sig + 2 if by_signature else 0)
+                + (10 if has_lut1 else 0) + (10 if has_lut2 else 0))
     print(f"  {'─' * min(rule_len, 120)}")
 
     for key in all_keys:
         if by_signature:
             op, sig = key
             sig_disp = sig if len(sig) <= col_w_sig else sig[: col_w_sig - 3] + "..."
-            p_cnt, p_ms, _ = prof_by.get(key, (0, 0.0, 0))
-            s_cnt, s_ms, s_lut = pol_by.get(key, (0, 0.0, 0))
+            cnt1, ms1, lut1 = by1.get(key, (0, 0.0, 0))
+            cnt2, ms2, lut2 = by2.get(key, (0, 0.0, 0))
         else:
             op = key
             sig_disp = ""
-            p_cnt, p_ms, _ = prof_by.get(op, (0, 0.0, 0))
-            s_cnt, s_ms, s_lut = pol_by.get(op, (0, 0.0, 0))
-        gap_pct = _pct_gap(p_ms, s_ms)
-        abs_gap = s_ms - p_ms
-        abs_gap_s = f"{abs_gap:+.4f}" if (p_cnt and s_cnt) else "—"
-        p_cnt_s = str(p_cnt) if p_cnt else "—"
-        s_cnt_s = str(s_cnt) if s_cnt else "—"
-        p_ms_s = f"{p_ms:.4f}" if p_cnt else "—"
-        s_ms_s = f"{s_ms:.4f}" if s_cnt else "—"
-        lut_s = f"{s_lut}/{s_cnt}" if s_cnt else "—"
+            cnt1, ms1, lut1 = by1.get(op, (0, 0.0, 0))
+            cnt2, ms2, lut2 = by2.get(op, (0, 0.0, 0))
+        gap_pct = _pct_gap(ms1, ms2)
+        abs_gap = ms2 - ms1
+        abs_gap_s = f"{abs_gap:+.4f}" if (cnt1 and cnt2) else "—"
+        cnt1_s = str(cnt1) if cnt1 else "—"
+        cnt2_s = str(cnt2) if cnt2 else "—"
+        ms1_s = f"{ms1:.4f}" if cnt1 else "—"
+        ms2_s = f"{ms2:.4f}" if cnt2 else "—"
+        lut1_s = f"{lut1}/{cnt1}" if has_lut1 and cnt1 else ("—" if has_lut1 else "")
+        lut2_s = f"{lut2}/{cnt2}" if has_lut2 and cnt2 else ("—" if has_lut2 else "")
         if by_signature:
-            print(
+            line = (
                 f"  {op:<{col_w_op}}"
                 f"  {sig_disp:<{col_w_sig}}"
-                f"  {p_cnt_s:>6}  {p_ms_s:>13}"
-                f"  {s_cnt_s:>6}  {s_ms_s:>13}"
-                f"  {lut_s:>8}"
-                f"  {abs_gap_s:>12}"
-                f"  {gap_pct:>9}"
+                f"  {cnt1_s:>6}  {ms1_s:>{col_ms}}"
+                f"  {cnt2_s:>6}  {ms2_s:>{col_ms}}"
             )
         else:
-            print(
+            line = (
                 f"  {op:<{col_w_op}}"
-                f"  {p_cnt_s:>6}  {p_ms_s:>13}"
-                f"  {s_cnt_s:>6}  {s_ms_s:>13}"
-                f"  {lut_s:>8}"
-                f"  {abs_gap_s:>12}"
-                f"  {gap_pct:>9}"
+                f"  {cnt1_s:>6}  {ms1_s:>{col_ms}}"
+                f"  {cnt2_s:>6}  {ms2_s:>{col_ms}}"
             )
+        if has_lut1:
+            line += f"  {lut1_s:>8}"
+        if has_lut2:
+            line += f"  {lut2_s:>8}"
+        line += f"  {abs_gap_s:>12}  {gap_pct:>9}"
+        print(line)
 
-    abs_total = pol_total_ms - prof_total_ms
+    abs_total = total_ms2 - total_ms1
     print(f"  {'─' * min(rule_len, 120)}")
     if by_signature:
-        print(
+        total_line = (
             f"  {'TOTAL':<{col_w_op}}"
             f"  {'':<{col_w_sig}}"
-            f"  {prof_total_cnt:>6}  {prof_total_ms:>13.4f}"
-            f"  {pol_total_cnt:>6}  {pol_total_ms:>13.4f}"
-            f"  {f'{pol_total_lut}/{pol_total_cnt}':>8}"
-            f"  {abs_total:>+12.4f}"
-            f"  {_pct_gap(prof_total_ms, pol_total_ms):>9}"
+            f"  {total_cnt1:>6}  {total_ms1:>{col_ms}.4f}"
+            f"  {total_cnt2:>6}  {total_ms2:>{col_ms}.4f}"
         )
     else:
-        print(
+        total_line = (
             f"  {'TOTAL':<{col_w_op}}"
-            f"  {prof_total_cnt:>6}  {prof_total_ms:>13.4f}"
-            f"  {pol_total_cnt:>6}  {pol_total_ms:>13.4f}"
-            f"  {f'{pol_total_lut}/{pol_total_cnt}':>8}"
-            f"  {abs_total:>+12.4f}"
-            f"  {_pct_gap(prof_total_ms, pol_total_ms):>9}"
+            f"  {total_cnt1:>6}  {total_ms1:>{col_ms}.4f}"
+            f"  {total_cnt2:>6}  {total_ms2:>{col_ms}.4f}"
         )
+    if has_lut1:
+        total_line += f"  {f'{total_lut1}/{total_cnt1}':>8}"
+    if has_lut2:
+        total_line += f"  {f'{total_lut2}/{total_cnt2}':>8}"
+    total_line += f"  {abs_total:>+12.4f}  {_pct_gap(total_ms1, total_ms2):>9}"
+    print(total_line)
+    print()
+
+
+# ---------------------------------------------------------------------------
+# LUT key summary helpers
+# ---------------------------------------------------------------------------
+
+_LUT_SLOT_NAMES: Tuple[str, ...] = ('w', 'z', 'y', 'x', 'layout', 'dtype', 'memory')
+
+
+def _lut_key_n_slots(key: Tuple[str, ...]) -> int:
+    """Number of input slots encoded in a lut_key tuple."""
+    if key and key[0] == 'halo':
+        return 1  # halo keys have exactly one input slot regardless of length (15-tuple v3, 16-tuple v4)
+    return max(0, (len(key) - 2) // 7)
+
+
+def _lut_key_slot_field(key: Tuple[str, ...], slot: int, field_idx: int) -> str:
+    """Return the string value for (slot, field_idx) in a lut_key, or '' if out of range."""
+    # math_fidelity sits at index 8 between slot-0 and slot-1; skip it when accessing slot 1+.
+    idx = 1 + slot * 7 + field_idx + (1 if slot > 0 else 0)
+    return str(key[idx]) if idx < len(key) else ''
+
+
+_HALO_V3_VARIANT_NAMES: Tuple[str, ...] = ('kernel_h', 'kernel_w', 'stride_h', 'stride_w', 'padding_h', 'padding_w')
+_HALO_V4_VARIANT_NAMES: Tuple[str, ...] = _HALO_V3_VARIANT_NAMES + ('is_transpose',)
+_ITS_VARIANT_NAMES: Tuple[str, ...] = ('output_0_memory',)
+
+
+def _lut_key_variant_tail(key: Tuple[str, ...]) -> List[Tuple[str, str]]:
+    """Return [(field_name, value), ...] for variant-specific fields at indices 9+ of a lut_key."""
+    if not key:
+        return []
+    op = key[0]
+    if op == 'halo':
+        if len(key) == 16:
+            names: Tuple[str, ...] = _HALO_V4_VARIANT_NAMES
+        elif len(key) == 15:
+            names = _HALO_V3_VARIANT_NAMES
+        else:
+            return []
+        return [(n, str(key[9 + i])) for i, n in enumerate(names)]
+    if op == 'interleavedtosharded' and len(key) == 10:
+        return [('output_0_memory', str(key[9]))]
+    return []
+
+
+def _lut_key_variant_col_names(keys: List[Tuple[str, ...]]) -> List[str]:
+    """Ordered union of all variant tail field names present across these keys."""
+    seen: dict = {}
+    for k in keys:
+        for name, _ in _lut_key_variant_tail(k):
+            seen[name] = None
+    return list(seen.keys())
+
+
+def _aggregate_by_lut_key(
+    layers: List[Dict[str, Any]],
+) -> Dict[Tuple[str, ...], Tuple[int, float, int]]:
+    """Group layers by their *resolved* LUT key; return {key: (count, total_ms, lut_hits)}.
+
+    Prefers ``lut_key_resolved`` (the tuple the polaris runtime LUT lookup actually
+    matched, after any fallback substitution: HEIGHT→BLOCK shard, L1→DRAM
+    interleaved, ROW_MAJOR→TILE layout, arity-1→arity-2 dup) over the literal
+    ``lut_key``.  This makes polaris rows and profiler rows that semantically
+    share a LUT entry land in the same bucket — without this, polaris's literal
+    key (built from the workload op's tensor state) and the profiler's literal key
+    (= the actual LUT entry) can differ in fallback-tolerable ways and over-segment.
+
+    Profiler-side rows only carry ``lut_key`` (their literal key IS a LUT entry, no
+    fallback needed); they fall through to the literal key automatically.  Older
+    polaris CSVs predating the Tier-1 plumbing also lack ``lut_key_resolved``;
+    those degrade to using the literal key — accurate for direct-hit rows,
+    over-segmenting for fallback-resolved rows (same as before).
+    """
+    counts: DefaultDict[Tuple[str, ...], int] = defaultdict(int)
+    ms_totals: DefaultDict[Tuple[str, ...], float] = defaultdict(float)
+    lut_totals: DefaultDict[Tuple[str, ...], int] = defaultdict(int)
+    for layer in layers:
+        raw = layer.get('lut_key_resolved') or layer.get('lut_key')
+        if raw is None:
+            continue
+        key: Tuple[str, ...] = tuple(str(f) for f in raw)
+        counts[key] += 1
+        d = layer.get('duration_ms')
+        if d is not None:
+            ms_totals[key] += float(d)
+        if layer.get('uses_perf_lookup'):
+            lut_totals[key] += 1
+    return {k: (counts[k], ms_totals.get(k, 0.0), lut_totals.get(k, 0)) for k in counts}
+
+
+def _lut_key_col_widths(
+    keys: List[Tuple[str, ...]], max_slots: int, variant_col_names: Optional[List[str]] = None
+) -> Tuple[int, int, List[List[int]], List[int]]:
+    """Return (col_op, col_mf, slot_widths, variant_widths) computed from data."""
+    col_op = max(10, max((len(k[0]) for k in keys), default=10))
+    col_mf = max(4, max((len(str(k[8])) if len(k) > 8 else 0 for k in keys), default=4))
+    slot_widths: List[List[int]] = []
+    for s in range(max_slots):
+        widths = []
+        for fi, name in enumerate(_LUT_SLOT_NAMES):
+            suffix = f'_{s}' if s > 0 else ''
+            hdr_w = len(name + suffix)
+            data_w = max((_lut_key_slot_field(k, s, fi).__len__() for k in keys), default=0)
+            widths.append(max(hdr_w, data_w, 4))
+        slot_widths.append(widths)
+    variant_widths: List[int] = []
+    for vname in (variant_col_names or []):
+        data_w = max((len(dict(_lut_key_variant_tail(k)).get(vname, '')) for k in keys), default=0)
+        variant_widths.append(max(len(vname), data_w, 4))
+    return col_op, col_mf, slot_widths, variant_widths
+
+
+def _lut_key_row(
+    key: Tuple[str, ...],
+    col_op: int,
+    col_mf: int,
+    slot_widths: List[List[int]],
+    prefix: str = '  ',
+    variant_col_names: Optional[List[str]] = None,
+    variant_widths: Optional[List[int]] = None,
+) -> str:
+    """Format the optype + per-slot + mf + variant-tail portion of a LUT key row."""
+    line = f'{prefix}{str(key[0]):<{col_op}}'
+    for s, widths in enumerate(slot_widths):
+        for fi in range(len(_LUT_SLOT_NAMES)):
+            v = _lut_key_slot_field(key, s, fi)
+            line += f'  {v:<{widths[fi]}}'
+    line += f'  {str(key[8]) if len(key) > 8 else "":<{col_mf}}'
+    if variant_col_names:
+        tail_dict = dict(_lut_key_variant_tail(key))
+        for vname, vw in zip(variant_col_names, variant_widths or []):
+            line += f'  {tail_dict.get(vname, ""):<{vw}}'
+    return line
+
+
+def _lut_key_header(
+    col_op: int,
+    col_mf: int,
+    slot_widths: List[List[int]],
+    prefix: str = '  ',
+    variant_col_names: Optional[List[str]] = None,
+    variant_widths: Optional[List[int]] = None,
+) -> str:
+    """Format the column header for the LUT key columns."""
+    hdr = f'{prefix}{"Layer type":<{col_op}}'
+    for s, widths in enumerate(slot_widths):
+        for fi, name in enumerate(_LUT_SLOT_NAMES):
+            suffix = f'_{s}' if s > 0 else ''
+            hdr += f'  {(name + suffix):<{widths[fi]}}'
+    hdr += f'  {"MF":<{col_mf}}'
+    if variant_col_names:
+        for vname, vw in zip(variant_col_names, variant_widths or []):
+            hdr += f'  {vname:<{vw}}'
+    return hdr
+
+
+def _print_lut_key_summary(
+    layers: List[Dict[str, Any]],
+    label: str,
+    *,
+    include_perf: bool,
+) -> None:
+    """Rollup: count (and optionally ms/LUT) per unique LUT key, columns exploded."""
+    by_key = _aggregate_by_lut_key(layers)
+    if not by_key:
+        print(f'\n(No lut_key data for {label} — profiler CSV, or polaris CSV from a build that emits lut_key columns, required)')
+        return
+
+    keys_sorted: List[Tuple[str, ...]] = sorted(
+        by_key.keys(),
+        key=lambda k: (-by_key[k][1] if include_perf else -by_key[k][0], str(k)),
+    )
+    max_slots = max((_lut_key_n_slots(k) for k in keys_sorted), default=0)
+    has_lut = include_perf and any(by_key[k][2] > 0 for k in keys_sorted)
+    variant_col_names = _lut_key_variant_col_names(keys_sorted)
+    col_op, col_mf, slot_widths, variant_widths = _lut_key_col_widths(keys_sorted, max_slots, variant_col_names)
+    col_c = 6
+    col_m = 12
+    col_l = 9
+
+    hdr_key = _lut_key_header(col_op, col_mf, slot_widths, variant_col_names=variant_col_names, variant_widths=variant_widths)
+    hdr = f'  {"Count":>{col_c}}{hdr_key[1:]}'
+    if include_perf:
+        hdr += f'  {"Sum ms":>{col_m}}'
+        if has_lut:
+            hdr += f'  {"LUT":>{col_l}}'
+    rule = '─' * max(len(hdr) - 2, 72)
+
+    print(f'\n{"=" * max(len(hdr), 72)}')
+    print(f'  Summary by LUT key ({label})')
+    print(f'{"=" * max(len(hdr), 72)}')
+    print(hdr)
+    print(f'  {rule}')
+
+    total_n = 0
+    total_ms = 0.0
+    total_lut = 0
+    for key in keys_sorted:
+        n, ms, lut = by_key[key]
+        total_n += n
+        total_ms += ms
+        total_lut += lut
+        line = f'  {n:>{col_c}}{_lut_key_row(key, col_op, col_mf, slot_widths, variant_col_names=variant_col_names, variant_widths=variant_widths)[1:]}'
+        if include_perf:
+            line += f'  {ms:>{col_m}.4f}'
+            if has_lut:
+                line += f'  {f"{lut}/{n}":>{col_l}}'
+        print(line)
+
+    print(f'  {rule}')
+    total_line = f'  {total_n:>{col_c}}  {"TOTAL":<{col_op}}'
+    for widths in slot_widths:
+        for w in widths:
+            total_line += f'  {"":>{w}}'
+    total_line += f'  {"":>{col_mf}}'
+    for vw in variant_widths:
+        total_line += f'  {"":>{vw}}'
+    if include_perf:
+        total_line += f'  {total_ms:>{col_m}.4f}'
+        if has_lut:
+            total_line += f'  {f"{total_lut}/{total_n}":>{col_l}}'
+    print(total_line)
+    print()
+
+
+def _print_lut_key_comparison(
+    layers1: List[Dict[str, Any]],
+    layers2: List[Dict[str, Any]],
+    *,
+    label1: str,
+    label2: str,
+    include_perf: bool,
+) -> None:
+    """Side-by-side LUT key comparison: count (and optionally ms/gap) per unique key."""
+    by1 = _aggregate_by_lut_key(layers1)
+    by2 = _aggregate_by_lut_key(layers2)
+
+    if not by1 and not by2:
+        print('\n(No lut_key data in either file — profiler CSV, or polaris CSV from a build that emits lut_key columns, required)')
+        return
+    if not by1:
+        print(f'\n(No lut_key data for {label1})')
+    if not by2:
+        print(f'\n(No lut_key data for {label2})')
+
+    all_keys: List[Tuple[str, ...]] = list(dict.fromkeys(list(by1.keys()) + list(by2.keys())))
+    if include_perf:
+        all_keys.sort(
+            key=lambda k: max(by1.get(k, (0, 0.0, 0))[1], by2.get(k, (0, 0.0, 0))[1]),
+            reverse=True,
+        )
+    else:
+        all_keys.sort(
+            key=lambda k: -(by1.get(k, (0, 0, 0))[0] + by2.get(k, (0, 0, 0))[0]),
+        )
+
+    max_slots = max((_lut_key_n_slots(k) for k in all_keys), default=0)
+    variant_col_names = _lut_key_variant_col_names(all_keys)
+    col_op, col_mf, slot_widths, variant_widths = _lut_key_col_widths(all_keys, max_slots, variant_col_names)
+    total_ms1 = sum(ms for _, ms, _ in by1.values())
+    total_ms2 = sum(ms for _, ms, _ in by2.values())
+    total_cnt1 = sum(cnt for cnt, _, _ in by1.values())
+    total_cnt2 = sum(cnt for cnt, _, _ in by2.values())
+    total_lut1 = sum(lut for _, _, lut in by1.values())
+    total_lut2 = sum(lut for _, _, lut in by2.values())
+    has_lut = (total_lut1 + total_lut2) > 0
+
+    lbl1 = label1[:10]
+    lbl2 = label2[:10]
+    col_cnt = 7
+    col_ms = max(13, len(f'{lbl1}(ms)'), len(f'{lbl2}(ms)'))
+
+    hdr_key = _lut_key_header(col_op, col_mf, slot_widths, variant_col_names=variant_col_names, variant_widths=variant_widths)
+    hdr = hdr_key
+    hdr += f'  {"#1":>{col_cnt}}'
+    if include_perf:
+        hdr += f'  {f"{lbl1}(ms)":>{col_ms}}'
+    hdr += f'  {"#2":>{col_cnt}}'
+    if include_perf:
+        hdr += f'  {f"{lbl2}(ms)":>{col_ms}}  {"AbsGap(ms)":>12}  {"Gap%":>9}'
+    rule = '─' * max(len(hdr) - 2, 82)
+
+    title_w = max(len(hdr), 82)
+    print(f'\n{"=" * title_w}')
+    print(f'  LUT key comparison: {label1} vs {label2}')
+    print(f'{"=" * title_w}')
+
+    if include_perf:
+        print('\n  Network total:')
+        print(f'    {label1}:  {total_ms1:.4f} ms')
+        print(f'    {label2}:  {total_ms2:.4f} ms')
+        print(f'    Gap:  {_pct_gap(total_ms1, total_ms2)} (w.r.t. {label1})')
+        if has_lut:
+            print(f'    {label1} LUT hits: {total_lut1}/{total_cnt1}')
+            print(f'    {label2} LUT hits: {total_lut2}/{total_cnt2}')
+        print()
+
+    print(hdr)
+    print(f'  {rule}')
+
+    for key in all_keys:
+        cnt1, ms1, lut1 = by1.get(key, (0, 0.0, 0))
+        cnt2, ms2, lut2 = by2.get(key, (0, 0.0, 0))
+        line = _lut_key_row(key, col_op, col_mf, slot_widths, variant_col_names=variant_col_names, variant_widths=variant_widths)
+        cnt1_s = str(cnt1) if cnt1 else '—'
+        cnt2_s = str(cnt2) if cnt2 else '—'
+        line += f'  {cnt1_s:>{col_cnt}}'
+        if include_perf:
+            ms1_s = f'{ms1:.4f}' if cnt1 else '—'
+            line += f'  {ms1_s:>{col_ms}}'
+        line += f'  {cnt2_s:>{col_cnt}}'
+        if include_perf:
+            ms2_s = f'{ms2:.4f}' if cnt2 else '—'
+            abs_gap_s = f'{ms2 - ms1:+.4f}' if (cnt1 and cnt2) else '—'
+            line += f'  {ms2_s:>{col_ms}}  {abs_gap_s:>12}  {_pct_gap(ms1, ms2):>9}'
+        print(line)
+
+    print(f'  {rule}')
+    total_line = f'  {"TOTAL":<{col_op}}'
+    for widths in slot_widths:
+        for w in widths:
+            total_line += f'  {"":>{w}}'
+    total_line += f'  {"":>{col_mf}}'
+    for vw in variant_widths:
+        total_line += f'  {"":>{vw}}'
+    total_line += f'  {total_cnt1:>{col_cnt}}'
+    if include_perf:
+        total_line += f'  {total_ms1:>{col_ms}.4f}'
+    total_line += f'  {total_cnt2:>{col_cnt}}'
+    if include_perf:
+        abs_total = total_ms2 - total_ms1
+        total_line += f'  {total_ms2:>{col_ms}.4f}  {abs_total:>+12.4f}  {_pct_gap(total_ms1, total_ms2):>9}'
+    print(total_line)
     print()
 
 
@@ -921,26 +1307,27 @@ def _print_perf_comparison(
 def _write_xlsx_report(
     path: str,
     *,
-    polaris_layers: Optional[List[Dict[str, Any]]],
-    profiler_layers: Optional[List[Dict[str, Any]]],
+    layers1: Optional[List[Dict[str, Any]]],
+    layers2: Optional[List[Dict[str, Any]]],
     stats: Optional[ComparisonStats],
-    polaris_label: str,
-    profiler_label: str,
-    polaris_source: Optional[str],
-    profiler_source: Optional[str],
+    label1: str,
+    label2: str,
+    source1: Optional[str],
+    source2: Optional[str],
     strip_leading_ones: bool,
     strip_singleton_dims: bool,
 ) -> None:
-    """Write a 3-sheet XLSX comparison report.
+    """Write a 4-sheet XLSX comparison report.
 
     Sheets:
       1. "Summary"          — model-wide totals, comparison, shape/attr stats.
       2. "By Layer Type"    — per canonical optype rollup with comparison.
       3. "By Layer Signature" — per (optype + normalized shape signature).
+      4. "By LUT Key"       — per full LUT key tuple with columns exploded.
 
-    In two-file mode (both ``polaris_layers`` and ``profiler_layers`` provided)
-    each sheet includes Profiler vs Polaris columns and the absolute / percent
-    gap.  In single-file mode only the side that was loaded is emitted.
+    In two-file mode (both ``layers1`` and ``layers2`` provided) each sheet
+    includes File2 vs File1 columns and the absolute / percent gap.
+    In single-file mode only the side that was loaded is emitted.
     """
     try:
         from openpyxl import Workbook
@@ -952,9 +1339,9 @@ def _write_xlsx_report(
             "`pip install openpyxl` (already present in the polarisdev env)."
         ) from e
 
-    have_polaris = polaris_layers is not None
-    have_profiler = profiler_layers is not None
-    two_sided = have_polaris and have_profiler
+    have1 = layers1 is not None
+    have2 = layers2 is not None
+    two_sided = have1 and have2
 
     header_font = Font(bold=True)
     header_fill = PatternFill("solid", fgColor="DDEBF7")
@@ -1006,10 +1393,10 @@ def _write_xlsx_report(
 
     ws1.cell(row=1, column=1, value="Compare Layers — XLSX Report").font = Font(bold=True, size=13)
     r = 2
-    if profiler_source:
-        ws1.cell(row=r, column=1, value="Profiler CSV"); ws1.cell(row=r, column=2, value=profiler_source); r += 1
-    if polaris_source:
-        ws1.cell(row=r, column=1, value="Polaris CSV"); ws1.cell(row=r, column=2, value=polaris_source); r += 1
+    if source2:
+        ws1.cell(row=r, column=1, value=f"{label2} CSV"); ws1.cell(row=r, column=2, value=source2); r += 1
+    if source1:
+        ws1.cell(row=r, column=1, value=f"{label1} CSV"); ws1.cell(row=r, column=2, value=source1); r += 1
     ws1.cell(row=r, column=1, value="strip_leading_ones"); ws1.cell(row=r, column=2, value=bool(strip_leading_ones)); r += 1
     ws1.cell(row=r, column=1, value="strip_singleton_dims"); ws1.cell(row=r, column=2, value=bool(strip_singleton_dims)); r += 1
     r += 1
@@ -1017,11 +1404,11 @@ def _write_xlsx_report(
     # Network totals
     ws1.cell(row=r, column=1, value="Network totals").font = Font(bold=True); r += 1
     if two_sided:
-        headers = ["Metric", profiler_label, polaris_label, "Abs Gap", "Gap %"]
-    elif have_profiler:
-        headers = ["Metric", profiler_label]
+        headers = ["Metric", label1, label2, "Abs Gap", "Gap %"]
+    elif have2:
+        headers = ["Metric", label2]
     else:
-        headers = ["Metric", polaris_label]
+        headers = ["Metric", label1]
     for c, h in enumerate(headers, start=1):
         ws1.cell(row=r, column=c, value=h)
     _style_header(ws1, r, len(headers))
@@ -1033,22 +1420,25 @@ def _write_xlsx_report(
         lut = sum(1 for l in layers if l.get("uses_perf_lookup"))
         return cnt, ms, lut
 
-    prof_cnt = prof_ms = prof_lut = 0
-    pol_cnt = pol_ms = pol_lut = 0
-    if have_profiler:
-        prof_cnt, prof_ms, prof_lut = _layer_totals(profiler_layers)  # type: ignore[assignment,arg-type]
-    if have_polaris:
-        pol_cnt, pol_ms, pol_lut = _layer_totals(polaris_layers)  # type: ignore[assignment,arg-type]
+    cnt2 = ms2 = lut2 = 0
+    cnt1 = ms1 = lut1 = 0
+    if have2:
+        cnt2, ms2, lut2 = _layer_totals(layers2)  # type: ignore[assignment,arg-type]
+    if have1:
+        cnt1, ms1, lut1 = _layer_totals(layers1)  # type: ignore[assignment,arg-type]
 
-    def _write_metric(metric: str, prof_v, pol_v, *, fmt_ms: bool = False, percent: bool = False) -> None:
+    def _write_metric(metric: str, v2, v1, *, fmt_ms: bool = False, percent: bool = False) -> None:
         nonlocal r
+        # Column order matches the docstring convention: gap = (file2 − file1) / file1.
+        # Header is [Metric, label1, label2, "Abs Gap", "Gap %"] so column 2 holds
+        # label1's value (v1) and column 3 holds label2's value (v2).
         ws1.cell(row=r, column=1, value=metric)
         if two_sided:
-            ws1.cell(row=r, column=2, value=prof_v)
-            ws1.cell(row=r, column=3, value=pol_v)
-            if isinstance(prof_v, (int, float)) and isinstance(pol_v, (int, float)):
-                ws1.cell(row=r, column=4, value=pol_v - prof_v)
-                p = _pct(float(prof_v), float(pol_v))
+            ws1.cell(row=r, column=2, value=v1)
+            ws1.cell(row=r, column=3, value=v2)
+            if isinstance(v2, (int, float)) and isinstance(v1, (int, float)):
+                ws1.cell(row=r, column=4, value=v2 - v1)
+                p = _pct(float(v1), float(v2))
                 ws1.cell(row=r, column=5, value=(p if p is not None else "N/A"))
                 if fmt_ms:
                     ws1.cell(row=r, column=2).number_format = "0.0000"
@@ -1056,36 +1446,36 @@ def _write_xlsx_report(
                     ws1.cell(row=r, column=4).number_format = "+0.0000;-0.0000"
                 if p is not None:
                     ws1.cell(row=r, column=5).number_format = "+0.00\"%\";-0.00\"%\""
-        elif have_profiler:
-            ws1.cell(row=r, column=2, value=prof_v)
-            if fmt_ms and isinstance(prof_v, (int, float)):
+        elif have2:
+            ws1.cell(row=r, column=2, value=v2)
+            if fmt_ms and isinstance(v2, (int, float)):
                 ws1.cell(row=r, column=2).number_format = "0.0000"
         else:
-            ws1.cell(row=r, column=2, value=pol_v)
-            if fmt_ms and isinstance(pol_v, (int, float)):
+            ws1.cell(row=r, column=2, value=v1)
+            if fmt_ms and isinstance(v1, (int, float)):
                 ws1.cell(row=r, column=2).number_format = "0.0000"
         r += 1
 
-    _write_metric("Total layers", prof_cnt, pol_cnt)
-    _write_metric("Total duration (ms)", prof_ms, pol_ms, fmt_ms=True)
-    if have_polaris:
-        # Polaris-only metric — display only on Polaris column when single-sided.
-        pol_miss = pol_cnt - pol_lut
+    _write_metric("Total layers", cnt2, cnt1)
+    _write_metric("Total duration (ms)", ms2, ms1, fmt_ms=True)
+    if have1:
+        # layers1-only metric — display only on layers1 column when single-sided.
+        miss1 = cnt1 - lut1
         if two_sided:
-            ws1.cell(row=r, column=1, value="Polaris LUT hits (count / total)")
+            ws1.cell(row=r, column=1, value=f"{label1} LUT hits (count / total)")
             ws1.cell(row=r, column=2, value="—")
-            ws1.cell(row=r, column=3, value=f"{pol_lut} / {pol_cnt}")
+            ws1.cell(row=r, column=3, value=f"{lut1} / {cnt1}")
             r += 1
-            ws1.cell(row=r, column=1, value="Polaris LUT misses (count / total)")
+            ws1.cell(row=r, column=1, value=f"{label1} LUT misses (count / total)")
             ws1.cell(row=r, column=2, value="—")
-            ws1.cell(row=r, column=3, value=f"{pol_miss} / {pol_cnt}")
+            ws1.cell(row=r, column=3, value=f"{miss1} / {cnt1}")
             r += 1
         else:
-            ws1.cell(row=r, column=1, value="Polaris LUT hits (count / total)")
-            ws1.cell(row=r, column=2, value=f"{pol_lut} / {pol_cnt}")
+            ws1.cell(row=r, column=1, value=f"{label1} LUT hits (count / total)")
+            ws1.cell(row=r, column=2, value=f"{lut1} / {cnt1}")
             r += 1
-            ws1.cell(row=r, column=1, value="Polaris LUT misses (count / total)")
-            ws1.cell(row=r, column=2, value=f"{pol_miss} / {pol_cnt}")
+            ws1.cell(row=r, column=1, value=f"{label1} LUT misses (count / total)")
+            ws1.cell(row=r, column=2, value=f"{miss1} / {cnt1}")
             r += 1
 
     # Shape/attr stats (two-file only)
@@ -1102,8 +1492,9 @@ def _write_xlsx_report(
             ("  input shape mismatches", stats.input_shape_mismatches),
             ("  output shape mismatches", stats.output_shape_mismatches),
             ("Attribute mismatches", stats.attr_mismatches),
-            ("Unmatched (Polaris)", stats.unmatched_polaris),
-            ("Unmatched (Profiler)", stats.unmatched_profiler),
+            ("LUT key mismatches", stats.lut_key_mismatches),
+            (f"Unmatched ({label1})", stats.unmatched_polaris),
+            (f"Unmatched ({label2})", stats.unmatched_profiler),
             ("Ambiguous", stats.ambiguous),
         ]:
             ws1.cell(row=r, column=1, value=label)
@@ -1114,218 +1505,343 @@ def _write_xlsx_report(
 
     # ---------- Sheet 2: By Layer Type ----------
     ws2 = wb.create_sheet("By Layer Type")
-    prof_by_op: Dict[str, Tuple[int, float, int]] = (
-        _aggregate_duration_by_optype(profiler_layers) if have_profiler else {}  # type: ignore[arg-type]
+    by_op2: Dict[str, Tuple[int, float, int]] = (
+        _aggregate_duration_by_optype(layers2) if have2 else {}  # type: ignore[arg-type]
     )
-    pol_by_op: Dict[str, Tuple[int, float, int]] = (
-        _aggregate_duration_by_optype(polaris_layers) if have_polaris else {}  # type: ignore[arg-type]
+    by_op1: Dict[str, Tuple[int, float, int]] = (
+        _aggregate_duration_by_optype(layers1) if have1 else {}  # type: ignore[arg-type]
     )
-    keys_op = list(dict.fromkeys(list(prof_by_op.keys()) + list(pol_by_op.keys())))
+    keys_op = list(dict.fromkeys(list(by_op2.keys()) + list(by_op1.keys())))
     keys_op.sort(
-        key=lambda k: max(prof_by_op.get(k, (0, 0.0, 0))[1], pol_by_op.get(k, (0, 0.0, 0))[1]),
+        key=lambda k: max(by_op2.get(k, (0, 0.0, 0))[1], by_op1.get(k, (0, 0.0, 0))[1]),
         reverse=True,
     )
     if two_sided:
+        # Column order: label1 first, label2 second (matches docstring "gap = (file2 − file1) / file1").
         op_headers = [
             "Layer Type",
-            f"# {profiler_label}", f"{profiler_label} ms",
-            f"# {polaris_label}", f"{polaris_label} ms",
-            "Polaris LUT hit", "Polaris LUT miss", "Polaris LUT total",
-            "Only in Polaris", "Only in Hardware",
+            f"# {label1}", f"{label1} ms",
+            f"# {label2}", f"{label2} ms",
+            f"{label1} LUT hit", f"{label1} LUT miss", f"{label1} LUT total",
+            f"Only in {label1}", f"Only in {label2}",
             "Abs Gap (ms)", "Gap %",
         ]
-    elif have_profiler:
-        op_headers = ["Layer Type", f"# {profiler_label}", f"{profiler_label} ms"]
+    elif have2:
+        op_headers = ["Layer Type", f"# {label2}", f"{label2} ms"]
     else:
         op_headers = [
-            "Layer Type", f"# {polaris_label}", f"{polaris_label} ms",
-            "Polaris LUT hit", "Polaris LUT miss", "Polaris LUT total",
+            "Layer Type", f"# {label1}", f"{label1} ms",
+            f"{label1} LUT hit", f"{label1} LUT miss", f"{label1} LUT total",
         ]
     for c, h in enumerate(op_headers, start=1):
         ws2.cell(row=1, column=c, value=h)
     _style_header(ws2, 1, len(op_headers))
 
     rr = 2
-    only_pol_op_total = 0
-    only_hw_op_total = 0
+    only1_op_total = 0
+    only2_op_total = 0
     for k in keys_op:
-        p_cnt, p_ms, _ = prof_by_op.get(k, (0, 0.0, 0))
-        s_cnt, s_ms, s_lut = pol_by_op.get(k, (0, 0.0, 0))
-        s_miss = s_cnt - s_lut
-        only_pol = max(0, s_cnt - p_cnt)
-        only_hw = max(0, p_cnt - s_cnt)
-        only_pol_op_total += only_pol
-        only_hw_op_total += only_hw
+        cnt2_row, ms2_row, _ = by_op2.get(k, (0, 0.0, 0))
+        cnt1_row, ms1_row, lut1_row = by_op1.get(k, (0, 0.0, 0))
+        miss1_row = cnt1_row - lut1_row
+        only1 = max(0, cnt1_row - cnt2_row)
+        only2 = max(0, cnt2_row - cnt1_row)
+        only1_op_total += only1
+        only2_op_total += only2
         if two_sided:
             ws2.cell(row=rr, column=1, value=k)
-            ws2.cell(row=rr, column=2, value=p_cnt)
-            ws2.cell(row=rr, column=3, value=p_ms).number_format = "0.0000"
-            ws2.cell(row=rr, column=4, value=s_cnt)
-            ws2.cell(row=rr, column=5, value=s_ms).number_format = "0.0000"
-            ws2.cell(row=rr, column=6, value=s_lut)
-            ws2.cell(row=rr, column=7, value=s_miss)
-            ws2.cell(row=rr, column=8, value=s_cnt)
-            ws2.cell(row=rr, column=9, value=only_pol)
-            ws2.cell(row=rr, column=10, value=only_hw)
-            ws2.cell(row=rr, column=11, value=(s_ms - p_ms)).number_format = "+0.0000;-0.0000"
-            p = _pct(p_ms, s_ms)
+            ws2.cell(row=rr, column=2, value=cnt1_row)
+            ws2.cell(row=rr, column=3, value=ms1_row).number_format = "0.0000"
+            ws2.cell(row=rr, column=4, value=cnt2_row)
+            ws2.cell(row=rr, column=5, value=ms2_row).number_format = "0.0000"
+            ws2.cell(row=rr, column=6, value=lut1_row)
+            ws2.cell(row=rr, column=7, value=miss1_row)
+            ws2.cell(row=rr, column=8, value=cnt1_row)
+            ws2.cell(row=rr, column=9, value=only1)
+            ws2.cell(row=rr, column=10, value=only2)
+            ws2.cell(row=rr, column=11, value=(ms2_row - ms1_row)).number_format = "+0.0000;-0.0000"
+            p = _pct(ms1_row, ms2_row)
             cell = ws2.cell(row=rr, column=12, value=(p if p is not None else "N/A"))
             if p is not None:
                 cell.number_format = "+0.00\"%\";-0.00\"%\""
-        elif have_profiler:
+        elif have2:
             ws2.cell(row=rr, column=1, value=k)
-            ws2.cell(row=rr, column=2, value=p_cnt)
-            ws2.cell(row=rr, column=3, value=p_ms).number_format = "0.0000"
+            ws2.cell(row=rr, column=2, value=cnt2_row)
+            ws2.cell(row=rr, column=3, value=ms2_row).number_format = "0.0000"
         else:
             ws2.cell(row=rr, column=1, value=k)
-            ws2.cell(row=rr, column=2, value=s_cnt)
-            ws2.cell(row=rr, column=3, value=s_ms).number_format = "0.0000"
-            ws2.cell(row=rr, column=4, value=s_lut)
-            ws2.cell(row=rr, column=5, value=s_miss)
-            ws2.cell(row=rr, column=6, value=s_cnt)
+            ws2.cell(row=rr, column=2, value=cnt1_row)
+            ws2.cell(row=rr, column=3, value=ms1_row).number_format = "0.0000"
+            ws2.cell(row=rr, column=4, value=lut1_row)
+            ws2.cell(row=rr, column=5, value=miss1_row)
+            ws2.cell(row=rr, column=6, value=cnt1_row)
         rr += 1
 
     # TOTAL row
-    pol_miss_total = pol_cnt - pol_lut
+    miss1_total = cnt1 - lut1
     ws2.cell(row=rr, column=1, value="TOTAL")
     if two_sided:
-        ws2.cell(row=rr, column=2, value=prof_cnt)
-        ws2.cell(row=rr, column=3, value=prof_ms).number_format = "0.0000"
-        ws2.cell(row=rr, column=4, value=pol_cnt)
-        ws2.cell(row=rr, column=5, value=pol_ms).number_format = "0.0000"
-        ws2.cell(row=rr, column=6, value=pol_lut)
-        ws2.cell(row=rr, column=7, value=pol_miss_total)
-        ws2.cell(row=rr, column=8, value=pol_cnt)
-        ws2.cell(row=rr, column=9, value=only_pol_op_total)
-        ws2.cell(row=rr, column=10, value=only_hw_op_total)
-        ws2.cell(row=rr, column=11, value=(pol_ms - prof_ms)).number_format = "+0.0000;-0.0000"
-        p = _pct(prof_ms, pol_ms)
+        ws2.cell(row=rr, column=2, value=cnt1)
+        ws2.cell(row=rr, column=3, value=ms1).number_format = "0.0000"
+        ws2.cell(row=rr, column=4, value=cnt2)
+        ws2.cell(row=rr, column=5, value=ms2).number_format = "0.0000"
+        ws2.cell(row=rr, column=6, value=lut1)
+        ws2.cell(row=rr, column=7, value=miss1_total)
+        ws2.cell(row=rr, column=8, value=cnt1)
+        ws2.cell(row=rr, column=9, value=only1_op_total)
+        ws2.cell(row=rr, column=10, value=only2_op_total)
+        ws2.cell(row=rr, column=11, value=(ms2 - ms1)).number_format = "+0.0000;-0.0000"
+        p = _pct(ms1, ms2)
         cell = ws2.cell(row=rr, column=12, value=(p if p is not None else "N/A"))
         if p is not None:
             cell.number_format = "+0.00\"%\";-0.00\"%\""
-    elif have_profiler:
-        ws2.cell(row=rr, column=2, value=prof_cnt)
-        ws2.cell(row=rr, column=3, value=prof_ms).number_format = "0.0000"
+    elif have2:
+        ws2.cell(row=rr, column=2, value=cnt2)
+        ws2.cell(row=rr, column=3, value=ms2).number_format = "0.0000"
     else:
-        ws2.cell(row=rr, column=2, value=pol_cnt)
-        ws2.cell(row=rr, column=3, value=pol_ms).number_format = "0.0000"
-        ws2.cell(row=rr, column=4, value=pol_lut)
-        ws2.cell(row=rr, column=5, value=pol_miss_total)
-        ws2.cell(row=rr, column=6, value=pol_cnt)
+        ws2.cell(row=rr, column=2, value=cnt1)
+        ws2.cell(row=rr, column=3, value=ms1).number_format = "0.0000"
+        ws2.cell(row=rr, column=4, value=lut1)
+        ws2.cell(row=rr, column=5, value=miss1_total)
+        ws2.cell(row=rr, column=6, value=cnt1)
     _style_total(ws2, rr, len(op_headers))
     ws2.freeze_panes = "A2"
     _autosize(ws2, len(op_headers))
 
     # ---------- Sheet 3: By Layer Signature ----------
     ws3 = wb.create_sheet("By Layer Signature")
-    prof_by_sig: Dict[Tuple[str, str], Tuple[int, float, int]] = (
+    by_sig2: Dict[Tuple[str, str], Tuple[int, float, int]] = (
         _aggregate_duration_by_optype_signature(
-            profiler_layers, strip_leading_ones, strip_singleton_dims  # type: ignore[arg-type]
-        ) if have_profiler else {}
+            layers2, strip_leading_ones, strip_singleton_dims  # type: ignore[arg-type]
+        ) if have2 else {}
     )
-    pol_by_sig: Dict[Tuple[str, str], Tuple[int, float, int]] = (
+    by_sig1: Dict[Tuple[str, str], Tuple[int, float, int]] = (
         _aggregate_duration_by_optype_signature(
-            polaris_layers, strip_leading_ones, strip_singleton_dims  # type: ignore[arg-type]
-        ) if have_polaris else {}
+            layers1, strip_leading_ones, strip_singleton_dims  # type: ignore[arg-type]
+        ) if have1 else {}
     )
-    keys_sig = list(dict.fromkeys(list(prof_by_sig.keys()) + list(pol_by_sig.keys())))
+    keys_sig = list(dict.fromkeys(list(by_sig2.keys()) + list(by_sig1.keys())))
     keys_sig.sort(
         key=lambda k: max(
-            prof_by_sig.get(k, (0, 0.0, 0))[1], pol_by_sig.get(k, (0, 0.0, 0))[1]
+            by_sig2.get(k, (0, 0.0, 0))[1], by_sig1.get(k, (0, 0.0, 0))[1]
         ),
         reverse=True,
     )
     if two_sided:
+        # Column order: label1 first, label2 second (matches docstring "gap = (file2 − file1) / file1").
         sig_headers = [
             "Layer Type", "Signature",
-            f"# {profiler_label}", f"{profiler_label} ms",
-            f"# {polaris_label}", f"{polaris_label} ms",
-            "Polaris LUT hit", "Polaris LUT miss", "Polaris LUT total",
-            "Only in Polaris", "Only in Hardware",
+            f"# {label1}", f"{label1} ms",
+            f"# {label2}", f"{label2} ms",
+            f"{label1} LUT hit", f"{label1} LUT miss", f"{label1} LUT total",
+            f"Only in {label1}", f"Only in {label2}",
             "Abs Gap (ms)", "Gap %",
         ]
-    elif have_profiler:
-        sig_headers = ["Layer Type", "Signature", f"# {profiler_label}", f"{profiler_label} ms"]
+    elif have2:
+        sig_headers = ["Layer Type", "Signature", f"# {label2}", f"{label2} ms"]
     else:
         sig_headers = [
             "Layer Type", "Signature",
-            f"# {polaris_label}", f"{polaris_label} ms",
-            "Polaris LUT hit", "Polaris LUT miss", "Polaris LUT total",
+            f"# {label1}", f"{label1} ms",
+            f"{label1} LUT hit", f"{label1} LUT miss", f"{label1} LUT total",
         ]
     for c, h in enumerate(sig_headers, start=1):
         ws3.cell(row=1, column=c, value=h)
     _style_header(ws3, 1, len(sig_headers))
 
     rr = 2
-    only_pol_sig_total = 0
-    only_hw_sig_total = 0
+    only1_sig_total = 0
+    only2_sig_total = 0
     for sig_key in keys_sig:
         op, sig = sig_key
-        p_cnt, p_ms, _ = prof_by_sig.get(sig_key, (0, 0.0, 0))
-        s_cnt, s_ms, s_lut = pol_by_sig.get(sig_key, (0, 0.0, 0))
-        s_miss = s_cnt - s_lut
-        only_pol = max(0, s_cnt - p_cnt)
-        only_hw = max(0, p_cnt - s_cnt)
-        only_pol_sig_total += only_pol
-        only_hw_sig_total += only_hw
+        cnt2_row, ms2_row, _ = by_sig2.get(sig_key, (0, 0.0, 0))
+        cnt1_row, ms1_row, lut1_row = by_sig1.get(sig_key, (0, 0.0, 0))
+        miss1_row = cnt1_row - lut1_row
+        only1 = max(0, cnt1_row - cnt2_row)
+        only2 = max(0, cnt2_row - cnt1_row)
+        only1_sig_total += only1
+        only2_sig_total += only2
         ws3.cell(row=rr, column=1, value=op)
         ws3.cell(row=rr, column=2, value=sig).alignment = left
         if two_sided:
-            ws3.cell(row=rr, column=3, value=p_cnt)
-            ws3.cell(row=rr, column=4, value=p_ms).number_format = "0.0000"
-            ws3.cell(row=rr, column=5, value=s_cnt)
-            ws3.cell(row=rr, column=6, value=s_ms).number_format = "0.0000"
-            ws3.cell(row=rr, column=7, value=s_lut)
-            ws3.cell(row=rr, column=8, value=s_miss)
-            ws3.cell(row=rr, column=9, value=s_cnt)
-            ws3.cell(row=rr, column=10, value=only_pol)
-            ws3.cell(row=rr, column=11, value=only_hw)
-            ws3.cell(row=rr, column=12, value=(s_ms - p_ms)).number_format = "+0.0000;-0.0000"
-            p = _pct(p_ms, s_ms)
+            ws3.cell(row=rr, column=3, value=cnt1_row)
+            ws3.cell(row=rr, column=4, value=ms1_row).number_format = "0.0000"
+            ws3.cell(row=rr, column=5, value=cnt2_row)
+            ws3.cell(row=rr, column=6, value=ms2_row).number_format = "0.0000"
+            ws3.cell(row=rr, column=7, value=lut1_row)
+            ws3.cell(row=rr, column=8, value=miss1_row)
+            ws3.cell(row=rr, column=9, value=cnt1_row)
+            ws3.cell(row=rr, column=10, value=only1)
+            ws3.cell(row=rr, column=11, value=only2)
+            ws3.cell(row=rr, column=12, value=(ms2_row - ms1_row)).number_format = "+0.0000;-0.0000"
+            p = _pct(ms1_row, ms2_row)
             cell = ws3.cell(row=rr, column=13, value=(p if p is not None else "N/A"))
             if p is not None:
                 cell.number_format = "+0.00\"%\";-0.00\"%\""
-        elif have_profiler:
-            ws3.cell(row=rr, column=3, value=p_cnt)
-            ws3.cell(row=rr, column=4, value=p_ms).number_format = "0.0000"
+        elif have2:
+            ws3.cell(row=rr, column=3, value=cnt2_row)
+            ws3.cell(row=rr, column=4, value=ms2_row).number_format = "0.0000"
         else:
-            ws3.cell(row=rr, column=3, value=s_cnt)
-            ws3.cell(row=rr, column=4, value=s_ms).number_format = "0.0000"
-            ws3.cell(row=rr, column=5, value=s_lut)
-            ws3.cell(row=rr, column=6, value=s_miss)
-            ws3.cell(row=rr, column=7, value=s_cnt)
+            ws3.cell(row=rr, column=3, value=cnt1_row)
+            ws3.cell(row=rr, column=4, value=ms1_row).number_format = "0.0000"
+            ws3.cell(row=rr, column=5, value=lut1_row)
+            ws3.cell(row=rr, column=6, value=miss1_row)
+            ws3.cell(row=rr, column=7, value=cnt1_row)
         rr += 1
 
-    pol_miss_total = pol_cnt - pol_lut
+    miss1_total = cnt1 - lut1
     ws3.cell(row=rr, column=1, value="TOTAL")
     ws3.cell(row=rr, column=2, value="")
     if two_sided:
-        ws3.cell(row=rr, column=3, value=prof_cnt)
-        ws3.cell(row=rr, column=4, value=prof_ms).number_format = "0.0000"
-        ws3.cell(row=rr, column=5, value=pol_cnt)
-        ws3.cell(row=rr, column=6, value=pol_ms).number_format = "0.0000"
-        ws3.cell(row=rr, column=7, value=pol_lut)
-        ws3.cell(row=rr, column=8, value=pol_miss_total)
-        ws3.cell(row=rr, column=9, value=pol_cnt)
-        ws3.cell(row=rr, column=10, value=only_pol_sig_total)
-        ws3.cell(row=rr, column=11, value=only_hw_sig_total)
-        ws3.cell(row=rr, column=12, value=(pol_ms - prof_ms)).number_format = "+0.0000;-0.0000"
-        p = _pct(prof_ms, pol_ms)
+        ws3.cell(row=rr, column=3, value=cnt1)
+        ws3.cell(row=rr, column=4, value=ms1).number_format = "0.0000"
+        ws3.cell(row=rr, column=5, value=cnt2)
+        ws3.cell(row=rr, column=6, value=ms2).number_format = "0.0000"
+        ws3.cell(row=rr, column=7, value=lut1)
+        ws3.cell(row=rr, column=8, value=miss1_total)
+        ws3.cell(row=rr, column=9, value=cnt1)
+        ws3.cell(row=rr, column=10, value=only1_sig_total)
+        ws3.cell(row=rr, column=11, value=only2_sig_total)
+        ws3.cell(row=rr, column=12, value=(ms2 - ms1)).number_format = "+0.0000;-0.0000"
+        p = _pct(ms1, ms2)
         cell = ws3.cell(row=rr, column=13, value=(p if p is not None else "N/A"))
         if p is not None:
             cell.number_format = "+0.00\"%\";-0.00\"%\""
-    elif have_profiler:
-        ws3.cell(row=rr, column=3, value=prof_cnt)
-        ws3.cell(row=rr, column=4, value=prof_ms).number_format = "0.0000"
+    elif have2:
+        ws3.cell(row=rr, column=3, value=cnt2)
+        ws3.cell(row=rr, column=4, value=ms2).number_format = "0.0000"
     else:
-        ws3.cell(row=rr, column=3, value=pol_cnt)
-        ws3.cell(row=rr, column=4, value=pol_ms).number_format = "0.0000"
-        ws3.cell(row=rr, column=5, value=pol_lut)
-        ws3.cell(row=rr, column=6, value=pol_miss_total)
-        ws3.cell(row=rr, column=7, value=pol_cnt)
+        ws3.cell(row=rr, column=3, value=cnt1)
+        ws3.cell(row=rr, column=4, value=ms1).number_format = "0.0000"
+        ws3.cell(row=rr, column=5, value=lut1)
+        ws3.cell(row=rr, column=6, value=miss1_total)
+        ws3.cell(row=rr, column=7, value=cnt1)
     _style_total(ws3, rr, len(sig_headers))
     ws3.freeze_panes = "C2"
     _autosize(ws3, len(sig_headers))
+
+    # ---------- Sheet 4: By LUT Key ----------
+    ws4 = wb.create_sheet("By LUT Key")
+    by_lk1: Dict[Tuple[str, ...], Tuple[int, float, int]] = (
+        _aggregate_by_lut_key(layers1) if have1 else {}  # type: ignore[arg-type]
+    )
+    by_lk2: Dict[Tuple[str, ...], Tuple[int, float, int]] = (
+        _aggregate_by_lut_key(layers2) if have2 else {}  # type: ignore[arg-type]
+    )
+    all_lk: List[Tuple[str, ...]] = list(dict.fromkeys(list(by_lk2.keys()) + list(by_lk1.keys())))
+    all_lk.sort(
+        key=lambda k: max(by_lk2.get(k, (0, 0.0, 0))[1], by_lk1.get(k, (0, 0.0, 0))[1]),
+        reverse=True,
+    )
+
+    if not all_lk:
+        ws4.cell(row=1, column=1, value="(No lut_key data in either file — polaris CSV with lut_key columns required)")
+    else:
+        max_slots_lk = max((_lut_key_n_slots(k) for k in all_lk), default=0)
+        variant_col_names_lk = _lut_key_variant_col_names(all_lk)
+        mf_col = 2 + max_slots_lk * len(_LUT_SLOT_NAMES)  # op_type + slots + mf
+        n_key_cols = mf_col + len(variant_col_names_lk)
+
+        lk_headers: List[str] = ['op_type']
+        for s in range(max_slots_lk):
+            for fi, fname in enumerate(_LUT_SLOT_NAMES):
+                lk_headers.append(fname + (f'_{s}' if s > 0 else ''))
+        lk_headers.append('mf')
+        lk_headers.extend(variant_col_names_lk)
+        if two_sided:
+            lk_headers += [
+                f'# {label1}', f'{label1} ms',
+                f'# {label2}', f'{label2} ms',
+                f'{label1} LUT hit', f'{label1} LUT miss', f'{label1} LUT total',
+                'Abs Gap (ms)', 'Gap %',
+            ]
+        elif have1:
+            lk_headers += [
+                f'# {label1}', f'{label1} ms',
+                f'{label1} LUT hit', f'{label1} LUT miss', f'{label1} LUT total',
+            ]
+        else:
+            lk_headers += [f'# {label2}', f'{label2} ms']
+
+        for c, h in enumerate(lk_headers, start=1):
+            ws4.cell(row=1, column=c, value=h)
+        _style_header(ws4, 1, len(lk_headers))
+
+        rr = 2
+        lk_cnt1_total = lk_ms1_total = lk_cnt2_total = lk_ms2_total = 0.0
+        lk_lut1_total = 0
+        for lk in all_lk:
+            ws4.cell(row=rr, column=1, value=lk[0])
+            for s in range(max_slots_lk):
+                for fi in range(len(_LUT_SLOT_NAMES)):
+                    ws4.cell(row=rr, column=2 + s * len(_LUT_SLOT_NAMES) + fi,
+                             value=_lut_key_slot_field(lk, s, fi))
+            ws4.cell(row=rr, column=mf_col, value=lk[8] if len(lk) > 8 else '')
+            lk_tail = dict(_lut_key_variant_tail(lk))
+            for vi, vname in enumerate(variant_col_names_lk):
+                ws4.cell(row=rr, column=mf_col + 1 + vi, value=lk_tail.get(vname, ''))
+
+            cnt2_row, ms2_row, _ = by_lk2.get(lk, (0, 0.0, 0))
+            cnt1_row, ms1_row, lut1_row = by_lk1.get(lk, (0, 0.0, 0))
+            miss1_row = cnt1_row - lut1_row
+            lk_cnt1_total += cnt1_row; lk_ms1_total += ms1_row
+            lk_cnt2_total += cnt2_row; lk_ms2_total += ms2_row
+            lk_lut1_total += lut1_row
+
+            col = n_key_cols + 1
+            if two_sided:
+                ws4.cell(row=rr, column=col, value=cnt1_row); col += 1
+                ws4.cell(row=rr, column=col, value=ms1_row).number_format = "0.0000"; col += 1
+                ws4.cell(row=rr, column=col, value=cnt2_row); col += 1
+                ws4.cell(row=rr, column=col, value=ms2_row).number_format = "0.0000"; col += 1
+                ws4.cell(row=rr, column=col, value=lut1_row); col += 1
+                ws4.cell(row=rr, column=col, value=miss1_row); col += 1
+                ws4.cell(row=rr, column=col, value=cnt1_row); col += 1
+                ws4.cell(row=rr, column=col, value=(ms2_row - ms1_row)).number_format = "+0.0000;-0.0000"; col += 1
+                p = _pct(ms1_row, ms2_row)
+                cell = ws4.cell(row=rr, column=col, value=(p if p is not None else "N/A"))
+                if p is not None:
+                    cell.number_format = "+0.00\"%\";-0.00\"%\""
+            elif have1:
+                ws4.cell(row=rr, column=col, value=cnt1_row); col += 1
+                ws4.cell(row=rr, column=col, value=ms1_row).number_format = "0.0000"; col += 1
+                ws4.cell(row=rr, column=col, value=lut1_row); col += 1
+                ws4.cell(row=rr, column=col, value=miss1_row); col += 1
+                ws4.cell(row=rr, column=col, value=cnt1_row)
+            else:
+                ws4.cell(row=rr, column=col, value=cnt2_row); col += 1
+                ws4.cell(row=rr, column=col, value=ms2_row).number_format = "0.0000"
+            rr += 1
+
+        # TOTAL row
+        lk_miss1_total = int(lk_cnt1_total) - lk_lut1_total
+        ws4.cell(row=rr, column=1, value="TOTAL")
+        col = n_key_cols + 1
+        if two_sided:
+            ws4.cell(row=rr, column=col, value=int(lk_cnt1_total)); col += 1
+            ws4.cell(row=rr, column=col, value=lk_ms1_total).number_format = "0.0000"; col += 1
+            ws4.cell(row=rr, column=col, value=int(lk_cnt2_total)); col += 1
+            ws4.cell(row=rr, column=col, value=lk_ms2_total).number_format = "0.0000"; col += 1
+            ws4.cell(row=rr, column=col, value=lk_lut1_total); col += 1
+            ws4.cell(row=rr, column=col, value=lk_miss1_total); col += 1
+            ws4.cell(row=rr, column=col, value=int(lk_cnt1_total)); col += 1
+            ws4.cell(row=rr, column=col, value=(lk_ms2_total - lk_ms1_total)).number_format = "+0.0000;-0.0000"; col += 1
+            p = _pct(lk_ms1_total, lk_ms2_total)
+            cell = ws4.cell(row=rr, column=col, value=(p if p is not None else "N/A"))
+            if p is not None:
+                cell.number_format = "+0.00\"%\";-0.00\"%\""
+        elif have1:
+            ws4.cell(row=rr, column=col, value=int(lk_cnt1_total)); col += 1
+            ws4.cell(row=rr, column=col, value=lk_ms1_total).number_format = "0.0000"; col += 1
+            ws4.cell(row=rr, column=col, value=lk_lut1_total); col += 1
+            ws4.cell(row=rr, column=col, value=lk_miss1_total); col += 1
+            ws4.cell(row=rr, column=col, value=int(lk_cnt1_total))
+        else:
+            ws4.cell(row=rr, column=col, value=int(lk_cnt2_total)); col += 1
+            ws4.cell(row=rr, column=col, value=lk_ms2_total).number_format = "0.0000"
+        _style_total(ws4, rr, len(lk_headers))
+        ws4.freeze_panes = f"{get_column_letter(n_key_cols + 1)}2"
+        _autosize(ws4, len(lk_headers))
 
     Path(path).parent.mkdir(parents=True, exist_ok=True)
     wb.save(path)
@@ -1350,11 +1866,11 @@ def main() -> int:
             print(f"Error: {e}", file=sys.stderr)
             return 1
 
-    # --- Standalone mode (single file + --perf and/or --summarize-by-signature) ---
+    # --- Standalone mode (single file + --perf / --summarize-by-signature / --by-lut-key) ---
     if file2_path is None:
-        if not args.perf and not args.summarize_by_signature:
+        if not args.perf and not args.summarize_by_signature and not args.by_lut_key:
             print("Error: Two files are required for shape comparison. "
-                  "Use --perf and/or --summarize-by-signature with a single file.",
+                  "Use --perf, --summarize-by-signature, or --by-lut-key with a single file.",
                   file=sys.stderr)
             return 1
 
@@ -1392,6 +1908,8 @@ def main() -> int:
                 args.strip_singleton_dims,
                 include_perf=args.perf,
             )
+        if args.by_lut_key:
+            _print_lut_key_summary(layers, label, include_perf=args.perf)
         if args.perf:
             if args.summarize_by_signature:
                 _print_perf_standalone_by_signature(
@@ -1400,20 +1918,20 @@ def main() -> int:
                     args.strip_leading_ones,
                     args.strip_singleton_dims,
                 )
-            else:
+            elif not args.by_lut_key:
                 _print_perf_standalone(layers, label)
 
         if args.xlsx:
             try:
                 _write_xlsx_report(
                     args.xlsx,
-                    polaris_layers=layers if ftype == 'polaris' else None,
-                    profiler_layers=layers if ftype == 'profiler' else None,
+                    layers1=layers if ftype == 'polaris' else None,
+                    layers2=layers if ftype == 'profiler' else None,
                     stats=None,
-                    polaris_label="Polaris",
-                    profiler_label="Profiler",
-                    polaris_source=args.file1 if ftype == 'polaris' else None,
-                    profiler_source=args.file1 if ftype == 'profiler' else None,
+                    label1="Polaris",
+                    label2="Profiler",
+                    source1=args.file1 if ftype == 'polaris' else None,
+                    source2=args.file1 if ftype == 'profiler' else None,
                     strip_leading_ones=args.strip_leading_ones,
                     strip_singleton_dims=args.strip_singleton_dims,
                 )
@@ -1432,95 +1950,112 @@ def main() -> int:
               "'archname' (polaris) or 'OP CODE' (profiler) columns.", file=sys.stderr)
         return 1
 
-    if type1 == type2:
-        print(f"Error: Both files appear to be {type1} CSVs. "
-              f"Expected one polaris and one profiler CSV.", file=sys.stderr)
-        return 1
+    # Determine loader for each file based on its detected type
+    loader1 = layers_polaris if type1 == 'polaris' else layers_profiler
+    loader2 = layers_polaris if type2 == 'polaris' else layers_profiler
 
-    # Assign files based on type
-    polaris_file = str(file1_path) if type1 == 'polaris' else str(file2_path)
-    profiler_file = str(file1_path) if type1 == 'profiler' else str(file2_path)
+    # Set default display labels; user overrides via --label1/--label2
+    if args.label1:
+        label1 = args.label1
+    else:
+        label1 = f"{type1.capitalize()} 1" if type1 == type2 else type1.capitalize()
+    if args.label2:
+        label2 = args.label2
+    else:
+        label2 = f"{type2.capitalize()} 2" if type1 == type2 else type2.capitalize()
 
-    print(f"Polaris CSV: {polaris_file}")
-    print(f"Profiler CSV: {profiler_file}")
+    print(f"File 1 ({label1}): {file1_path}")
+    print(f"File 2 ({label2}): {file2_path}")
     print()
 
     # Extract layers
     try:
-        polaris_layers = layers_polaris(polaris_file)
-        profiler_layers = layers_profiler(profiler_file)
+        layers1 = loader1(str(file1_path))
+        layers2 = loader2(str(file2_path))
     except Exception as e:
         print(f"Error extracting layers: {e}", file=sys.stderr)
         return 1
 
-    print(f"Loaded {len(polaris_layers)} polaris layers, {len(profiler_layers)} profiler layers")
+    print(f"Loaded {len(layers1)} {label1} layers, {len(layers2)} {label2} layers")
 
     # Filter by optype if requested
     if args.filter_optype:
         filter_optype_norm = normalize_optype(args.filter_optype)
 
-        polaris_layers = [
-            layer for layer in polaris_layers
+        layers1 = [
+            layer for layer in layers1
             if normalize_optype(layer['optype']) == filter_optype_norm
         ]
-        profiler_layers = [
-            layer for layer in profiler_layers
+        layers2 = [
+            layer for layer in layers2
             if normalize_optype(layer['optype']) == filter_optype_norm
         ]
 
-        print(f"Filtered to {len(polaris_layers)} polaris layers, {len(profiler_layers)} profiler layers with optype='{args.filter_optype}'")
+        print(f"Filtered to {len(layers1)} {label1} layers, {len(layers2)} {label2} layers with optype='{args.filter_optype}'")
 
-        if len(polaris_layers) == 0 and len(profiler_layers) == 0:
+        if len(layers1) == 0 and len(layers2) == 0:
             print(f"Warning: No layers found with optype='{args.filter_optype}'")
             return 0
 
     print()
 
     # Compare layers (shape / attribute matching)
-    stats = compare_layers(polaris_layers, profiler_layers, args.max_search_distance,
+    stats = compare_layers(layers1, layers2, args.max_search_distance,
                            args.strip_leading_ones, args.strip_singleton_dims,
-                           ignore_attrs=args.ignore_attrs)
+                           ignore_attrs=args.ignore_attrs,
+                           label1=label1, label2=label2)
 
     # Print shape-comparison summary
-    print_summary(stats)
+    print_summary(stats, label1=label1, label2=label2)
 
     if args.summarize_by_signature:
         _print_signature_summary(
-            polaris_layers,
-            "Polaris",
+            layers1,
+            label1,
             args.strip_leading_ones,
             args.strip_singleton_dims,
             include_perf=args.perf,
         )
         _print_signature_summary(
-            profiler_layers,
-            "Profiler",
+            layers2,
+            label2,
             args.strip_leading_ones,
             args.strip_singleton_dims,
+            include_perf=args.perf,
+        )
+
+    if args.by_lut_key:
+        _print_lut_key_comparison(
+            layers1,
+            layers2,
+            label1=label1,
+            label2=label2,
             include_perf=args.perf,
         )
 
     # Performance comparison (when --perf is enabled)
     if args.perf:
         _print_perf_comparison(
-            profiler_layers,
-            polaris_layers,
+            layers1,
+            layers2,
             by_signature=args.summarize_by_signature,
             strip_leading_ones=args.strip_leading_ones,
             strip_singleton_dims=args.strip_singleton_dims,
+            label1=label1,
+            label2=label2,
         )
 
     if args.xlsx:
         try:
             _write_xlsx_report(
                 args.xlsx,
-                polaris_layers=polaris_layers,
-                profiler_layers=profiler_layers,
+                layers1=layers1,
+                layers2=layers2,
                 stats=stats,
-                polaris_label="Polaris",
-                profiler_label="Profiler",
-                polaris_source=polaris_file,
-                profiler_source=profiler_file,
+                label1=label1,
+                label2=label2,
+                source1=str(file1_path),
+                source2=str(file2_path),
                 strip_leading_ones=args.strip_leading_ones,
                 strip_singleton_dims=args.strip_singleton_dims,
             )

--- a/tools/profiling/op_canonical.py
+++ b/tools/profiling/op_canonical.py
@@ -73,6 +73,11 @@ PROFILER_PREFIX_RULES: tuple[tuple[str, str], ...] = (
     ("Reshard", "reshard"),
     ("ShardedToInterleaved", "shardedtointerleaved"),
     ("InterleavedToSharded", "interleavedtosharded"),
+    ("Conv2d", "conv2d"),
+    ("Pool2D", "pool2d"),
+    ("Halo", "halo"),
+    ("Move", "move"),
+    ("Pad", "pad"),
 )
 
 # BinaryOpType::ENUM (uppercase) → canonical layer type.
@@ -121,6 +126,8 @@ _RE_UNARY_OP_TYPE = re.compile(
     r"UnaryOpType::(\w+)",
     re.IGNORECASE,
 )
+# SlidingWindowConfig embeds is_transpose=true for conv_transpose2d on hardware.
+_RE_CONV_IS_TRANSPOSE = re.compile(r'is_transpose\s*=\s*true', re.IGNORECASE)
 
 _UNKNOWN_PROFILER_BASES: set[str] = set()
 
@@ -134,7 +141,31 @@ POLARIS_SYNONYMS: Dict[str, str] = {
     "nlpcreateqkvheads": "createqkvheads",  # backward-compat: old CSVs used NLP prefix
     "nlpconcatheads": "concatheads",
     "untilizewithvalunpadding": "untilizewithunpadding",  # Polaris uses "Val", profiler uses plain form
+    "maxpool": "pool2d",  # Polaris emits op.type='MaxPool'; profiler/LUT uses 'Pool2D' → 'pool2d'
 }
+
+# ---------------------------------------------------------------------------
+# Preallocated-output op codes
+# ---------------------------------------------------------------------------
+#
+# Op codes whose CSV ``INPUT_1_*`` columns, when populated, record the
+# **optional preallocated output tensor** rather than a real second operand.
+# Reference (tt-metal): InterleavedToSharded/ShardedToInterleaved/Reshard each
+# define their ``tensor_args_t`` as ``input_tensor`` + ``std::optional<Tensor>
+# preallocated_output``.  The preallocated_output is a buffer-reuse optimization
+# and does not change the operation's behavior or cost.  The profiler logs it
+# as INPUT_1_* when present.  LUT-key producers should force the key to arity-1
+# (drop INPUT_1) for these op codes so LUT entries are consistent regardless of
+# whether the caller pre-allocated the output buffer.
+#
+# Move is intentionally NOT in this set: its ``MoveTensorArgs`` has a
+# **required** ``output_tensor`` whose memory config genuinely affects the
+# Move's cost (different destinations = different DMA paths).
+PREALLOC_OUTPUT_AS_INPUT1_OPS: frozenset[str] = frozenset({
+    "interleavedtosharded",
+    "shardedtointerleaved",
+    "reshard",
+})
 
 # ---------------------------------------------------------------------------
 # Comparison groups  (canonical → coarsened group for sequence matching)
@@ -148,6 +179,11 @@ COMPARISON_GROUPS: Dict[str, str] = {
     "sub": "binary",
     "eltwise": "binary",
     "tilizewithvalpadding": "tilize",
+    # Polaris abstract names → profiler hardware names
+    # conv_transpose2d has no separate OP CODE on hardware; implemented as Conv2dDeviceOperation
+    "conv": "conv2d",
+    "maxpool": "pool2d",
+    "convtranspose": "conv2d",
 }
 
 # ---------------------------------------------------------------------------
@@ -263,6 +299,22 @@ def _resolve_unary_attrs(attrs: Any) -> Optional[str]:
     return None
 
 
+def _resolve_conv_subtype(attrs: Any) -> str:
+    """Return 'convtranspose' when attrs contain is_transpose=true, else 'conv2d'.
+
+    Conv2dDeviceOperation on hardware implements both regular and transposed
+    convolutions.  The SlidingWindowConfig embedded in ATTRIBUTES carries an
+    explicit ``is_transpose`` flag that distinguishes the two variants.
+    """
+    if attrs is None:
+        return 'conv2d'
+    if isinstance(attrs, dict):
+        return 'convtranspose' if attrs.get('is_transpose', False) else 'conv2d'
+    if _RE_CONV_IS_TRANSPOSE.search(str(attrs)):
+        return 'convtranspose'
+    return 'conv2d'
+
+
 def normalize_profiler_opcode(opcode: Any, attrs: Any = None) -> str:
     """Map a profiler OP CODE cell (+ optional ATTRIBUTES) to a canonical
     lowercase Polaris layer type.
@@ -326,6 +378,10 @@ def normalize_profiler_opcode(opcode: Any, attrs: Any = None) -> str:
             s,
         )
         return _apply_prefix_rules(base)
+
+    # Conv2d: distinguish regular conv from transposed conv via is_transpose flag
+    if base == "Conv2d":
+        return _resolve_conv_subtype(attrs)
 
     return _apply_prefix_rules(base)
 

--- a/tools/profiling/shape_canonical.py
+++ b/tools/profiling/shape_canonical.py
@@ -265,7 +265,10 @@ def compare_tensor_shapes(
     Returns ``(match, details)`` — ``True`` when all shapes agree after
     normalization.
     """
-    from tools.profiling.op_canonical import normalize_polaris_optype
+    try:
+        from op_canonical import normalize_polaris_optype  # type: ignore[import-not-found]
+    except ImportError:
+        from tools.profiling.op_canonical import normalize_polaris_optype  # type: ignore[import-not-found]
 
     polaris_normalized = [
         normalize_shape(parse_shape_string(s), strip_leading_ones,

--- a/tools/profiling/show_layers_polaris.py
+++ b/tools/profiling/show_layers_polaris.py
@@ -6,7 +6,7 @@ import sys
 import argparse
 import csv
 import json
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Tuple
 
 try:
     from op_canonical import normalize_polaris_optype  # type: ignore[import-not-found]
@@ -116,8 +116,45 @@ def layers_polaris(input_file: str) -> List[Dict[str, Any]]:
             lut_raw = row.get('uses_perf_lookup', '').strip().lower()
             filtered_row['uses_perf_lookup'] = lut_raw in ('true', '1', 'yes')
 
+            # LUT key trail (polaris CSV columns added by the Tier-1 plumbing):
+            #   ``lut_key``           — literal tuple built from this op + tensor state,
+            #                            before any fallback substitution
+            #   ``lut_key_resolved``  — tuple the lookup chain actually matched (after
+            #                            HEIGHT→BLOCK / L1→DRAM / arity-dup / layout
+            #                            fallbacks).  Equals ``lut_key`` when the
+            #                            literal hit directly.
+            # Both columns are absent on older polaris CSVs predating the Tier-1
+            # plumbing — leave the row fields unset (= None) in that case so
+            # downstream consumers (compare_layers ``--by-lut-key``) treat the row
+            # as not-yet-canonicalized.
+            filtered_row['lut_key'] = _parse_lut_key_cell(row.get('lut_key'))
+            filtered_row['lut_key_resolved'] = _parse_lut_key_cell(row.get('lut_key_resolved'))
+
             rows.append(filtered_row)
     return rows
+
+
+def _parse_lut_key_cell(raw: Optional[str]) -> Optional[Tuple[Any, ...]]:
+    """Parse a polaris CSV ``lut_key`` / ``lut_key_resolved`` cell into a tuple.
+
+    The cell holds ``str(tuple)`` (e.g. ``"('halo', 1, 1, 65536, 16, 'ROW_MAJOR', …)"``)
+    when ``uses_perf_lookup`` is True, ``''`` / ``None`` otherwise.  We round-trip via
+    :func:`ast.literal_eval`; on any parse error return ``None`` rather than crash so
+    older polaris CSVs (which lack these columns) and malformed cells degrade gracefully.
+    """
+    import ast
+    if raw is None:
+        return None
+    s = str(raw).strip()
+    if not s or s.lower() in ('none', 'na', 'null'):
+        return None
+    try:
+        value = ast.literal_eval(s)
+    except (ValueError, SyntaxError):
+        return None
+    if not isinstance(value, tuple):
+        return None
+    return value
 
 def show_layers_polaris(input_file: str) -> None:
     for row in layers_polaris(input_file):

--- a/tools/profiling/show_layers_profiler.py
+++ b/tools/profiling/show_layers_profiler.py
@@ -10,9 +10,46 @@ import yaml
 from typing import Any, Dict, List, Optional, Tuple
 
 try:
-    from op_canonical import normalize_profiler_opcode  # type: ignore[import-not-found]
+    from op_canonical import (  # type: ignore[import-not-found]
+        PREALLOC_OUTPUT_AS_INPUT1_OPS,
+        normalize_profiler_opcode,
+    )
 except ImportError:
-    from .op_canonical import normalize_profiler_opcode  # type: ignore
+    from .op_canonical import (  # type: ignore
+        PREALLOC_OUTPUT_AS_INPUT1_OPS,
+        normalize_profiler_opcode,
+    )
+
+# Schema v4 per-op variant key extensions. Mirror of helpers in tt_perf_mapper.py.
+_HALO_WINDOW_RE = re.compile(r"window_hw\s*=\s*\(\s*(\d+)\s*[;,]\s*(\d+)\s*\)")
+_HALO_STRIDE_RE = re.compile(r"stride_hw\s*=\s*\(\s*(\d+)\s*[;,]\s*(\d+)\s*\)")
+_HALO_PADDING_RE = re.compile(
+    r"padding\s*=\s*\(\s*\(\s*(\d+)\s*[;,]\s*\d+\s*\)\s*[;,]\s*\(\s*(\d+)\s*[;,]\s*\d+\s*\)\s*\)"
+)
+_HALO_ISTRANSPOSE_RE = re.compile(r"is_transpose\s*=\s*(true|false)")
+_HALO_OP_CODE = "halo"
+_ITS_OP_CODE = "interleavedtosharded"
+
+
+def _extract_halo_geometry(attrs_cell: str) -> Optional[Tuple[int, int, int, int, int, int, bool]]:
+    """Parse (kernel_h, kernel_w, stride_h, stride_w, padding_h, padding_w, is_transpose) from ATTRIBUTES."""
+    if not attrs_cell:
+        return None
+    win = _HALO_WINDOW_RE.search(attrs_cell)
+    stride = _HALO_STRIDE_RE.search(attrs_cell)
+    pad = _HALO_PADDING_RE.search(attrs_cell)
+    istr = _HALO_ISTRANSPOSE_RE.search(attrs_cell)
+    if not (win and stride and pad and istr):
+        return None
+    return (
+        int(win.group(1)),
+        int(win.group(2)),
+        int(stride.group(1)),
+        int(stride.group(2)),
+        int(pad.group(1)),
+        int(pad.group(2)),
+        istr.group(1) == "true",
+    )
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description='Show layers from profiler CSV')
@@ -57,9 +94,52 @@ def expand_tensor_attrs(row: Dict[str, Any], input_index: int, in_or_out: str = 
     memory_raw = (row.get(f'{prefix}_MEMORY') or '').strip()
     if not layout and not dtype and not memory_raw:
         return None
-    # Strip device prefix (e.g. "DEV_1_L1_INTERLEAVED" -> "L1_INTERLEAVED")
-    memory = re.sub(r'^DEV_\d+_', '', memory_raw) if memory_raw else ''
-    return {'layout': layout, 'dtype': dtype, 'memory': memory}
+    return {'layout': layout, 'dtype': dtype, 'memory': memory_raw}
+
+
+def _build_lut_key(
+    optype: str,
+    pad_logical_slots: List[List[tuple]],
+    layouts: List[Optional[str]],
+    dtypes: List[Optional[str]],
+    memories: List[Optional[str]],
+    math_fidelity: str,
+    *,
+    halo_geometry: Optional[Tuple[int, int, int, int, int, int, bool]] = None,
+    its_output_memory: Optional[str] = None,
+) -> tuple:
+    """Build a LUT key tuple matching tt_perf_master_schema KEY_TUPLE_YAML_KEYS convention.
+
+    Each input slot contributes 7 elements: w_pad, z_pad, y_pad, x_pad, layout, dtype, memory.
+    Dimensions are zero-padded to 4 (W, Z, Y, X); missing slots use empty strings.
+
+    Op codes in ``PREALLOC_OUTPUT_AS_INPUT1_OPS`` (ITS, STS, Reshard) are forced
+    to arity-1 — any INPUT_1 slot is a preallocated output, not a real operand,
+    and including it would produce inconsistent keys across rows that do/don't
+    pre-allocate the output buffer.
+
+    Schema v4 per-op variants: ``halo`` rows extend the base 9-tuple to a 16-tuple
+    via ``halo_geometry`` (kernel_h/w, stride_h/w, padding_h/w, is_transpose);
+    ``interleavedtosharded`` rows extend to a 10-tuple via ``its_output_memory``.
+    """
+    use_slots = pad_logical_slots
+    if optype in PREALLOC_OUTPUT_AS_INPUT1_OPS:
+        use_slots = pad_logical_slots[:1]
+    key: list = [optype]
+    for slot_idx, dims in enumerate(use_slots):
+        pad_vals = [p for p, _ in dims]
+        pad_vals.extend([''] * (4 - len(pad_vals)))
+        key.extend(pad_vals[:4])
+        key.append(layouts[slot_idx] or '')
+        key.append(dtypes[slot_idx] or '')
+        key.append(memories[slot_idx] or '')
+        if slot_idx == 0:
+            key.append(math_fidelity)
+    if optype == _HALO_OP_CODE and halo_geometry is not None:
+        key.extend(halo_geometry)
+    elif optype == _ITS_OP_CODE and its_output_memory is not None:
+        key.append(its_output_memory)
+    return tuple(key)
 
 
 def layers_profiler(input_file: str) -> List[Dict[str, Any]]:
@@ -77,6 +157,8 @@ def layers_profiler(input_file: str) -> List[Dict[str, Any]]:
             if not isinstance(parsed_attrs, dict):
                 parsed_attrs = None
             optype = normalize_profiler_opcode(row['OP CODE'], parsed_attrs)
+            math_fidelity_raw = (row.get('MATH FIDELITY') or '').strip()
+            math_fidelity = math_fidelity_raw if math_fidelity_raw else 'N/A'
             # Attribute lists (dtypes, layouts, memories) must stay parallel
             # with their tensor lists so that positional indexing in
             # compare_tensor_attributes (compare_layers.py) compares the
@@ -128,6 +210,23 @@ def layers_profiler(input_file: str) -> List[Dict[str, Any]]:
                     filtered_row['output_dtypes'].append(a['dtype'] if a else None)
                     filtered_row['output_layouts'].append(a['layout'] if a else None)
                     filtered_row['output_memories'].append(a['memory'] if a else None)
+            halo_geom: Optional[Tuple[int, int, int, int, int, int, bool]] = None
+            its_out_mem: Optional[str] = None
+            if optype == _HALO_OP_CODE:
+                halo_geom = _extract_halo_geometry(attrs_cell)
+            elif optype == _ITS_OP_CODE:
+                out_mem_raw = (row.get('OUTPUT_0_MEMORY') or '').strip()
+                its_out_mem = out_mem_raw or None
+            filtered_row['lut_key'] = _build_lut_key(
+                optype,
+                filtered_row['input_pad_logical'],
+                filtered_row['input_layouts'],
+                filtered_row['input_dtypes'],
+                filtered_row['input_memories'],
+                math_fidelity,
+                halo_geometry=halo_geom,
+                its_output_memory=its_out_mem,
+            )
             rows.append(filtered_row)
 
     # Post-process: correct ops where the profiler conflates PAD and LOGICAL

--- a/ttsim/back/device.py
+++ b/ttsim/back/device.py
@@ -184,6 +184,10 @@ class Device:
         # 2) SET RESOURCES FOR ALL OPS
         wlgraph.set_resources(wlmapspec.rsrc_spec)
 
+        # 2.5) ARCH-AWARE LUT-KEY ANNOTATIONS (must run before execute_op → LUT lookup)
+        self._annotate_conv_x_pad_logical(wlgraph)
+        self._annotate_halo_y_pad_logical(wlgraph)
+
         # 3) EXECUTE OPS RESOURCES FOR ALL OPS : FIND COMPUTE/MEM CYCLES
         for opname in graph_ordered_nodes:
             op = wlgraph.get_op(opname)
@@ -305,6 +309,214 @@ class Device:
     def _profiler_pct_to_exec_fraction(v: float) -> float:
         """Convert validated LUT utilization from percentage (0–100) to exec_stats fraction (0–1)."""
         return float(v) / 100.0
+
+    def _annotate_conv_x_pad_logical(self, wlgraph: Any) -> None:
+        """Tag conv2d/conv_transpose2d input tensors (+ upstream passthrough chain) with HW-padded channels.
+
+        For BLOCK_SHARDED convs on devices that declare ``compute_grid_size``, computes
+        the channel padding tt-metal's ``determine_parallel_config`` would apply and
+        writes it to the conv input tensor's ``x_pad_logical`` attr. The tag is then
+        propagated BACKWARD through Move/ITS/STS/Reshard/Halo so each upstream tensor
+        carries the same padded x — without this, the upstream Move's LUT key uses
+        unpadded channels and analytical-fallbacks (over-estimating duration).
+
+        See doc/TTNN_SHIM_ARCHITECTURE.md §17.
+        """
+        grid = getattr(self.simconfig_obj, "compute_grid_size", None)
+        if grid is None or len(grid) != 2:
+            return  # arch doesn't declare a grid — leave tensors alone (no-op fallback)
+
+        from tools.perf_lookup.conv_parallel_config import (
+            determine_block_sharded_channel_padding,
+        )
+        from ttsim.front.ttnn.buffer import TensorMemoryLayout
+
+        # Backward-propagation traverses Move-class passthrough ops only.  Halo is excluded
+        # intentionally: Halo's LUT key uses its PRE-halo (input) shape; the channel
+        # padding applies to the POST-halo path that feeds the conv.  Walking through Halo
+        # would tag the pre-halo tensor with the post-halo padded x and miss the Halo LUT.
+        passthrough_ops_backward = frozenset(
+            {"Move", "InterleavedToSharded", "ShardedToInterleaved", "Reshard"}
+        )
+
+        def _propagate_backward(start_tensor_name: str, padded: int) -> int:
+            """Walk backward through single-producer Move-class passthroughs; tag each upstream tensor.
+
+            Stops at Halo (or any non-passthrough op) so the Halo's LUT key — which uses the
+            pre-halo input shape — is not perturbed.
+            """
+            count = 0
+            cur_name = start_tensor_name
+            while True:
+                cur_t = wlgraph._tensors.get(cur_name)
+                if cur_t is None:
+                    break
+                producers = getattr(cur_t, "op_out", None) or []
+                if len(producers) != 1:
+                    break
+                upstream_op = wlgraph.get_op(producers[0])
+                if upstream_op is None or getattr(upstream_op, "optype", "") not in passthrough_ops_backward:
+                    break
+                u_inList = getattr(upstream_op, "inList", None) or []
+                if not u_inList:
+                    break
+                u_in_t = wlgraph._tensors.get(u_inList[0])
+                if u_in_t is None:
+                    break
+                u_in_t.x_pad_logical = padded
+                count += 1
+                cur_name = u_inList[0]
+            return count
+
+        grid_xy = (int(grid[0]), int(grid[1]))
+        tagged_convs = 0
+        tagged_propagations = 0
+        for opname in wlgraph.get_ordered_nodes():
+            op = wlgraph.get_op(opname)
+            optype = getattr(op, "optype", "")
+            if optype not in ("Conv", "ConvTranspose"):
+                continue
+            inList = getattr(op, "inList", None) or []
+            outList = getattr(op, "outList", None) or []
+            if not inList or not outList:
+                continue
+            in_t = wlgraph._tensors.get(inList[0])
+            out_t = wlgraph._tensors.get(outList[0])
+            if in_t is None or out_t is None:
+                continue
+            mc = getattr(in_t, "_memory_config", None)
+            if mc is None or getattr(mc, "memory_layout", None) != TensorMemoryLayout.BLOCK_SHARDED:
+                continue
+            # Channel count: prefer hw_shape (NHWC-flat [1, 1, N*H*W, C]); fall back to logical last dim.
+            in_hw = getattr(in_t, "hw_shape", None)
+            in_channels = int(in_hw[3]) if in_hw is not None and len(in_hw) >= 4 else None
+            if in_channels is None:
+                in_shape = getattr(in_t, "shape", None)
+                if in_shape is None or len(in_shape) == 0:
+                    continue
+                in_channels = int(in_shape[1])  # NCHW: index 1 is channels
+            out_hw = getattr(out_t, "hw_shape", None)
+            if out_hw is None or len(out_hw) < 3:
+                continue  # need output N*H*W; skip rather than guess
+            out_nhw = int(out_hw[2])
+            try:
+                _, _, padded_channels = determine_block_sharded_channel_padding(
+                    input_channels=in_channels,
+                    output_nhw=out_nhw,
+                    compute_grid_size=grid_xy,
+                )
+            except ValueError:
+                continue
+            if padded_channels != in_channels:
+                in_t.x_pad_logical = padded_channels
+                tagged_convs += 1
+                tagged_propagations += _propagate_backward(inList[0], padded_channels)
+        if tagged_convs:
+            logger.debug(
+                "Annotated x_pad_logical on {} conv input tensor(s) (+{} upstream passthrough) "
+                "(BLOCK_SHARDED on compute_grid_size={})",
+                tagged_convs,
+                tagged_propagations,
+                grid_xy,
+            )
+
+    def _annotate_halo_y_pad_logical(self, wlgraph: Any) -> None:
+        """Tag halo output tensors (and their passthrough downstream chain) with arch-specific extended-Y.
+
+        The base ``_HALO_EXT_Y`` table in ttsim/ops/desc/ttsim_layout.py was calibrated against
+        WH n150's profiler trace; some halo positions emit a different extended-y on other
+        arches because tt-metal's ``determine_parallel_config`` picks a different
+        ``num_cores_nhw`` for the downstream conv.  ``_HALO_EXT_Y_OVERRIDES_BY_DEVICE`` declares
+        the arch-specific values; when an entry exists for the current device, this pass
+        writes ``y_pad_logical`` onto the halo output tensor AND propagates it forward through
+        passthrough ops (Move, ITS, STI, Reshard) to the downstream conv input.  See
+        doc/TTNN_SHIM_ARCHITECTURE.md §17 (D.2b).
+        """
+        device_name = getattr(self, "name", None)
+        if not device_name:
+            return
+        from ttsim.ops.desc.ttsim_layout import _HALO_EXT_Y_OVERRIDES_BY_DEVICE
+
+        overrides = _HALO_EXT_Y_OVERRIDES_BY_DEVICE.get(device_name)
+        if not overrides:
+            return
+
+        passthrough_ops = frozenset({"Move", "InterleavedToSharded", "ShardedToInterleaved", "Reshard"})
+        tagged_halos = 0
+        tagged_propagations = 0
+
+        def _propagate_forward(start_tensor_name: str, ext_y: int) -> int:
+            """Walk forward through passthrough ops; tag every output tensor on the chain."""
+            count = 0
+            cur_name = start_tensor_name
+            while True:
+                cur_t = wlgraph._tensors.get(cur_name)
+                if cur_t is None:
+                    break
+                consumers = getattr(cur_t, "op_in", None) or []
+                # Stop when there are zero or multiple consumers (branching) — only single-consumer
+                # passthrough chains are safe to propagate through.
+                if len(consumers) != 1:
+                    break
+                downstream_op = wlgraph.get_op(consumers[0])
+                if downstream_op is None or getattr(downstream_op, "optype", "") not in passthrough_ops:
+                    break
+                d_outList = getattr(downstream_op, "outList", None) or []
+                if len(d_outList) != 1:
+                    break
+                d_out_t = wlgraph._tensors.get(d_outList[0])
+                if d_out_t is None:
+                    break
+                d_out_t.y_pad_logical = ext_y
+                count += 1
+                cur_name = d_outList[0]
+            return count
+
+        for opname in wlgraph.get_ordered_nodes():
+            op = wlgraph.get_op(opname)
+            if getattr(op, "optype", "") != "Halo":
+                continue
+            inList = getattr(op, "inList", None) or []
+            outList = getattr(op, "outList", None) or []
+            if not inList or not outList:
+                continue
+            in_t = wlgraph._tensors.get(inList[0])
+            out_t = wlgraph._tensors.get(outList[0])
+            if in_t is None or out_t is None:
+                continue
+            in_shape = getattr(in_t, "shape", None)
+            if in_shape is None or len(in_shape) < 4:
+                continue
+            attrs = getattr(op, "attrs", None) or {}
+            ks = attrs.get("kernel_size")
+            pd = attrs.get("padding")
+            if ks is None or pd is None:
+                continue
+            try:
+                kH = int(ks[0]) if hasattr(ks, "__getitem__") else int(ks)
+                kW = int(ks[1]) if hasattr(ks, "__getitem__") else int(ks)
+                pH = int(pd[0]) if hasattr(pd, "__getitem__") else int(pd)
+                pW = int(pd[1]) if hasattr(pd, "__getitem__") else int(pd)
+            except (TypeError, ValueError):
+                continue
+            N, C, H, W = int(in_shape[0]), int(in_shape[1]), int(in_shape[2]), int(in_shape[3])
+            nhw = N * H * W
+            is_tp = bool(attrs.get("is_transpose", False))
+            key = (nhw, C, kH, kW, pH, pW, is_tp)
+            override_y = overrides.get(key)
+            if override_y is None:
+                continue
+            out_t.y_pad_logical = int(override_y)
+            tagged_halos += 1
+            tagged_propagations += _propagate_forward(outList[0], int(override_y))
+
+        if tagged_halos:
+            logger.debug(
+                "Annotated y_pad_logical on {} halo output tensor(s) (+{} downstream passthrough) for device {!r}",
+                tagged_halos,
+                tagged_propagations,
+                device_name,
+            )
 
     def _try_operator_perf_lookup(
         self,

--- a/ttsim/config/simconfig.py
+++ b/ttsim/config/simconfig.py
@@ -491,6 +491,11 @@ class PackageInstanceModel(BaseModel, extra='forbid'):
     operator_lookup_core_count: Optional[int] = None
     #: When True, ``entry_type: hybrid`` LUT rows use embedded ``curve`` stats at runtime core count.
     operator_lookup_hybrid_curve: bool = False
+    #: Logical compute grid [x, y] = (num_cols, num_rows) — mirrors tt-metal's compute_with_storage_grid_range.
+    #: Used by the conv2d parallel-config helper to compute BLOCK_SHARDED channel padding (see
+    #: doc/TTNN_SHIM_ARCHITECTURE.md §17). Optional — only required for arches that participate in
+    #: the LUT-key channel-padding pass; otherwise polaris falls back to unpadded channels.
+    compute_grid_size: Optional[List[int]] = None
 
     def get_ipgroup(self, iptype: str) -> IPGroupModel:
         matching = [ipgroup for ipgroup in self.ipgroups if ipgroup.iptype == iptype]

--- a/ttsim/ops/desc/ttsim_layout.py
+++ b/ttsim/ops/desc/ttsim_layout.py
@@ -20,6 +20,30 @@ TILE_WIDTH = 32
 _TTNN_OP_DOMAIN = "com.tenstorrent.ttnn"
 
 
+# Per-arch overrides to ``_HALO_EXT_Y``. The base table is empirical (WH n150 trace);
+# some halo positions emit a different extended-y on other arches because
+# ``determine_parallel_config`` picks a workload-specific ``num_cores_nhw``.
+# Applied by the annotation pass in ttsim/back/device.py at execute_graph time, when
+# the back Device's instance name is known. See doc/TTNN_SHIM_ARCHITECTURE.md §17.
+_HALO_EXT_Y_OVERRIDES_BY_DEVICE: dict[
+    str, dict[tuple[int, int, int, int, int, int, bool], int]
+] = {
+    # BH p100a (grid 12x10): d2.conv1 (4096 nhw, 512 channels, k=3 p=1 s=1) lands on
+    # num_cores_nhw=10 (cores=80, 10x8 grid) per tt-metal's parallel-config picker
+    # — different from the base table's WH assumption of num_cores_nhw=8 (cores=64).
+    # HW-captured extended y = 5620 (verified against
+    # __refrun_cache/vgg_unet/bh/p100a/merged_ops_dualref_260519.csv).
+    "p100a": {
+        (4096, 512, 3, 3, 1, 1, False): 5620,
+        # d4 up convtranspose: WH n150 emits y=82240 (the base table value); BH p100a's
+        # parallel-config for the underlying conv2d (post-zero-insert upsample + halo) picks
+        # different num_cores → HW captures y=88408 (verified against
+        # __refrun_cache/vgg_unet/bh/p100a/merged_ops_dualref_260519.csv convtranspose entry).
+        (16384, 128, 2, 2, 0, 0, True): 88408,
+    },
+}
+
+
 def _round_up(value, multiple):
     return ((value + multiple - 1) // multiple) * multiple
 

--- a/ttsim/ops/tensor.py
+++ b/ttsim/ops/tensor.py
@@ -140,6 +140,22 @@ class SimTensor:
         self.is_const    = cfg.get('is_const', False) # Is it constant? Boolean
         self.has_grad    = cfg.get('has_grad', True)  # Has a gradient during bwd pass? Boolean
         self.link_module = None                       # Associated Module
+        # hw_shape: NHWC-flattened [1, 1, N*H*W, C] used for LUT key matching and profiler comparison.
+        # Set by conv/pool sinfs; propagated by Move/ITS/STI/Reshard/Concat passthrough sinfs.
+        # None for ops that produce non-NCHW outputs (attention projections, embeddings, etc.).
+        # TODO: set hw_shape for MaxPool/AvgPool descriptors if LUT coverage is extended.
+        self.hw_shape: list[int] | None = None
+        # x_pad_logical: padded channel count for LUT key construction when this tensor feeds
+        # a BLOCK_SHARDED conv2d/conv_transpose2d.  Set by the Device.execute_graph annotation
+        # pass (post-shim, post-arch-load) via determine_block_sharded_channel_padding.
+        # See doc/TTNN_SHIM_ARCHITECTURE.md §17. None when the tensor doesn't participate in
+        # a BLOCK_SHARDED conv input chain; LUT key builders then fall back to shape's X dim.
+        self.x_pad_logical: int | None = None
+        # y_pad_logical: halo-extended Y stick count override for LUT key construction.
+        # Set by the Device.execute_graph annotation pass when an arch-specific halo
+        # extension differs from the base _HALO_EXT_Y table (e.g. BH p100a's d2.conv1
+        # picks num_cores_nhw=10 → y=5620 vs WH's y=5280).  See doc/TTNN_SHIM_ARCHITECTURE.md §17.
+        self.y_pad_logical: int | None = None
         SimTensor.set_shape(self, cfg.get('shape'))   # Other classes that subclass might override set_shape
 
     def set_module(self, m): self.link_module = m


### PR DESCRIPTION
## Summary

This branch bundles two threads of work:

**(1) compare_layers refactor (#437 original scope):**
- Removes the `type1 == type2` guard in `main()` so **profiler-vs-profiler** and **polaris-vs-polaris** comparisons now work alongside the existing polaris-vs-profiler mode
- Adds `--label1` / `--label2` CLI flags to name the two files in all output; defaults to `"Polaris 1"/"Polaris 2"` or `"Profiler 1"/"Profiler 2"` for same-type pairs, detected type name for mixed pairs
- Generalises `compare_layers()`, `print_summary()`, `_print_perf_comparison()`, and `_write_xlsx_report()` with `label1`/`label2` throughout; renames `polaris_layers`/`profiler_layers`/`polaris_label`/`profiler_label` params to `layers1`/`layers2`/`label1`/`label2`
- Adds 5 missing entries to `PROFILER_PREFIX_RULES` in `op_canonical.py`: `Conv2dDeviceOperation→conv2d`, `Pool2D→pool2d`, `HaloDeviceOperation→halo`, `MoveDeviceOperation→move`, `PadDeviceOperation→pad`
- Adds `--by-lut-key` rollup mode + `lut_key` / `lut_key_resolved` columns + ``--xlsx`` Summary/By-Layer-Type/By-Layer-Signature sheets

**(2) Per-op variant LUT keys (#45 — bundled here as it landed via the same branch):**

| Commit | Scope |
|---|---|
| `d4c4bea` | schema v3 — per-op variant key tuples: halo (15-field), ITS (10-field) |
| `fbd0dd5` | mapper extracts halo `SlidingWindowConfig` + ITS `OUTPUT_0_MEMORY` |
| `ddb0a0f` | lookup builds 15-tuple for halo, 10-tuple for ITS |
| `439659c` | show_layers_profiler emits matching keys for compare_layers |
| `986847f` | `--cv-threshold` CLI knob for `tt_perf_mapper` (handles CV outliers in halo profiler traces) |
| `8d90a51` | schema v4 — halo key gains `is_transpose` (16-field); disambiguates Conv vs ConvTranspose halos that previously collided (5.3× duration delta observed on hardware) |

Schema v4 ↔ LUT regeneration is handled separately, outside this PR.

## Verification (4-combo, post-#45 schema v4 + LUT v5)

Run from branch 428 (PR #434) which has the schema work cherry-picked + applied. The numbers below are pre any #428-specific shim audit fixes — they exercise only the #45 changes' impact:

| Combo | Polaris (ms) | Profiler (ms) | Gap | LUT hits |
|---|---|---|---|---|
| ViT WH n150 (bs=8) | 5.0428 | 5.0924 | +0.98% | 204/204 |
| ViT BH p100a (bs=10) | 3.2423 | 3.2795 | +1.15% | 192/192 |
| VGG WH n150 (bs=1) | 3.3186 | 3.2911 | −0.83% | 102/104 |
| VGG BH p100a (bs=1) | 2.4070 | 2.5156 | +4.51% | 97/104 |

The remaining VGG BH residuals (3 conv2d/convtranspose analytical misses) are addressed in PR #434's modeling-floor audit work (D.2a/D.2b/D.2c on issue #428).

## Test plan

- [x] Profiler-vs-profiler comparison runs without error and produces correct layer/perf output
- [x] All 1365 layers match between two VGG UNet profiler runs (vggref vs vggdualref) with 0 mismatches
- [x] No remaining `Unknown profiler OP base` warnings for the 5 newly mapped op types
- [x] `mypy` and `ruff check` clean on all changed files
- [x] Existing polaris-vs-profiler mode unaffected (label defaults preserved)
- [x] Schema v4 round-trip (`tuple_to_labeled_key_map` ↔ `labeled_key_map_to_tuple`) for both halo and ITS variants
- [x] New unit test `test_halo_key_distinguishes_conv_from_conv_transpose` locks in the Conv ≠ ConvTranspose key property
- [x] All 423 tests in `tests/test_tools/` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
