### PR TITLE
config/simconfig: fix IndexError in set_param loop guard (len(pname) → len(parts))

### DIFF
--- a/ttsim/config/simconfig.py
+++ b/ttsim/config/simconfig.py
@@ -95,7 +95,7 @@ class SimCfgBlk: #Generic Sim Configuration Block
         #search the obj hierachy for name match. child objects may be SimCfgBlk or dict
         cur_child_obj = getattr(self, cur_attr)
         cur_child_pos = 1
-        while not isinstance(cur_child_obj, SimCfgBlk) and cur_child_pos < len(pname):
+        while not isinstance(cur_child_obj, SimCfgBlk) and cur_child_pos < len(parts):
             if isinstance(cur_child_obj, dict):
                 if '.' in next_pname:
                     cur_attr       = parts[cur_child_pos]


### PR DESCRIPTION
`SimCfgBlk.set_param` splits a dotted path (e.g. `"a.b.c"`) into `parts`
and uses `cur_child_pos` as an index into that list. The while-loop guard
compared against `len(pname)` — the character length of the original string
— instead of `len(parts)`, the number of segments.

For any path with more than one dot-separated segment where traversal passes
through a dict node, `cur_child_pos` would exceed `len(parts) - 1` while
still satisfying `cur_child_pos < len(pname)`, causing `parts[cur_child_pos]`
to raise an `IndexError`.

Fix: replace `len(pname)` with `len(parts)` in the loop condition.