### PR TITLE
fix(449): spdxchecker skips .git pointer file in linked worktrees

### DIFF
--- a/tests/test_tools/test_spdxchecker.py
+++ b/tests/test_tools/test_spdxchecker.py
@@ -72,6 +72,32 @@ def test_collects_all_files_in_directory(tmp_path):
     (tmp_path / ".git" / "ignored_file").write_text("")
     assert collect_all_files(str(tmp_path)) == ["file1.py", "file2.js"]
 
+
+def test_collects_all_files_skips_git_pointer_file_in_worktree(tmp_path):
+    """In a linked git worktree, ``.git`` is a one-line pointer file at the root, not a directory.
+
+    The walker must skip it just like it skips the ``.git`` directory in a normal checkout.
+    """
+    (tmp_path / "file1.py").write_text("")
+    (tmp_path / "file2.js").write_text("")
+    # .git as a regular file (linked-worktree case)
+    (tmp_path / ".git").write_text("gitdir: /path/to/main-repo/.git/worktrees/some-name\n")
+    assert collect_all_files(str(tmp_path)) == ["file1.py", "file2.js"]
+
+
+def test_collects_all_files_does_not_descend_into_git_directory(tmp_path):
+    """os.walk should be pruned at .git so deep .git/ subtrees don't slow the SPDX check.
+
+    Confirms files nested several levels deep inside .git are not even visited (not just
+    skipped after visiting).  Regression guard for the `dirs.remove('.git')` prune.
+    """
+    (tmp_path / "file1.py").write_text("")
+    (tmp_path / ".git").mkdir()
+    nested = tmp_path / ".git" / "objects" / "ab" / "cd"
+    nested.mkdir(parents=True)
+    (nested / "deep_file.py").write_text("")
+    assert collect_all_files(str(tmp_path)) == ["file1.py"]
+
 def test_collects_git_status_files(tmp_path):
     res = get_active_files(True, ConfigFileModel()) # collect_git_status_files(True) != []
     assert isinstance(res, list)

--- a/tools/spdxchecker.py
+++ b/tools/spdxchecker.py
@@ -214,17 +214,32 @@ def collect_all_files(dirname: str) -> list[str]:
     files: list[str] = []
     filename: str
     root: str
-    _dirs: list[str]
+    dirs: list[str]
     filenames: list[str]
     # Normalize dirname to use forward slashes
     dirname_normalized = dirname.replace('\\', '/')
-    for root, _dirs, filenames in os.walk(dirname):
+    for root, dirs, filenames in os.walk(dirname):
+        # Prune .git from the walk so os.walk doesn't recurse into the
+        # (potentially large) .git/objects subtree on non-worktree checkouts.
+        # In linked worktrees .git is a one-line pointer file rather than a
+        # directory, so it's not in `dirs` and this no-ops there.  Mutating
+        # `dirs` in-place during top-down walk is the os.walk-documented way
+        # to skip a subtree.
+        if '.git' in dirs:
+            dirs.remove('.git')
         # Normalize root path
         root_normalized = root.replace('\\', '/')
-        # Skip .git directory; Only the startswith condition will wrongly match .gitHub directory
+        # Belt-and-suspenders: even with the prune above, keep the path-prefix
+        # skip in case os.walk is invoked elsewhere or a symlink reintroduces
+        # the directory.  The trailing slash on '/.git/' is intentional: it
+        # prevents the startswith from also matching '.gitHub' / '.gitignore_local/'.
         if root_normalized == dirname_normalized + '/.git' or root_normalized.startswith(dirname_normalized + '/.git/'):
             continue
         for filename in filenames:
+            # Skip the .git file at the worktree root (git creates this as a
+            # one-line pointer file in linked worktrees instead of a .git dir).
+            if filename == '.git' and root_normalized == dirname_normalized:
+                continue
             # Build relative path with forward slashes
             full_path = os.path.join(root, filename).replace('\\', '/')
             rel_path = os.path.relpath(full_path, dirname).replace(os.sep, '/')


### PR DESCRIPTION
## Summary

In a linked git worktree, `.git` is a one-line pointer file (not a directory). `tools/spdxchecker.py`'s walker was treating that file as a source file and failing the License/Copyright check on it — breaking every pre-commit attempt from a worktree.

This PR skips the `.git` filename when its parent directory is the worktree root. No behavior change for non-worktree checkouts (`.git` is a directory there and the existing dir-skip short-circuits before reaching the filename loop).

Closes #449.

## Test plan

- [x] `pre-commit run --all-files` from inside a worktree passes (verified during commit on this branch)
- [ ] `pre-commit run --all-files` from a non-worktree checkout still passes
- [ ] Existing `tests/test_tools/` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)