### PR TITLE
[TEST — DO NOT MERGE] ci(461): verify reduced CI on fork PRs

### DIFF
--- a/.github/workflows/checkin_tests.yml
+++ b/.github/workflows/checkin_tests.yml
@@ -21,6 +21,11 @@ jobs:
       PASS_REQUIRED: 95
       COVERAGE_YELLOW: 75
       COVERAGE_REQUIRED: 85
+      # Boolean gate for the lfcdownload step. `secrets.*` is not allowed in
+      # step-level `if:` expressions, so we materialise a boolean (NOT the
+      # secret value) here. On fork PRs the secret is empty per GitHub policy,
+      # so this resolves to 'false'. Issue #461.
+      HAS_LFC_SECRET: ${{ secrets.LFC_SERVER_URLS != '' }}
 
     runs-on: tt-ubuntu-2204-large-stable
     strategy:
@@ -37,10 +42,24 @@ jobs:
 
     - id: lfcdownload
       name: Download required files from LFC
+      # Skip on fork PRs where the secret is unavailable (GitHub policy: fork PRs
+      # cannot read secrets). Checkin tests exclude tools_secondary, the only
+      # marker that consumes LFC artifacts, so coverage on fork PRs is unaffected.
+      # See issue #461. Gate reads `env.HAS_LFC_SECRET` (set at job level above)
+      # because `secrets.*` is not allowed in step-level `if:` expressions.
+      if: ${{ env.HAS_LFC_SECRET == 'true' }}
       uses: ./.github/actions/lfcdownload
       with:
         files: 'ext_test_onnx_models.tar.gz ext_llk_elf_files.tar.gz'
         lfc-server-urls: ${{ secrets.LFC_SERVER_URLS }}
+
+    - id: lfcdownload-skip-notice
+      name: LFC download skipped (no secret available)
+      if: ${{ env.HAS_LFC_SECRET == 'false' }}
+      run: |
+        echo "::warning title=LFC download skipped::LFC_SERVER_URLS is not available (typical for fork PRs). LFC artifacts will NOT be downloaded for this run."
+        echo "Tests marked tools_secondary (which is the only marker that consumes LFC data) are already excluded from checkin runs, so test coverage is unaffected."
+        echo "Full CI including LFC-dependent tests runs at merge-queue time via the merge_group trigger, before any PR actually lands in main."
 
     - id: setup-mamba
       name: Setup mamba - developer


### PR DESCRIPTION
Verification PR for #461. Same commit as the canonical PR #462 but coming from a fork so CI runs without `secrets.LFC_SERVER_URLS` — to confirm the gate added in #462 behaves correctly on a real fork-PR code path.

## Expected outcome

- `lfcdownload` step shows status **skipped**
- `lfcdownload-skip-notice` step runs and emits a `::warning::` annotation visible in the run summary
- `run-unit-and-coverage-tests`, `run-static-analysis`, `upload-artifacts` all run and report normally (no LFC dependency)
- `check-overall-success` step passes — overall job status: PASSED

## Relationship to other PRs

- The canonical PR landing this change is **#462** (from `tenstorrent/polaris:461-…`). Review and merge that one, not this.
- Issue is **#461**.

This PR will be closed without merging once CI completes and the expected outcome is confirmed.