### PR TITLE
L1 modeling: implementation only for MatMul Op

### DIFF
--- a/ttsim/ops/desc/math.py
+++ b/ttsim/ops/desc/math.py
@@ -666,8 +666,10 @@ def matmul_shape_inf(iTList, oTList, op, **kwargs):
     # ttnn.linear fuses bias as a 3rd input on the same MatMul SimOp (see
     # op.py linear()).  Summing over iTList ensures the bias tensor's memory
     # footprint is reflected in inElems/inBytes.
-    in_elems = sum(t.nelems() for t in iTList)
-    in_bytes = sum(t.nbytes(op.precision) for t in iTList)
+    import ttsim.front.ttnn.memory as ttnn_memory
+    iTList_residency = [t.memory_config().buffer_type if isinstance(t.memory_config(), ttnn_memory.MemoryConfig) else None for t in iTList]
+    in_elems = sum(t.nelems() if ir != ttnn_memory.BufferType.L1 else 0 for t, ir in zip(iTList, iTList_residency))
+    in_bytes = sum(t.nbytes(op.precision) if ir != ttnn_memory.BufferType.L1 else 0 for t, ir in zip(iTList, iTList_residency))
     instrs: dict = {"mac": oTList[0].nelems() * reduced_dim}
     if len(iTList) > 2:
         instrs["add"] = oTList[0].nelems()
@@ -691,11 +693,12 @@ def matmul_shape_inf(iTList, oTList, op, **kwargs):
             instrs["div"] = instrs.get("div", 0) + nelem
             instrs["mul"] = instrs.get("mul", 0) + nelem
 
+    oTList_residency = oTList[0].memory_config().buffer_type if isinstance(oTList[0].memory_config(), ttnn_memory.MemoryConfig) else None
     op.perf_stats = {
         "inElems": in_elems,
-        "outElems": oTList[0].nelems(),
+        "outElems": oTList[0].nelems() if oTList_residency != ttnn_memory.BufferType.L1 else 0,
         "inBytes": in_bytes,
-        "outBytes": oTList[0].nbytes(op.precision),
+        "outBytes": oTList[0].nbytes(op.precision) if oTList_residency != ttnn_memory.BufferType.L1 else 0,
         "instrs": instrs,
     }
     return

--- a/ttsim/ops/tensor.py
+++ b/ttsim/ops/tensor.py
@@ -144,6 +144,9 @@ class SimTensor:
 
     def set_module(self, m): self.link_module = m
 
+    def memory_config(self):
+        return getattr(self, '_memory_config', None)
+
     def __str__(self):
         s  = f"SimTensor({self.name}) shape={self.shape}, dtype={self.dtype}, "
         s += f"is_param={self.is_param}, "
@@ -176,8 +179,9 @@ class SimTensor:
             assert False, f"What kinda tensor {self.name} is this? {self.shape}"
         if self.data is not None:
             assert isinstance(self.data, tuple([np.ndarray, np.float32, np.bool_])), f'data should be ndarray, is {type(self.data)}'
-            res1 = self.data.size
-            assert res1 == res, f"Mismatch SimTensor({self.name}).nelems = {res} and np.size={res1}"
+            if isinstance(self.data, np.ndarray):
+                res1 = self.data.size
+                assert res1 == res, f"Mismatch SimTensor({self.name}).nelems = {res} and np.size={res1}"
         return res
 
     def numel(self):

--- a/ttsim/stats/hlmstats.py
+++ b/ttsim/stats/hlmstats.py
@@ -387,6 +387,8 @@ class HLMStats:
         _graph_ordered_nodes = self.wlgraph.get_ordered_nodes()
         for opnum, opname in enumerate(_graph_ordered_nodes):
             op = self.wlgraph.get_op(opname)
+            if op.perf_stats['inElems'] == 0:
+                continue
             val_in_bpe = op.perf_stats['inBytes'] // op.perf_stats['inElems']
             if (not op.removed_in_optimization) and val_in_bpe != get_bpe(get_sim_dtype(op.precision)):
                 WARNING(

--- a/ttsim/utils/common.py
+++ b/ttsim/utils/common.py
@@ -219,7 +219,7 @@ def convert_units(val, from_unit, to_unit):
     return new_val
 
 def make_tuple(value, tuple_len):
-    if isinstance(value, tuple([tuple, list])):
+    if isinstance(value, (tuple, list)):
         if len(value) != tuple_len:
             raise RuntimeError(f'incompatible tuple/list with {len(value)} instead of {tuple_len} elements')
         return value

--- a/workloads/MapTracker/plugin/models/backbones/bevformer/custom_base_transformer_layer.py
+++ b/workloads/MapTracker/plugin/models/backbones/bevformer/custom_base_transformer_layer.py
@@ -686,7 +686,7 @@ class MyCustomBaseTransformerLayer(SimNN.Module):
 
         # Get embed_dims from first attention
         if len(self.attentions) > 0:
-            self.embed_dims = self.attentions[0].embed_dims
+            self.embed_dims = self.attentions[0].embed_dims # type: ignore[union-attr]
         else:
             self.embed_dims = ffn_cfgs.get("embed_dims", 256)
 


### PR DESCRIPTION
This PR takes into account tensor residency in `L1` for `MatMul` operation. The assumption is steady state in that the data is resident in `L1` and reused multiple times before being `read` into or `written` out to `DRAM`.