### PR TITLE
fix: pre-commit hooks fail with missing packages despite correct cond…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,23 +11,21 @@ repos:
         -   id: spdx-checker
             name: Check SPDX License and Copyright
             description: Check SPDX License and Copyright
-            language: python
-            entry: tools/spdxchecker.py
+            language: system
+            entry: python tools/spdxchecker.py
             args: [--config, .github/spdxchecker-config.yml, --loglevel, error]
-            additional_dependencies: [pyyaml, loguru, pydantic]
             pass_filenames: false
         -   id: static checker
             name: Run static checks on the repository
             description: Check static checks
-            language: python
-            entry: ./checkin_tests.py
+            language: system
+            entry: python ./checkin_tests.py
             args:  [static]
-            # additional_dependencies: [pyyaml, loguru, pydantic]
             pass_filenames: false
         -   id: unit tests
             name: Run unit tests
             description: Run unit tests
-            language: python
+            language: system
             entry: pytest
             args: [-m, 'unit and not slow and not tools_secondary']
             pass_filenames: false

--- a/checkin_tests.py
+++ b/checkin_tests.py
@@ -4,6 +4,7 @@
 import os
 import sys
 import argparse
+import importlib
 import re
 import subprocess
 from itertools import product
@@ -121,16 +122,20 @@ def check_environment_sanity() -> tuple[bool, str]:
         'networkx': 'networkx',
         'numpy': 'numpy',
     }
+    broken_packages = []
 
     for module, package_name in critical_imports.items():
         try:
-            __import__(module)
-        except ImportError as e:
-            print(f"ERROR: {e} module {module} {package_name}")
+            importlib.import_module(module)
+        except ImportError:
             missing_packages.append(package_name)
+        except Exception as e:
+            print(f"ERROR: {e} module {module} {package_name}")
+            broken_packages.append(package_name)
 
+    messages = []
     if missing_packages:
-        return False, (
+        messages.append(
             f"ERROR: Missing required packages: {', '.join(missing_packages)}\n"
             f"Current environment: {conda_env}\n\n"
             f"Options to fix:\n"
@@ -139,6 +144,17 @@ def check_environment_sanity() -> tuple[bool, str]:
             f"  3. Create environment from environment.yaml:\n"
             f"     conda env create -f environment.yaml"
         )
+    if broken_packages:
+        messages.append(
+            f"ERROR: Installed packages failed to import (version/runtime conflict): {', '.join(broken_packages)}\n"
+            f"Current environment: {conda_env}\n\n"
+            f"Options to fix:\n"
+            f"  1. Use --environment/-e to specify a different environment\n"
+            f"  2. Recreate environment from environment.yaml:\n"
+            f"     conda env create -f environment.yaml"
+        )
+    if messages:
+        return False, "\n\n".join(messages)
 
     return True, f"Environment check passed (using: {conda_env})"
 


### PR DESCRIPTION
…a env

- Switch all hooks in .pre-commit-config.yaml from language: python to language: system so pre-commit uses the active conda env's Python instead of an isolated venv; remove now-unnecessary additional_dependencies
- Replace __import__() with importlib.import_module() (public API)
- Broaden except ImportError to except Exception to catch non-ImportError failures (e.g. protobuf version conflicts in onnx)