### PR TITLE
Titans MAC Port to Polaris 

### DIFF
--- a/config/ip_workloads.yaml
+++ b/config/ip_workloads.yaml
@@ -32,6 +32,50 @@ workloads:
       rn50_b1_hd : { img_height: 1024, img_width: 1024 }
       rn50_b1_uhd: { img_height: 2828, img_width: 2828 }
 
+  - api: TTSIM
+    name: TitansMAC
+    basedir: workloads/Titans
+    module : TitansMAC@mac_transformer.py
+    params :
+      vocab_sz                  : 256
+      drop_prob                 : 0.0
+      ff_mult                   : 4
+      segment_len               : 32
+      num_persist_mem_tokens    : 4
+      num_longterm_mem_tokens   : 0
+      neural_memory_layers      : [2, 4, 6]
+      neural_memory_segment_len : 4
+      mem_depth                 : 2
+      mem_expansion_factor      : 2.0
+      mem_heads                 : 4
+      mem_dim_head              : 64
+      mem_chunk_size            : 4
+      max_ttt_slices            : 16
+      bs                        : 1
+    instances:
+      titans_mac_nano  : { nL: 2,  nH: 4,  dE: 128, dim_head: 32, nW: 64,   mem_chunk_size: 8  }
+      titans_mac_micro : { nL: 4,  nH: 4,  dE: 256, dim_head: 64, nW: 128, mem_chunk_size: 8  }
+      titans_mac_small : { nL: 8,  nH: 8,  dE: 384, dim_head: 48, nW: 512, mem_chunk_size: 32  }  
+      titans_mac_base  : { nL: 12, nH: 12, dE: 768, dim_head: 64, nW: 1024, mem_chunk_size: 64  }
+      titans_mac_large : { nL: 24, nH: 16, dE: 1024, dim_head: 64, nW: 2048, mem_chunk_size: 128 }
+      titans_mac_xlarge : { nL: 24, nH: 16, dE: 1536, dim_head: 96, nW: 2048, mem_chunk_size: 128 }
+
+  - api: TTSIM
+    name: BasicLLM
+    basedir: workloads
+    module : BasicLLM@BasicLLM.py
+    params :
+      vocab_sz  : 256
+      drop_prob : 0.0
+      bs        : 1
+    instances:
+      basic_llm_titans_nano  : { nL: 2,  nH: 4,  dE: 128, nW: 64   }
+      basic_llm_titans_micro : { nL: 4,  nH: 4,  dE: 256, nW: 128  }
+      basic_llm_titans_small : { nL: 8,  nH: 8,  dE: 384, nW: 512  }
+      basic_llm_titans_base  : { nL: 12, nH: 12, dE: 768, nW: 1024 }
+      basic_llm_titans_large : { nL: 24, nH: 16, dE: 1024, nW: 2048 }
+      basic_llm_titans_xlarge : { nL: 24, nH: 16, dE: 1536, nW: 2048 }
+
   # generate resnet50.onnx using code in workloads/onnx/examples/:
   - api: ONNX
     name: RESNET50

--- a/tools/mac_util.py
+++ b/tools/mac_util.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""
+Compute MAC utilization for each workload model by scanning all STATS opstats.json files.
+
+Definition (for each op):
+- Actual MACs = value under op['instrs'].get('mac', 0) (falls back to op['instr_count'] if 'mac' missing)
+- Potential MACs = compute_capacity_per_cycle * compute_cycles
+
+Where compute_capacity_per_cycle is inferred per-op as:
+    compute_capacity_per_cycle = actual_macs / (compute_cycles * DG_COMPUTE_UTIL_CONSTANT)
+    with DG_COMPUTE_UTIL_CONSTANT = 0.6 (see polaris/tools/statattr.py and ttsim/back/device.py)
+
+Hence per-op utilization simplifies to DG_COMPUTE_UTIL_CONSTANT when compute is the bottleneck.
+However, for memory- or NA-bounded ops (cycles == 0), we consider only compute cycles component.
+
+We will compute:
+- Sum(actual_macs) / Sum(potential_macs) across ops in each file
+- Aggregate by model directory (parent of STATS) as well
+
+Outputs a concise table.
+"""
+
+import argparse
+import json
+import math
+import os
+from typing import Dict, Tuple, List
+
+
+DG_COMPUTE_UTIL_CONSTANT = 0.6
+
+# Cache for device peak IPC lookups: {(model_dir, devname): mapping[(pipe, instr, prec)] -> peak_macs_per_cycle}
+_DEV_IPC_CACHE: Dict[Tuple[str, str], Dict[Tuple[str, str, str], float]] = {}
+
+
+def iter_opstats_json_files(root_dir: str) -> List[str]:
+    results: List[str] = []
+    for dirpath, dirnames, filenames in os.walk(root_dir):
+        if os.path.basename(dirpath).upper() == "STATS":
+            for fn in filenames:
+                if fn.endswith(".json") and fn.endswith("-opstats.json"):
+                    results.append(os.path.join(dirpath, fn))
+    return sorted(results)
+
+
+def load_json(path: str):
+    with open(path, "r") as f:
+        return json.load(f)
+
+
+def extract_ops(doc: Dict) -> List[Dict]:
+    ops = doc.get("operatorstats")
+    if isinstance(ops, list):
+        return ops
+    # Some CSV-driven or alternative formats may store in another key; fallback to empty
+    return []
+
+
+def get_actual_macs(op: Dict) -> int:
+    # Use total instruction count as proxy for MACs per user request
+    # This matches conv ops exactly and is close for others; we will filter to MAC-issuing ops
+    return int(op.get("instr_count", 0))
+
+
+def get_total_operations(op: Dict) -> int:
+    # Get total operations from instr_count (includes all instruction types, not just MACs)
+    return int(op.get("instr_count", 0))
+
+
+def get_compute_cycles(op: Dict) -> float:
+    # prefer explicit compute_cycles
+    cc = op.get("compute_cycles")
+    if cc is None:
+        return 0.0
+    try:
+        return float(cc)
+    except Exception:
+        return 0.0
+
+
+def get_total_cycles(op: Dict) -> float:
+    # total cycles field used in STATS CSV is 'cycles'; JSON has it as well
+    cyc = op.get("cycles")
+    try:
+        return float(cyc) if cyc is not None else 0.0
+    except Exception:
+        return 0.0
+
+
+def get_model_dir_from_stats_path(stats_path: str) -> str:
+    # stats path: .../<model>/STATS/<file>
+    return os.path.basename(os.path.dirname(os.path.dirname(stats_path)))
+
+
+def load_dev_ipc_table(model_root: str, devname: str) -> Dict[Tuple[str, str, str], float]:
+    """Load device peak IPC table from CONFIG/<devname>.json under the given model root.
+
+    Returns mapping: (pipe_lower, instr_lower, precision_lower) -> device_peak_macs_per_cycle
+    device_peak_macs_per_cycle = ipgroup.num_units * pipe.num_units * pipe.systolic_depth * insn.tpt[precision]
+    """
+    cache_key = (model_root, devname)
+    if cache_key in _DEV_IPC_CACHE:
+        return _DEV_IPC_CACHE[cache_key]
+
+    cfg_path = os.path.join(model_root, "CONFIG", f"{devname}.json")
+    if not os.path.isfile(cfg_path):
+        # Some repos may store configs elsewhere; return empty to skip potential calc
+        _DEV_IPC_CACHE[cache_key] = {}
+        return _DEV_IPC_CACHE[cache_key]
+
+    cfg = load_json(cfg_path)
+    ipgroups = cfg.get("ipgroups", [])
+    compute_groups = [g for g in ipgroups if g.get("iptype") == "compute"]
+    if not compute_groups:
+        _DEV_IPC_CACHE[cache_key] = {}
+        return _DEV_IPC_CACHE[cache_key]
+
+    cg = compute_groups[0]
+    dev_num_units = int(cg.get("num_units", 1))
+    ipobj = cg.get("ipobj", {})
+    pipes = ipobj.get("pipes", [])
+
+    table: Dict[Tuple[str, str, str], float] = {}
+    for pipe in pipes:
+        pipe_name = str(pipe.get("name", "")).lower()
+        pipe_units = int(pipe.get("num_units", 1))
+        pipe_sd    = int(pipe.get("systolic_depth", 1) or 1)
+        for ins in pipe.get("instructions", []):
+            instr_name = str(ins.get("name", "")).lower()
+            tpt = ins.get("tpt", {}) or {}
+            for prec, val in tpt.items():
+                try:
+                    prec_l = str(prec).lower()
+                    v = float(val)
+                except Exception:
+                    continue
+                peak = dev_num_units * pipe_units * pipe_sd * v
+                table[(pipe_name, instr_name, prec_l)] = peak
+
+    _DEV_IPC_CACHE[cache_key] = table
+    return table
+
+
+def op_issues_mac(op: Dict) -> bool:
+    instrs = op.get("instrs", {}) or {}
+    macs = instrs.get("mac", 0)
+    try:
+        return int(macs) > 0
+    except Exception:
+        return False
+
+
+def compute_file_util(path: str, root_dir: str) -> Tuple[int, float, float, float]:
+    """Return (num_counted_ops, sum_actual_macs, sum_potential_macs, sum_total_operations).
+
+    We consider only MAC-issuing ops (instrs.mac > 0). Potential MACs = device_peak_macs_per_cycle * total op cycles.
+    Device peak MACs/cycle derived from the model's CONFIG/<devname>.json.
+    Total operations include all instruction types across all ops.
+    """
+    doc = load_json(path)
+    ops = extract_ops(doc)
+
+    devname = str(doc.get("name", doc.get("devname", "")))
+    # get model dir and load device IPC table
+    model_dir_name = get_model_dir_from_stats_path(path)
+    model_root = os.path.join(root_dir, model_dir_name)
+    dev_ipc_tbl = load_dev_ipc_table(model_root, devname)
+
+    counted_ops = 0
+    sum_actual = 0.0
+    sum_potential = 0.0
+    sum_total_ops = 0.0
+
+    # First pass: calculate total operations across ALL ops (not just MAC-issuing ones)
+    for op in ops:
+        sum_total_ops += get_total_operations(op)
+
+    # Second pass: calculate MAC-specific metrics for MAC-issuing ops only
+    for op in ops:
+        if not op_issues_mac(op):
+            continue
+        cycles_total = get_total_cycles(op)
+        if cycles_total <= 0:
+            # no time spent → no potential capacity contribution
+            continue
+
+        actual_macs = get_actual_macs(op)
+        op_pipe = str(op.get("pipe", "")).lower()
+        op_prec = str(op.get("precision", "")).lower()
+
+        # prefer matrix.mac throughput; if missing, try any mac entry for the pipe
+        peak_ipc = 0.0
+        for key in [
+            (op_pipe, "mac", op_prec),
+            (op_pipe, "mac", "int8"),
+            (op_pipe, "mac", "bf16"),
+            ("matrix", "mac", op_prec),
+        ]:
+            if key in dev_ipc_tbl:
+                peak_ipc = dev_ipc_tbl[key]
+                break
+
+        if peak_ipc <= 0:
+            # cannot compute potential for this op without device IPC
+            continue
+
+        potential_macs = peak_ipc * cycles_total
+
+        counted_ops += 1
+        sum_actual += actual_macs
+        sum_potential += potential_macs
+
+    return (counted_ops, float(sum_actual), float(sum_potential), float(sum_total_ops))
+
+
+def compute_file_record(path: str, root_dir: str) -> Dict:
+    """Return a dict with metadata and computed utilization for a single file."""
+    doc = load_json(path)
+
+    # Meta fields (robust to naming differences)
+    devname = doc.get("devname", "NA")
+    freq = doc.get("freq_MHz", doc.get("freq_Mhz", None))
+    wlgroup = doc.get("wlgroup", doc.get("wlcls", "NA"))
+    wlname = doc.get("wlname", "NA")
+    wlinstance = doc.get("wlinstance", "NA")
+    batch = doc.get("batch", None)
+
+    return {
+        "devname": devname,
+        "freq_MHz": freq,
+        "wlgroup": wlgroup,
+        "wlname": wlname,
+        "wlinstance": wlinstance,
+        "batch": batch,
+        "stat_file": os.path.relpath(path, root_dir),
+        # The following fields will be filled by caller after compute_file_util
+        "sum_actual_MACs": 0,
+        "sum_potential_MACs": 0,
+        "utilization": 0.0,
+        "total_operations": 0,
+    }
+
+
+def compute_op_level_util(path: str, root_dir: str) -> List[Dict]:
+    """Return per-op utilization rows for a given opstats file.
+
+    Returns rows with keys: opname, pipe, precision, instr_count, cycles, actual_macs, potential_macs, utilization
+    """
+    doc = load_json(path)
+    ops = extract_ops(doc)
+
+    devname = str(doc.get("name", doc.get("devname", "")))
+    model_dir_name = get_model_dir_from_stats_path(path)
+    model_root = os.path.join(root_dir, model_dir_name)
+    dev_ipc_tbl = load_dev_ipc_table(model_root, devname)
+
+    out_rows: List[Dict] = []
+    for op in ops:
+        if not op_issues_mac(op):
+            continue
+        cycles_total = get_total_cycles(op)
+        if cycles_total <= 0:
+            continue
+
+        actual_macs = get_actual_macs(op)
+        op_pipe = str(op.get("pipe", "")).lower()
+        op_prec = str(op.get("precision", "")).lower()
+        peak_ipc = 0.0
+        for key in [
+            (op_pipe, "mac", op_prec),
+            (op_pipe, "mac", "int8"),
+            (op_pipe, "mac", "bf16"),
+            ("matrix", "mac", op_prec),
+        ]:
+            if key in dev_ipc_tbl:
+                peak_ipc = dev_ipc_tbl[key]
+                break
+        if peak_ipc <= 0:
+            continue
+        potential_macs = peak_ipc * cycles_total
+        util = (actual_macs / potential_macs) if potential_macs > 0 else 0.0
+
+        out_rows.append({
+            "opname": op.get("opname", ""),
+            "pipe": op.get("pipe", ""),
+            "precision": op.get("precision", ""),
+            "instr_count": int(op.get("instr_count", 0)),
+            "total_operations": int(get_total_operations(op)),
+            "cycles": float(op.get("cycles", 0.0)),
+            "actual_macs": int(actual_macs),
+            "potential_macs": int(potential_macs),
+            "utilization": util,
+        })
+
+    return out_rows
+
+
+def write_reports(records: List[Dict], root_dir: str) -> None:
+    """Write per-model and per-target CSVs under each model's REPORTS directory.
+
+    Layout:
+        <root>/<model>/REPORTS/mac_util_<devname>.csv
+
+    Each CSV contains per-file rows and a TOTAL row.
+    """
+    # Group by model and devname (target)
+    by_model: Dict[str, Dict[str, List[Dict]]] = {}
+    for rec in records:
+        # resolve absolute path from rel stat_file to find model dir
+        abs_path = os.path.join(root_dir, rec["stat_file"])  # .../<model>/STATS/<file>
+        model_dir = os.path.basename(os.path.dirname(os.path.dirname(abs_path)))
+        devname = rec.get("devname", "NA")
+        if model_dir not in by_model:
+            by_model[model_dir] = {}
+        if devname not in by_model[model_dir]:
+            by_model[model_dir][devname] = []
+        by_model[model_dir][devname].append(rec)
+
+    # Write CSVs
+    header = [
+        "devname","freq_MHz","wlgroup","wlname","wlinstance","batch",
+        "stat_file","sum_actual_MACs","sum_potential_MACs","utilization","total_operations"
+    ]
+
+    for model, targets in by_model.items():
+        reports_dir = os.path.join(root_dir, model, "REPORTS")
+        os.makedirs(reports_dir, exist_ok=True)
+
+        for devname, rows in targets.items():
+            out_path = os.path.join(reports_dir, f"mac_util_{devname}.csv")
+            # aggregate totals per target
+            tot_actual = sum(r["sum_actual_MACs"] for r in rows)
+            tot_potential = sum(r["sum_potential_MACs"] for r in rows)
+            tot_util = (tot_actual / tot_potential) if tot_potential > 0 else 0.0
+            tot_operations = sum(r["total_operations"] for r in rows)
+
+            with open(out_path, "w") as f:
+                f.write(",".join(header) + "\n")
+                for r in sorted(rows, key=lambda x: (str(x.get("freq_MHz")), x["stat_file"])):
+                    f.write(
+                        f"{r['devname']},{r.get('freq_MHz','')},{r['wlgroup']},{r['wlname']},{r['wlinstance']},{r.get('batch','')},{r['stat_file']},{r['sum_actual_MACs']},{r['sum_potential_MACs']},{r['utilization']:.6f},{r['total_operations']}\n"
+                    )
+                # TOTAL row
+                f.write(
+                    f"TOTAL,ALL,,,{model},,{devname},"  # keep columns aligned but mark aggregation
+                )
+                # the above columns do not map 1:1; pad with empties to align numeric columns
+                # Reconstruct a consistent row with blanks for non-numeric
+                # Format: devname,freq_MHz,wlgroup,wlname,wlinstance,batch,stat_file,sum_actual,sum_potential,util
+                # We'll rewrite the TOTAL line properly:
+            with open(out_path, "a") as f:
+                f.write(f"TOTAL,ALL,,,,,TOTAL,{tot_actual},{tot_potential},{tot_util:.6f},{tot_operations}\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Calculate MAC utilization across STATS opstats JSONs")
+    parser.add_argument(
+        "--root",
+        type=str,
+        default=os.path.join(os.path.dirname(__file__), "rfi_runs"),
+        help="Root directory to search under (default: <repo>/rfi_runs)",
+    )
+    parser.add_argument(
+        "--by_model",
+        action="store_true",
+        help="Aggregate and print per-model summaries (parent folder of STATS)",
+    )
+    parser.add_argument(
+        "--write_reports",
+        action="store_true",
+        help="Write per-model per-target CSV reports under each model's REPORTS directory",
+    )
+    parser.add_argument(
+        "--write_op_reports",
+        action="store_true",
+        help="Write per-op MAC utilization CSVs under each model's REPORTS directory",
+    )
+    args = parser.parse_args()
+
+    files = iter_opstats_json_files(args.root)
+    if not files:
+        print(f"No STATS opstats JSON files found under: {args.root}")
+        return
+
+    # per-file output
+    print("Per-file MAC Utilization and Total Operations:")
+    print("file,sum_actual_MACs,sum_potential_MACs,utilization,total_operations")
+
+    # group by model (two levels up: .../<model>/STATS/<file>)
+    model_aggr: Dict[str, Tuple[float, float, float, int]] = {}  # (actual, potential, total_ops, count)
+    records: List[Dict] = []
+
+    for fpath in files:
+        num_ops, s_actual, s_potential, s_total_ops = compute_file_util(fpath, args.root)
+        util = (s_actual / s_potential) if s_potential > 0 else 0.0
+        print(f"{os.path.relpath(fpath, args.root)},{int(s_actual)},{int(s_potential)},{util:.6f},{int(s_total_ops)}")
+
+        # build detailed record for reporting
+        rec = compute_file_record(fpath, args.root)
+        rec["sum_actual_MACs"] = int(s_actual)
+        rec["sum_potential_MACs"] = int(s_potential)
+        rec["utilization"] = util
+        rec["total_operations"] = int(s_total_ops)
+        records.append(rec)
+
+        if args.by_model:
+            # model dir is parent of STATS
+            model_dir = os.path.basename(os.path.dirname(os.path.dirname(fpath)))
+            if model_dir not in model_aggr:
+                model_aggr[model_dir] = (0.0, 0.0, 0.0, 0)
+            a, p, t, n = model_aggr[model_dir]
+            model_aggr[model_dir] = (a + s_actual, p + s_potential, t + s_total_ops, n + 1)
+
+    if args.by_model:
+        print("\nPer-model Aggregated MAC Utilization:")
+        print("model,sum_actual_MACs,sum_potential_MACs,utilization,total_operations,num_files")
+        for model, (a, p, t, n) in sorted(model_aggr.items()):
+            util = (a / p) if p > 0 else 0.0
+            print(f"{model},{int(a)},{int(p)},{util:.6f},{int(t)},{n}")
+
+    if args.write_reports:
+        write_reports(records, args.root)
+
+    if args.write_op_reports:
+        # For each file, write per-op CSV next to model reports
+        for rec in records:
+            rel = rec["stat_file"]  # <model>/STATS/<file>.json
+            abs_path = os.path.join(args.root, rel)
+            model = os.path.basename(os.path.dirname(os.path.dirname(abs_path)))
+            dev = rec.get("devname", "NA")
+            reports_dir = os.path.join(args.root, model, "REPORTS")
+            os.makedirs(reports_dir, exist_ok=True)
+            stem = os.path.splitext(os.path.basename(abs_path))[0]
+            out_csv = os.path.join(reports_dir, f"op_mac_util_{dev}_{stem}.csv")
+            rows = compute_op_level_util(abs_path, args.root)
+            if rows:
+                header = ["opname","pipe","precision","instr_count","total_operations","cycles","actual_macs","potential_macs","utilization"]
+                with open(out_csv, "w") as f:
+                    f.write(",".join(header) + "\n")
+                    for r in rows:
+                        f.write(f"{r['opname']},{r['pipe']},{r['precision']},{r['instr_count']},{r['total_operations']},{r['cycles']},{r['actual_macs']},{r['potential_macs']},{r['utilization']:.6f}\n")
+
+
+if __name__ == "__main__":
+    main()
+
+

--- a/workloads/Titans/mac_transformer.py
+++ b/workloads/Titans/mac_transformer.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""
+TTSim port of titans_pytorch.mac_transformer
+
+- SegmentedAttention   : local/segment causal attention + persistent memory K/V
+- MemoryAsContextTransformer : full MAC stack
+"""
+import os, sys, math
+from typing import Any
+sys.path.append(os.path.join(os.path.dirname(__file__), '../..'))
+
+import numpy as np
+import ttsim.front.functional.op as F
+import ttsim.front.functional.tensor_op as T
+import ttsim.front.functional.sim_nn as SimNN
+
+from workloads.Titans.neural_memory import NeuralMemory, _RMSNorm
+from workloads.Titans.memory_models import MemoryMLP
+
+class FeedForward(SimNN.Module):
+    def __init__(self, name, dim, mult=4):
+        super().__init__()
+        self.name = name
+        dim_inner = int(dim * mult * 2 / 3)
+        self.norm  = _RMSNorm(f'{name}.norm', dim)
+        self.proj_in  = SimNN.Linear(f'{name}.proj_in', dim, dim_inner * 2)
+        self.split    = F.SplitOpHandle(f'{name}.split', count=2, axis=2)
+        self.silu     = F.Sigmoid(f'{name}.silu_sig')   # we use sigmoid * x as silu
+        self.mul_silu = F.Mul(f'{name}.mul_silu')
+        self.mul_gate = F.Mul(f'{name}.mul_gate')
+        self.proj_out = SimNN.Linear(f'{name}.proj_out', dim_inner, dim)
+        self.dim = dim
+        self.dim_inner = dim_inner
+        super().link_op2module()
+
+    def __call__(self, x):
+        x = self.norm(x)
+        h = self.proj_in(x)
+        a, gate = self.split(h)
+        gate_silu = self.mul_silu(gate, self.silu(gate))
+        h = self.mul_gate(a, gate_silu)
+        return self.proj_out(h)
+
+    def analytical_param_count(self, lvl=0):
+        pc  = self.proj_in.analytical_param_count(lvl + 1)
+        pc += self.proj_out.analytical_param_count(lvl + 1)
+        pc += self.norm.analytical_param_count(lvl + 1)
+        return pc
+
+class SegmentedAttention(SimNN.Module):
+    def __init__(self, name, dim, segment_len,
+                 num_persist_mem_tokens=0, num_longterm_mem_tokens=0,
+                 dim_head=64, heads=8):
+        super().__init__()
+        self.name = name
+        self.dim  = dim
+        self.dim_head = dim_head
+        self.heads    = heads
+        self.dim_inner= dim_head * heads
+        self.segment_len             = segment_len
+        self.num_persist_mem_tokens  = num_persist_mem_tokens
+        self.num_longterm_mem_tokens = num_longterm_mem_tokens
+        self.total_segment_len       = segment_len + num_longterm_mem_tokens
+
+        self.norm   = _RMSNorm(f'{name}.norm', dim)
+        self.to_qkv = SimNN.Linear(f'{name}.to_qkv', dim, self.dim_inner * 3)
+        self.split  = F.SplitOpHandle(f'{name}.qkv_split', count=3, axis=2)
+        self.softmax= F.Softmax(f'{name}.softmax')
+        self.to_out = SimNN.Linear(f'{name}.to_out', self.dim_inner, dim)
+        self.attn_scale = F._from_data(f'{name}.attn_scale',
+                                       data=np.float32(1.0 / math.sqrt(dim_head)))
+        self.qk_mm = F.MatMul(f'{name}.qk_mm')
+        self.av_mm = F.MatMul(f'{name}.av_mm')
+
+        if num_persist_mem_tokens > 0:
+            self.persistent_k = F._from_shape(f'{name}.persistent_k',
+                                              shape=[1, heads, num_persist_mem_tokens, dim_head],
+                                              is_param=True)
+            self.persistent_v = F._from_shape(f'{name}.persistent_v',
+                                              shape=[1, heads, num_persist_mem_tokens, dim_head],
+                                              is_param=True)
+        else:
+            self.persistent_k = None  # type: ignore[assignment]
+            self.persistent_v = None  # type: ignore[assignment]
+        super().link_op2module()
+
+    def __call__(self, x):
+        B, N, D = x.shape
+        H, Dh   = self.heads, self.dim_head
+        x = self.norm(x)
+        qkv = self.to_qkv(x)
+        Q, K, V = self.split(qkv)
+        Q = Q.reshape(B, N, H, Dh).transpose(1, 2)
+        K = K.reshape(B, N, H, Dh).transpose(1, 2)
+        V = V.reshape(B, N, H, Dh).transpose(1, 2)
+
+        # prepend persistent memory K/V
+        if self.persistent_k is not None:
+            pmk = self.persistent_k  
+            pmv = self.persistent_v
+            K = T.cat([pmk, K], dim=-2)
+            V = T.cat([pmv, V], dim=-2)
+
+        scores = self.qk_mm(Q, K.transpose(-1, -2)) * self.attn_scale
+        attn   = self.softmax(scores)
+        out    = self.av_mm(attn, V)
+        out    = out.transpose(1, 2).reshape(B, N, H * Dh)
+        return self.to_out(out)
+
+    def analytical_param_count(self, lvl=0):
+        pc  = self.to_qkv.analytical_param_count(lvl + 1)
+        pc += self.to_out.analytical_param_count(lvl + 1)
+        pc += self.norm.analytical_param_count(lvl + 1)
+        if self.persistent_k is not None:
+            pc += 2 * self.heads * self.num_persist_mem_tokens * self.dim_head
+        return pc
+
+class MACBlock(SimNN.Module):
+    def __init__(self, name, dim, segment_len, dim_head, heads, ff_mult,
+                 num_persist_mem_tokens, num_longterm_mem_tokens,
+                 use_neural_memory, neural_memory_segment_len,
+                 mem_depth, mem_expansion_factor, mem_heads, mem_dim_head,
+                 mem_chunk_size,
+                 max_chunks_unroll = 16):
+        super().__init__()
+        self.name = name
+        self.use_mem = use_neural_memory
+        if use_neural_memory:
+            self.mem = NeuralMemory(
+                name       = f'{name}.mem',
+                dim        = dim,
+                chunk_size = mem_chunk_size,
+                dim_head   = mem_dim_head,
+                heads      = mem_heads,
+                depth      = mem_depth,
+                expansion_factor = mem_expansion_factor,
+                max_chunks_unroll = max_chunks_unroll,
+            )
+            self.add_mem = F.Add(f'{name}.add_mem')
+        else:
+            self.mem = None  # type: ignore[assignment]
+
+        self.attn    = SegmentedAttention(
+            name=f'{name}.attn', dim=dim, segment_len=segment_len,
+            num_persist_mem_tokens=num_persist_mem_tokens,
+            num_longterm_mem_tokens=num_longterm_mem_tokens,
+            dim_head=dim_head, heads=heads)
+        self.add_attn= F.Add(f'{name}.add_attn')
+        self.ff      = FeedForward(f'{name}.ff', dim, mult=ff_mult)
+        self.add_ff  = F.Add(f'{name}.add_ff')
+        super().link_op2module()
+
+    def __call__(self, x, mem_state=None):
+        if self.use_mem:
+            retrieved, mem_state = self.mem(x, state=mem_state)
+            x = self.add_mem(x, retrieved)
+        x = self.add_attn(x, self.attn(x))
+        x = self.add_ff  (x, self.ff(x))
+        return x, mem_state
+
+    def analytical_param_count(self, lvl=0):
+        pc = 0
+        if self.use_mem:
+            pc += self.mem.analytical_param_count(lvl + 1)
+        pc += self.attn.analytical_param_count(lvl + 1)
+        pc += self.ff.analytical_param_count(lvl + 1)
+        return pc
+
+class MemoryAsContextTransformer(SimNN.Module):
+    def __init__(self, name, cfg):
+        super().__init__()
+        self.name = name
+        self.cfg  = cfg
+        self.vocab_sz = cfg['vocab_sz']
+        self.dim      = cfg['dE']
+        self.nL       = cfg['nL']
+        self.nL_proxy = 1 if self.nL > 1 else self.nL   # BasicLLM-style proxy
+        self.nH       = cfg['nH']
+        self.dim_head = cfg.get('dim_head', self.dim // self.nH)
+        self.nW       = cfg['nW']                       # seq_len
+        self.bs       = cfg['bs']
+        self.ff_mult  = cfg.get('ff_mult', 4)
+        self.segment_len            = cfg['segment_len']
+        self.num_persist_mem_tokens = cfg.get('num_persist_mem_tokens', 0)
+        self.num_longterm_mem_tokens= cfg.get('num_longterm_mem_tokens', 0)
+        self.neural_memory_layers   = set(cfg.get('neural_memory_layers',
+                                                   list(range(1, self.nL_proxy + 1))))
+        self.neural_memory_segment_len = cfg.get('neural_memory_segment_len',
+                                                  self.segment_len + self.num_longterm_mem_tokens)
+        self.mem_depth        = cfg.get('mem_depth', 2)
+        self.mem_expansion    = cfg.get('mem_expansion_factor', 2.0)
+        self.mem_heads        = cfg.get('mem_heads', 4)
+        self.mem_dim_head     = cfg.get('mem_dim_head', 64)
+        self.mem_chunk_size   = cfg.get('mem_chunk_size', self.neural_memory_segment_len)
+        self.max_chunks_unroll = cfg.get('max_chunks_unroll', 16)
+
+        self.wte = F.Embedding('wte', self.vocab_sz, self.dim)
+        self.wpe = F.Embedding('wpe', self.nW, self.dim)
+        self.add_emb = F.Add('add_emb')
+
+        # longterm memory tokens (learnable)
+        if self.num_longterm_mem_tokens > 0:
+            self.longterm_mems = F._from_shape(
+                'longterm_mems',
+                shape=[1, self.num_longterm_mem_tokens, self.dim], is_param=True)
+        else:
+            self.longterm_mems = None  # type: ignore[assignment]
+
+        mem_layer_set = set(self.neural_memory_layers)
+        all_layers    = set(range(1, self.nL + 1))
+        self._n_mem_layers   = len(mem_layer_set & all_layers)
+        self._n_nomem_layers = self.nL - self._n_mem_layers
+
+        self.blocks = SimNN.ModuleList([
+            MACBlock(
+                name='t_mem',
+                dim=self.dim, segment_len=self.segment_len,
+                dim_head=self.dim_head, heads=self.nH, ff_mult=self.ff_mult,
+                num_persist_mem_tokens=self.num_persist_mem_tokens,
+                num_longterm_mem_tokens=self.num_longterm_mem_tokens,
+                use_neural_memory=True,
+                neural_memory_segment_len=self.neural_memory_segment_len,
+                mem_depth=self.mem_depth,
+                mem_expansion_factor=self.mem_expansion,
+                mem_heads=self.mem_heads,
+                mem_dim_head=self.mem_dim_head,
+                mem_chunk_size=self.mem_chunk_size,
+                max_chunks_unroll=self.max_chunks_unroll,
+            ),
+            MACBlock(
+                name='t_nomem',
+                dim=self.dim, segment_len=self.segment_len,
+                dim_head=self.dim_head, heads=self.nH, ff_mult=self.ff_mult,
+                num_persist_mem_tokens=self.num_persist_mem_tokens,
+                num_longterm_mem_tokens=self.num_longterm_mem_tokens,
+                use_neural_memory=False,
+                neural_memory_segment_len=self.neural_memory_segment_len,
+                mem_depth=self.mem_depth,
+                mem_expansion_factor=self.mem_expansion,
+                mem_heads=self.mem_heads,
+                mem_dim_head=self.mem_dim_head,
+                mem_chunk_size=self.mem_chunk_size,
+                max_chunks_unroll=self.max_chunks_unroll,
+            ),
+        ])
+        self._block_repeat_counts = [self._n_mem_layers, self._n_nomem_layers]
+
+        self.final_norm = _RMSNorm('final_norm', self.dim)
+        self.to_logits  = SimNN.Linear('to_logits', self.dim, self.vocab_sz, bias=False) \
+            if hasattr(SimNN.Linear, 'bias') else SimNN.Linear('to_logits', self.dim, self.vocab_sz)
+
+        self.input_tensors = {}
+        super().link_op2module()
+
+    def set_batch_size(self, new_bs):
+        self.bs = new_bs
+
+    def create_input_tensors(self):
+        self.input_tensors = {
+            'tokens': F._from_shape('tokens', [self.bs, self.nW], is_param=False, np_dtype=np.int64),
+            'mask'  : F._from_shape('mask',   [self.bs, self.nW], is_param=False, np_dtype=np.int64),
+        }
+
+    def get_forward_graph(self):
+        return super()._get_forward_graph(self.input_tensors)
+
+    def __call__(self):
+        assert len(self.input_tensors) == 2, "call create_input_tensors() first"
+        tok = self.input_tensors['tokens']
+        pos = self.input_tensors['mask']
+        x = self.add_emb(self.wte(tok), self.wpe(pos))
+
+        if self.longterm_mems is not None:
+            x = T.cat([self.longterm_mems, x], dim=1)
+
+        for blk in self.blocks:
+            x, _ = blk(x, mem_state=None)
+
+        for blk, rc in zip(self.blocks, self._block_repeat_counts):
+            if rc == 0:
+                continue
+            repeated_ops: dict[str, Any] = {}
+            blk.get_ops(repeated_ops)
+            for _, op_obj in repeated_ops.items():
+                op_obj.repeat_count = rc
+
+        x = self.final_norm(x)
+        return self.to_logits(x)
+
+    def analytical_param_count(self, lvl=0):
+        pc = 0
+        pc += self.vocab_sz * self.dim
+        pc += self.nW * self.dim
+        if self.longterm_mems is not None:
+            pc += self.num_longterm_mem_tokens * self.dim
+        pc += sum(b.analytical_param_count(lvl + 1) for b in self.blocks) * self.nL  # type: ignore[attr-defined]
+        pc += self.dim
+        pc += self.dim * self.vocab_sz
+        return pc
+
+
+class TitansMAC(MemoryAsContextTransformer):
+    """Polaris workload class. Same surface as BasicLLM:
+       __init__(name, cfg) / set_batch_size / create_input_tensors /
+       get_forward_graph / __call__ / analytical_param_count.
+    """
+    pass
+
+
+if __name__ == '__main__':
+    cfg = dict(
+        nL=2, nH=4, dE=128, dim_head=32, nW=32, vocab_sz=256, bs=1,
+        segment_len=8,
+        num_persist_mem_tokens=4,
+        num_longterm_mem_tokens=4,
+        neural_memory_layers=[2],
+        neural_memory_segment_len=4,
+        mem_depth=2, mem_expansion_factor=2.0, mem_heads=2, mem_dim_head=32,
+        mem_chunk_size=4,
+    )
+    m = TitansMAC('titans_mac', cfg)
+    m.create_input_tensors()
+    y = m()
+    print('Output shape:', y.shape)
+    print(f'#Params = {m.analytical_param_count():,d}')

--- a/workloads/Titans/memory_models.py
+++ b/workloads/Titans/memory_models.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""
+TTSim port of titans_pytorch/memory_models.py
+- MemoryMLP : the small 2-layer MLP whose weights ARE the neural memory
+- ResidualNorm : LayerNorm(model(x)) + x wrapper (TTT-paper convention)
+Only MemoryMLP is wired into NeuralMemory by default.
+Other variants (GatedResidualMemoryMLP, FactorizedMemoryMLP, MemorySwiGluMLP,
+MemoryAttention) can be added later with the same SimNN.Module pattern.
+"""
+import os, sys
+sys.path.append(os.path.join(os.path.dirname(__file__), '../..'))
+
+import ttsim.front.functional.op as F
+import ttsim.front.functional.sim_nn as SimNN
+
+class ResidualNorm(SimNN.Module):
+    """LayerNorm(model(x)) + x.  Used by NeuralMemory when mem_model_norm_add_residual=True."""
+    def __init__(self, name, dim, model):
+        super().__init__()
+        self.name  = name
+        self.dim   = dim
+        self.model = model
+        self.norm  = F.LayerNorm(f'{name}.ln', dim)
+        self.add   = F.Add(f'{name}.add_res')
+        super().link_op2module()
+
+    def __call__(self, x):
+        out = self.model(x)
+        return self.add(self.norm(out), x)
+
+    def analytical_param_count(self, lvl=0):
+        return 2 * self.dim + self.model.analytical_param_count(lvl + 1)
+
+class MemoryMLP(SimNN.Module):
+    """
+    Reference: titans_pytorch.memory_models.MemoryMLP
+
+    depth-layer MLP, GELU between layers, no bias.
+    Input/output dim == dim (i.e. dim_head of NeuralMemory).
+    """
+    def __init__(self, name, dim, depth, expansion_factor=2.0):
+        super().__init__()
+        self.name  = name
+        self.dim   = dim
+        self.depth = depth
+        dim_hidden = int(dim * expansion_factor)
+        dims       = [dim] + [dim_hidden] * (depth - 1) + [dim]
+        self.dims  = dims
+
+        self.matmuls = []
+        self.gelus   = []
+        for i in range(depth):
+            mm = F.MatMul(f'{name}.W{i}')
+            w  = F._from_shape(f'{name}.W{i}.param', shape=[dims[i], dims[i + 1]], is_param=True)
+            setattr(self, f'_W{i}', w)
+            setattr(self, f'mm{i}', mm)
+            self.matmuls.append((mm, w))
+            if i < depth - 1:
+                g = F.Gelu(f'{name}.gelu{i}')
+                setattr(self, f'gelu{i}', g)
+                self.gelus.append(g)
+        super().link_op2module()
+
+    def __call__(self, x):
+        out = x
+        for i, (mm, w) in enumerate(self.matmuls):
+            if i > 0:
+                out = self.gelus[i - 1](out)
+            out = mm(out, w)
+        return out
+
+    def analytical_param_count(self, lvl=0):
+        return sum(self.dims[i] * self.dims[i + 1] for i in range(self.depth))

--- a/workloads/Titans/neural_memory.py
+++ b/workloads/Titans/neural_memory.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""
+TTSim port of titans_pytorch/neural_memory.NeuralMemory
+  - Memory IS the weights of a small MLP (MemoryMLP).
+  - store_memories chunk-by-chunk:
+       (a) project seq -> keys, values, adaptive_lr, decay_factor
+       (b) per-chunk: forward MemoryMLP on keys, compute (pred - v)^2 loss,
+           derive grads dL/dW for each W in MemoryMLP via explicit chain-rule
+           matmuls (cheap to emit, correct shapes/FLOPs for perf projection).
+       (c) momentum accumulation:  M_t = a * M_{t-1} + grad_t       (one step per chunk)
+       (d) decay-based weight update: W_t = (1-decay) * W_{t-1} + M_t
+  - retrieve_memories:
+       q = Linear(norm(seq)); out = MemoryMLP(q | W_current); merge_heads.
+
+Forward-only. State (NeuralMemState) is a 5-tuple of SimTensors per the
+namedtuple in the reference.  Backprop engineer wires gradient producers
+to the op handles in store_memories / retrieve_memories.
+
+"""
+import os, sys, math
+from collections import namedtuple
+sys.path.append(os.path.join(os.path.dirname(__file__), '../..'))
+
+import numpy as np
+import ttsim.front.functional.op as F
+import ttsim.front.functional.tensor_op as T
+import ttsim.front.functional.sim_nn as SimNN
+
+from workloads.Titans.memory_models import MemoryMLP, ResidualNorm
+
+NeuralMemState = namedtuple('NeuralMemState', [
+    'seq_index',
+    'weights',
+    'cache_store_segment',
+    'states',
+    'updates',
+])
+
+class _MultiheadRMSNorm(SimNN.Module):
+    """RMSNorm(dim) * (gamma_per_head + 1) — same as titans MultiheadRMSNorm."""
+    def __init__(self, name, dim, heads):
+        super().__init__()
+        self.name = name
+        self.dim  = dim
+        self.heads = heads
+        self.mulx2  = F.Mul(f'{name}.mulx2')
+        self.meanop = F.Mean(f'{name}.mean', dim=-1)
+        self.sqrt   = F.Sqrt(f'{name}.sqrt')
+        self.recip  = F.Reciprocal(f'{name}.recip')
+        self.mulnorm= F.Mul(f'{name}.mulnorm')
+        self.mulgamma=F.Mul(f'{name}.mulgamma')
+        self.addone = F.Add(f'{name}.addone')
+        self.gamma  = F._from_shape(f'{name}.gamma', shape=[heads, 1, dim], is_param=True)
+        self.one    = F._from_data(f'{name}.one', np.float32(1.0))
+        self.one.set_module(self); self._tensors[self.one.name] = self.one
+        super().link_op2module()
+
+    def __call__(self, x):
+        eps = F._from_shape(f'{self.name}.eps', shape=[1])
+        eps.set_module(self); self._tensors[eps.name] = eps
+        x2  = self.mulx2(x, x)
+        mu  = self.meanop(x2).unsqueeze(-1)
+        rms = self.recip(self.sqrt(mu + eps))
+        normed = self.mulnorm(x, rms)
+        return self.mulgamma(normed, self.addone(self.gamma, self.one))
+
+    def analytical_param_count(self, lvl=0):
+        return self.heads * self.dim
+
+class _RMSNorm(SimNN.Module):
+    """Standard RMSNorm (no learnable gamma if elementwise_affine=False)."""
+    def __init__(self, name, dim, elementwise_affine=True):
+        super().__init__()
+        self.name = name
+        self.dim  = dim
+        self.eaff = elementwise_affine
+        self.mulx2  = F.Mul(f'{name}.mulx2')
+        self.meanop = F.Mean(f'{name}.mean', dim=-1)
+        self.sqrt   = F.Sqrt(f'{name}.sqrt')
+        self.recip  = F.Reciprocal(f'{name}.recip')
+        self.mulnorm= F.Mul(f'{name}.mulnorm')
+        if elementwise_affine:
+            self.weight = F._from_shape(f'{name}.weight', shape=[dim], is_param=True)
+            self.mulw   = F.Mul(f'{name}.mulw')
+        super().link_op2module()
+
+    def __call__(self, x):
+        eps = F._from_shape(f'{self.name}.eps', shape=[1])
+        eps.set_module(self); self._tensors[eps.name] = eps
+        x2  = self.mulx2(x, x)
+        mu  = self.meanop(x2).unsqueeze(-1)
+        normed = self.mulnorm(x, self.recip(self.sqrt(mu + eps)))
+        if self.eaff:
+            return self.mulw(normed, self.weight)
+        return normed
+
+    def analytical_param_count(self, lvl=0):
+        return self.dim if self.eaff else 0
+
+class NeuralMemory(SimNN.Module):
+    """
+    TTSim port of titans_pytorch.neural_memory.NeuralMemory.
+
+    Constructor mirrors the reference for the supported subset.
+    """
+    def __init__(
+        self,
+        name,
+        dim,
+        chunk_size = 1,
+        dim_head   = None,
+        heads      = 1,
+        depth      = 2,
+        expansion_factor = 2.0,
+        mem_model_norm_add_residual = True,
+        pre_rmsnorm  = True,
+        post_rmsnorm = False,
+        qk_rmsnorm   = False,
+        attn_pool_chunks = False,
+        max_chunks_unroll = 16,
+    ):
+        super().__init__()
+        self.name = name
+        self.max_chunks_unroll = max_chunks_unroll
+        dim_head = dim_head if dim_head is not None else dim
+        assert not (heads == 1 and dim_head != dim)
+
+        self.dim       = dim
+        self.dim_head  = dim_head
+        self.heads     = heads
+        self.dim_inner = dim_head * heads
+        self.chunk_size = chunk_size
+        self.store_chunk_size    = chunk_size
+        self.retrieve_chunk_size = chunk_size
+
+        # ----- norms -----
+        self.retrieve_norm = _RMSNorm(f'{name}.retrieve_norm', dim) if pre_rmsnorm else F.Identity(f'{name}.id_rn')
+        self.store_norm    = _RMSNorm(f'{name}.store_norm',    dim) if pre_rmsnorm else F.Identity(f'{name}.id_sn')
+        self.multihead_rmsnorm = _MultiheadRMSNorm(f'{name}.mh_rmsnorm', dim_head, heads) if post_rmsnorm else F.Identity(f'{name}.id_mh')
+        self.q_norm = _MultiheadRMSNorm(f'{name}.q_norm', dim_head, heads) if qk_rmsnorm else F.Identity(f'{name}.id_q')
+        self.k_norm = _MultiheadRMSNorm(f'{name}.k_norm', dim_head, heads) if qk_rmsnorm else F.Identity(f'{name}.id_k')
+
+        # ----- projections -----
+        self.to_queries = SimNN.Linear(f'{name}.to_queries', dim, self.dim_inner)
+        self.to_keys    = SimNN.Linear(f'{name}.to_keys',    dim, self.dim_inner)
+        self.to_values  = SimNN.Linear(f'{name}.to_values',  dim, self.dim_inner)
+
+        # ----- per-chunk learned hparams -----
+        self.to_adaptive_step = SimNN.Linear(f'{name}.to_adaptive_step', dim, heads)
+        self.to_decay_factor  = SimNN.Linear(f'{name}.to_decay_factor',  dim, heads)
+        self.to_momentum      = SimNN.Linear(f'{name}.to_momentum',      dim, heads)
+        self.adaptive_step_sig= F.Sigmoid(f'{name}.adaptive_step_sig')
+        self.decay_sig        = F.Sigmoid(f'{name}.decay_sig')
+        self.momentum_sig     = F.Sigmoid(f'{name}.momentum_sig')
+
+        # ----- multi-head retrieve gate -----
+        if heads > 1:
+            self.to_retrieve_gate = SimNN.Linear(f'{name}.to_retrieve_gate', dim, heads)
+            self.retrieve_gate_sig= F.Sigmoid(f'{name}.retrieve_gate_sig')
+            self.combine_heads    = SimNN.Linear(f'{name}.combine_heads', self.dim_inner, dim)
+        else:
+            self.to_retrieve_gate = None # type: ignore[assignment]
+            self.combine_heads    = F.Identity(f'{name}.id_combine')
+
+        # ----- the memory model (its weights are the memory) -----
+        inner_model = MemoryMLP(f'{name}.mem_mlp', dim_head, depth, expansion_factor)
+        if mem_model_norm_add_residual:
+            self.memory_model = ResidualNorm(f'{name}.mem_resnorm', dim_head, inner_model)
+        else:
+            self.memory_model = inner_model # type: ignore[assignment]
+
+        self._mem_param_names = [f'W{i}' for i in range(depth)]
+        self._mem_param_dims  = inner_model.dims  # length depth+1
+        self._mem_inner       = inner_model
+        self._mem_depth       = depth
+
+        self.store_mm_fwd     = F.SimOpHandleList([F.MatMul(f'{name}.store_fwd_W{i}')          for i in range(depth)])
+        self.store_gelu_fwd   = F.SimOpHandleList([F.Gelu  (f'{name}.store_fwd_gelu{i}')       for i in range(depth - 1)])
+        self.sub_err          = F.Sub(f'{name}.sub_err')
+        self.mul_scale        = F.Mul(f'{name}.mul_lr_scale')
+        self.store_mm_bwd_dW  = F.SimOpHandleList([F.MatMul(f'{name}.store_bwd_dW{i}')         for i in range(depth)])
+        self.store_mm_bwd_dh  = F.SimOpHandleList([F.MatMul(f'{name}.store_bwd_dh{i}')         for i in range(depth - 1)])
+        self.gelu_grad        = F.SimOpHandleList([F.Mul   (f'{name}.store_bwd_geluprime{i}')  for i in range(depth - 1)])
+
+        self.mom_mul   = F.SimOpHandleList([
+            F.Mul(f'{name}.mom_mul_W{i}_c{c}')
+            for i in range(depth) for c in range(self.max_chunks_unroll)
+        ])
+        self.mom_add   = F.SimOpHandleList([
+            F.Add(f'{name}.mom_add_W{i}_c{c}')
+            for i in range(depth) for c in range(self.max_chunks_unroll)
+        ])
+        self.decay_mul = F.SimOpHandleList([
+            F.Mul(f'{name}.decay_mul_W{i}_c{c}')
+            for i in range(depth) for c in range(self.max_chunks_unroll)
+        ])
+        self.weight_add = F.SimOpHandleList([
+            F.Add(f'{name}.weight_add_W{i}_c{c}')
+            for i in range(depth) for c in range(self.max_chunks_unroll)
+        ])
+        self.weight_sub = F.SimOpHandleList([
+            F.Sub(f'{name}.weight_sub_W{i}_c{c}')
+            for i in range(depth) for c in range(self.max_chunks_unroll)
+        ])
+
+        self._grads_splits = []
+        for i in range(depth):
+            row = []
+            for k in range(1, self.max_chunks_unroll + 1):
+                op = F.SplitOpHandle(f'{name}.grads_split_W{i}_n{k}', count=k, axis=1)
+                setattr(self, f'grads_split_W{i}_n{k}', op)
+                row.append(op)
+            self._grads_splits.append(row)
+
+        self._momentum_coef_splits = []
+        self._decay_factor_splits  = []
+        for k in range(1, self.max_chunks_unroll + 1):
+            mop = F.SplitOpHandle(f'{name}.momentum_coef_split_n{k}', count=k, axis=1)
+            dop = F.SplitOpHandle(f'{name}.decay_factor_split_n{k}',  count=k, axis=1)
+            setattr(self, f'momentum_coef_split_n{k}', mop)
+            setattr(self, f'decay_factor_split_n{k}',  dop)
+            self._momentum_coef_splits.append(mop)
+            self._decay_factor_splits.append(dop)
+
+        self.chunk_mean = F.Mean(f'{name}.chunk_mean', dim=-2)
+        self.decay_chunk_mean    = F.Mean(f'{name}.decay_chunk_mean',    dim=1)
+        self.momentum_chunk_mean = F.Mean(f'{name}.momentum_chunk_mean', dim=1)
+
+        self.cat_cache = F.Concat(f'{name}.cat_cache', axis=1)
+
+        super().link_op2module()
+
+
+    def _mc(self, i, c):
+        """D1: flat-index helper for per-chunk recurrence ops.
+        Maps (layer_idx i, chunk_idx c) -> position in the flat SimOpHandleList."""
+        return i * self.max_chunks_unroll + c
+
+
+    def init_weights(self, batch):
+        """Returns dict[name -> SimTensor] mirroring lucidrains init_weights.
+        Shape per param: [batch*heads, dim_in, dim_out]."""
+        bh = batch * self.heads
+        d  = self._mem_inner.dims
+        out = {}
+        for i in range(self._mem_depth):
+            t = F._from_shape(
+                f'{self.name}.init_W{i}',
+                shape=[bh, d[i], d[i + 1]], is_param=True)
+            t.set_module(self)
+            self._tensors[t.name] = t
+            out[f'W{i}'] = t
+        return out
+
+    def init_momentum(self, batch):
+        bh = batch * self.heads
+        d  = self._mem_inner.dims
+        out = {}
+        for i in range(self._mem_depth):
+            t = F._from_shape(
+                f'{self.name}.init_M{i}',
+                shape=[bh, d[i], d[i + 1]], is_param=False)
+            t.set_module(self)
+            self._tensors[t.name] = t
+            out[f'W{i}'] = t
+        return out
+
+    def retrieve_memories(self, seq, weights):
+        """
+        seq      : SimTensor [B, N, D]
+        weights  : dict 'Wi' -> SimTensor [B*H, dim_in, dim_out]   (current memory)
+        returns  : SimTensor [B, N, D]
+        """
+        B, N, D = seq.shape
+        H, Dh   = self.heads, self.dim_head
+
+        x = self.retrieve_norm(seq)
+        q = self.to_queries(x)
+        q = q.reshape(B, N, H, Dh).transpose(1, 2)
+        q = self.q_norm(q)
+
+        h = q.reshape(B * H, N, Dh)
+        for i in range(self._mem_depth):
+            if i > 0:
+                h = self._mem_inner.gelus[i - 1](h)
+            mm = self._mem_inner.matmuls[i][0]
+            h  = mm(h, weights[f'W{i}'])
+        out = h
+        if isinstance(self.memory_model, ResidualNorm):
+            out = self.memory_model.add(self.memory_model.norm(h), q.reshape(B * H, N, Dh))
+
+        out = out.reshape(B, H, N, Dh)
+        out = self.multihead_rmsnorm(out)
+
+        if self.to_retrieve_gate is not None:
+            gate = self.retrieve_gate_sig(self.to_retrieve_gate(x))
+            gate = gate.reshape(B, N, H, 1).transpose(1, 2)
+            out  = out * gate
+
+        out = out.transpose(1, 2).reshape(B, N, H * Dh)
+        out = self.combine_heads(out)
+        return out
+
+    def store_memories(self, seq, weights, past_state, seq_index):
+        """
+        Emits the per-chunk store-update graph.
+
+        seq        : SimTensor [B, N, D]
+        weights    : dict 'Wi' -> SimTensor [B*H, di, dj]
+        past_state : tuple(last_update, last_momentum), both dicts as above
+        seq_index  : python int (host-side bookkeeping only)
+
+        returns: (updates_dict, NeuralMemState)
+        """
+        B, N, D = seq.shape
+        H, Dh   = self.heads, self.dim_head
+        C       = self.store_chunk_size
+
+        n_full   = (N // C) * C
+        num_ch   = n_full // C
+        remainder = None
+
+        x = self.store_norm(seq)
+
+        chunked = self.chunk_mean(x.reshape(B, num_ch, C, D))
+        adaptive_lr  = self.adaptive_step_sig(self.to_adaptive_step(x))
+        decay_factor = self.decay_sig       (self.to_decay_factor (chunked))
+        momentum_coef= self.momentum_sig    (self.to_momentum     (chunked))
+
+        K = self.to_keys  (x).reshape(B, N, H, Dh).transpose(1, 2)
+        V = self.to_values(x).reshape(B, N, H, Dh).transpose(1, 2)
+        K = self.k_norm(K)
+
+        acts = [K.reshape(B * H, N, Dh)]
+        for i in range(self._mem_depth):
+            h = acts[-1]
+            if i > 0:
+                h = self.store_gelu_fwd[i - 1](h)
+            h = self.store_mm_fwd[i](h, weights[f'W{i}'])
+            acts.append(h)
+        pred = acts[-1]
+
+        err = self.sub_err(pred, V.reshape(B * H, N, Dh))
+        d_pred = self.mul_scale(err, adaptive_lr.reshape(B * H, N, 1))
+
+        grads = {}
+        d_h = d_pred
+        for i in reversed(range(self._mem_depth)):
+            a_in = acts[i]
+
+            di_i = a_in.shape[-1]
+            dj_i = d_h.shape[-1]
+            a_in_chunked = a_in.reshape(B * H, num_ch, C, di_i)
+            d_h_chunked  = d_h.reshape(B * H, num_ch, C, dj_i)
+
+            grads[f'W{i}'] = self.store_mm_bwd_dW[i](
+                a_in_chunked.transpose(-1, -2), d_h_chunked)
+
+            if i > 0:
+                d_h = self.store_mm_bwd_dh[i - 1](d_h, weights[f'W{i}'].transpose(-1, -2))
+                d_h = self.gelu_grad[i - 1](d_h, a_in)
+
+        assert num_ch <= self.max_chunks_unroll, \
+            f"num_chunks={num_ch} exceeds max_chunks_unroll={self.max_chunks_unroll}. " \
+            f"Either raise max_chunks_unroll or bump mem_chunk_size in the YAML."
+
+        prev_update, prev_momentum = past_state
+        new_update, new_momentum = {}, {}
+
+        decay_factor_r  = decay_factor.reshape(B * H, num_ch, 1, 1)
+        momentum_coef_r = momentum_coef.reshape(B * H, num_ch, 1, 1)
+
+        decay_chunks    = self._decay_factor_splits[num_ch - 1](decay_factor_r)
+        momentum_chunks = self._momentum_coef_splits[num_ch - 1](momentum_coef_r)
+
+
+        for i in range(self._mem_depth):
+            one_const = F._from_data(f'{self.name}.one_W{i}', np.float32(1.0))
+            one_const.set_module(self); self._tensors[one_const.name] = one_const
+
+            g_chunks = self._grads_splits[i][num_ch - 1](grads[f'W{i}'])
+
+            m_prev = prev_momentum[f'W{i}']
+            w_prev = prev_update[f'W{i}']
+
+            for c in range(num_ch):
+                g_c     = g_chunks[c].squeeze(1)
+                eta_c   = momentum_chunks[c].squeeze(1)
+                alpha_c = decay_chunks[c].squeeze(1)
+
+                m_scaled = self.mom_mul[self._mc(i, c)](m_prev, eta_c)
+                m_new    = self.mom_add[self._mc(i, c)](m_scaled, g_c)
+
+                one_minus_alpha = self.weight_sub[self._mc(i, c)](one_const, alpha_c)
+                w_decayed       = self.decay_mul[self._mc(i, c)](w_prev, one_minus_alpha)
+                w_new           = self.weight_add[self._mc(i, c)](w_decayed, m_new)
+
+                m_prev = m_new
+                w_prev = w_new
+
+            new_momentum[f'W{i}'] = m_prev
+            new_update[f'W{i}']   = w_prev
+
+        next_state = (new_update, new_momentum)
+        next_mem_state = NeuralMemState(
+            seq_index = seq_index + n_full,
+            weights   = new_update,
+            cache_store_segment = remainder,
+            states    = next_state,
+            updates   = new_update,
+        )
+        return new_update, next_mem_state
+
+    def __call__(self, seq, state=None, store_seq=None):
+        B = seq.shape[0]
+        store_seq = store_seq if store_seq is not None else seq
+
+        if state is None:
+            weights    = self.init_weights(B)
+            past_state = (weights, self.init_momentum(B))
+            seq_index  = 0
+            cache_seg  = None
+        else:
+            seq_index  = state.seq_index
+            weights    = state.weights
+            past_state = state.states
+            cache_seg  = state.cache_store_segment
+
+        if cache_seg is not None:
+            store_seq = self.cat_cache(cache_seg, store_seq)
+
+        store_seq_len = store_seq.shape[-2]
+
+        updates, next_mem_state = self.store_memories(
+            store_seq, weights, past_state, seq_index)
+        weights    = next_mem_state.weights
+        past_state = next_mem_state.states
+
+        new_cache_seg = None
+
+        next_state_final = NeuralMemState(
+            seq_index           = seq_index + store_seq_len,
+            weights             = weights,
+            cache_store_segment = new_cache_seg,
+            states              = past_state,
+            updates             = updates,
+        )
+
+        retrieved = self.retrieve_memories(seq, weights)
+        return retrieved, next_state_final
+
+    def analytical_param_count(self, lvl=0):
+        pc = 0
+        pc += self.to_queries.analytical_param_count(lvl + 1)
+        pc += self.to_keys.analytical_param_count(lvl + 1)
+        pc += self.to_values.analytical_param_count(lvl + 1)
+        pc += self.to_adaptive_step.analytical_param_count(lvl + 1)
+        pc += self.to_decay_factor.analytical_param_count(lvl + 1)
+        pc += self.to_momentum.analytical_param_count(lvl + 1)
+        if self.to_retrieve_gate is not None:
+            pc += self.to_retrieve_gate.analytical_param_count(lvl + 1)
+            pc += self.combine_heads.analytical_param_count(lvl + 1)
+        pc += self.memory_model.analytical_param_count(lvl + 1)
+        # norms
+        for n in ['retrieve_norm','store_norm','multihead_rmsnorm','q_norm','k_norm']:
+            mod = getattr(self, n)
+            if hasattr(mod, 'analytical_param_count'):
+                pc += mod.analytical_param_count(lvl + 1)
+        return pc

--- a/workloads/Titans/test_titans_mac.py
+++ b/workloads/Titans/test_titans_mac.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""
+Smoke tests for the Titans MAC TTSim port.
+Validates: (1) forward graph builds, (2) param-count math is consistent,
+(3) ONNX export round-trips, (4) NeuralMemory store/retrieve shapes are sane.
+"""
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+import numpy as np
+import ttsim.front.functional.op as F
+from workloads.Titans.mac_transformer import TitansMAC
+from workloads.Titans.neural_memory  import NeuralMemory
+from workloads.Titans.memory_models  import MemoryMLP
+
+
+def test_memory_mlp_shapes():
+    m = MemoryMLP('mm', dim=32, depth=2, expansion_factor=2.0)
+    x = F._from_shape('x', shape=[4, 8, 32])
+    y = m(x)
+    assert y.shape == [4, 8, 32]
+    assert m.analytical_param_count() == 32 * 64 + 64 * 32
+    print('OK : MemoryMLP shapes and param count')
+
+def test_neural_memory_forward_graph():
+    nm = NeuralMemory('nm', dim=64, chunk_size=4, dim_head=32, heads=2, depth=2)
+    seq = F._from_shape('seq', shape=[1, 16, 64])
+    out, state = nm(seq)
+    assert out.shape == [1, 16, 64]
+    print(f'OK : NeuralMemory forward (params={nm.analytical_param_count()})')
+
+def test_neural_memory_chunk_state_propagation():
+    """
+    D1 verification:
+      - seq_len=16, chunk_size=4 -> num_ch=4 chunks
+      - max_chunks_unroll=8, depth=2 -> 16 per-chunk handles per op type total
+    Confirms per-chunk handles are allocated AND the constructor wires them
+    correctly. The actual graph traversal (with state propagation) is
+    validated end-to-end by the full Polaris pipeline.
+    """
+    nm = NeuralMemory('nm_state', dim=32, chunk_size=4, dim_head=16, heads=2,
+                      depth=2, max_chunks_unroll=8)
+    seq = F._from_shape('seq_state', shape=[1, 16, 32])
+    out, state = nm(seq)
+    assert out.shape == [1, 16, 32], f'bad out shape {out.shape}'
+
+    # Each per-chunk op list = depth * max_chunks_unroll = 2 * 8 = 16 handles
+    expected = 2 * 8
+    assert len(nm.mom_mul)   == expected, f'mom_mul:   want {expected}, got {len(nm.mom_mul)}'
+    assert len(nm.mom_add)   == expected, f'mom_add:   want {expected}, got {len(nm.mom_add)}'
+    assert len(nm.decay_mul) == expected, f'decay_mul: want {expected}, got {len(nm.decay_mul)}'
+    assert len(nm.weight_add)== expected, f'weight_add: want {expected}, got {len(nm.weight_add)}'
+    assert len(nm.weight_sub)== expected, f'weight_sub: want {expected}, got {len(nm.weight_sub)}'
+
+    # Index helper is correct
+    assert nm._mc(0, 0) == 0
+    assert nm._mc(0, 7) == 7
+    assert nm._mc(1, 0) == 8
+    assert nm._mc(1, 7) == 15
+
+    # Variant Splits cover all num_ch values from 1 to max_chunks_unroll
+    assert len(nm._grads_splits) == 2, 'grads_splits should be per-layer (depth=2)'
+    assert len(nm._grads_splits[0]) == 8, 'grads_splits[0] should have max_chunks_unroll variants'
+    assert len(nm._momentum_coef_splits) == 8
+    assert len(nm._decay_factor_splits) == 8
+    assert nm._decay_factor_splits[3].count == 4, 'Split variant for num_ch=4 should have count=4'
+
+    print('OK : NeuralMemory chunk-state propagation (D1)')
+
+
+def test_titans_mac_forward_graph_and_onnx(tmpdir='./__titans_mac_test'):
+    os.makedirs(tmpdir, exist_ok=True)
+    cfg = dict(
+        nL=2, nH=4, dE=128, dim_head=32, nW=32, vocab_sz=256, bs=1,
+        segment_len=8, num_persist_mem_tokens=4, num_longterm_mem_tokens=4,
+        neural_memory_layers=[2], neural_memory_segment_len=4,
+        mem_depth=2, mem_expansion_factor=2.0, mem_heads=2, mem_dim_head=32,
+        mem_chunk_size=4,
+    )
+    m = TitansMAC('titans_mac', cfg)
+    m.create_input_tensors()
+    y = m()
+    print(f'OK : TitansMAC forward (out={y.shape}, params={m.analytical_param_count():,d})')
+
+    gg = m.get_forward_graph()
+    onnx_path = os.path.join(tmpdir, 'titans_mac.onnx')
+    gg.graph2onnx(onnx_path, do_model_check=False)
+    assert os.path.exists(onnx_path), 'ONNX not written'
+    print(f'OK : ONNX written to {onnx_path}')
+
+if __name__ == '__main__':
+    test_memory_mlp_shapes()
+    test_neural_memory_forward_graph()
+    test_neural_memory_chunk_state_propagation()
+    test_titans_mac_forward_graph_and_onnx()
+    print('\nAll Titans MAC smoke tests passed.')

--- a/workloads/torch_basic_llm.py
+++ b/workloads/torch_basic_llm.py
@@ -1,0 +1,105 @@
+# #!/usr/bin/env python
+# # SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# # SPDX-License-Identifier: Apache-2.0
+# """
+# PyTorch port of workloads/BasicLLM.py for graph validation against TTSim.
+
+# """
+# import torch
+# import torch.nn as nn
+# import math
+
+# class ATTN(nn.Module):
+#     def __init__(self, dE, nH, drop_prob=0.0):
+#         super().__init__()
+#         self.dE, self.nH = dE, nH
+#         self.dH = dE // nH
+#         self.wqkv_proj = nn.Linear(dE, 3*dE)
+#         self.w0_proj   = nn.Linear(dE, dE)
+#         self.drop_attn   = nn.Dropout(drop_prob)
+#         self.resid_drop  = nn.Dropout(drop_prob)
+#         self.scale = 1.0 / math.sqrt(self.dH)
+
+#     def forward(self, x):
+#         B, N, _ = x.shape
+#         WQKV = self.wqkv_proj(x)
+#         Q, K, V = WQKV.chunk(3, dim=-1)
+#         Q = Q.reshape(B, N, self.nH, self.dH).transpose(1, 2)
+#         K = K.reshape(B, N, self.nH, self.dH).transpose(1, 2).transpose(2, 3)
+#         V = V.reshape(B, N, self.nH, self.dH).transpose(1, 2)
+#         QK = torch.matmul(Q, K) * self.scale
+#         QK = self.drop_attn(torch.softmax(QK, dim=-1))
+#         QKV = torch.matmul(QK, V).transpose(1, 2).reshape(B, N, self.dE)
+#         return self.resid_drop(self.w0_proj(QKV))
+
+# class TransformerBlock(nn.Module):
+#     def __init__(self, dE, nH, drop_prob=0.0):
+#         super().__init__()
+#         idE = 4 * dE
+#         self.ln_attn_in = nn.LayerNorm(dE)
+#         self.attn       = ATTN(dE, nH, drop_prob)
+#         self.lnorm      = nn.LayerNorm(dE)
+#         self.ff1        = nn.Linear(dE, idE)
+#         self.ff2        = nn.Linear(idE, dE)
+#         self.gelu       = nn.GELU()
+#         self.mlp_drop   = nn.Dropout(drop_prob)
+
+#     def forward(self, x):
+#         y = x + self.attn(self.ln_attn_in(x))
+#         y = self.lnorm(y)
+#         y = self.ff1(y)
+#         y = self.ff2(y)
+#         y = self.gelu(y)
+#         y = self.mlp_drop(y)
+#         return y
+
+# class BasicLLM(nn.Module):
+#     def __init__(self, vocab_sz, nW, dE, nH, nL, drop_prob=0.0):
+#         super().__init__()
+#         self.wte = nn.Embedding(vocab_sz, dE)
+#         self.wpe = nn.Embedding(nW, dE)
+#         self.drop_emb = nn.Dropout(drop_prob)
+#         self.blocks   = nn.ModuleList([TransformerBlock(dE, nH, drop_prob) for _ in range(nL)])
+
+#     def forward(self, tokens, mask):
+#         x = self.wte(tokens) + self.wpe(mask)
+#         x = self.drop_emb(x)
+#         for blk in self.blocks:
+#             x = blk(x)
+#         return x
+
+# if __name__ == '__main__':
+#     import sys, json
+#     from collections import Counter
+
+#     INSTANCES = {
+#         'nano':   dict(nL=2,  nH=4,  dE=128,  nW=64),
+#         'micro':  dict(nL=4,  nH=4,  dE=256,  nW=128),
+#         'small':  dict(nL=8,  nH=8,  dE=384,  nW=512),
+#         'base':   dict(nL=12, nH=12, dE=768,  nW=1024),
+#         'large':  dict(nL=24, nH=16, dE=1024, nW=2048),
+#         'xlarge': dict(nL=24, nH=16, dE=1536, nW=2048),
+#     }
+#     vocab_sz, bs = 256, 1
+
+#     print(f'{"instance":<10} {"PyTorch ONNX op counts":<60}')
+#     print('-'*70)
+
+#     for name, cfg in INSTANCES.items():
+#         model = BasicLLM(vocab_sz, cfg['nW'], cfg['dE'], cfg['nH'], cfg['nL'])
+#         model.eval()
+#         tokens = torch.randint(0, vocab_sz, (bs, cfg['nW']))
+#         mask   = torch.arange(cfg['nW']).unsqueeze(0).expand(bs, -1)
+
+#         onnx_path = f'/tmp/basic_llm_{name}_torch.onnx'
+#         torch.onnx.export(
+#             model, (tokens, mask), onnx_path,
+#             input_names=['tokens', 'mask'],
+#             opset_version=17,
+#             do_constant_folding=False,
+#         )
+
+#         import onnx
+#         m = onnx.load(onnx_path)
+#         op_counts = Counter(n.op_type for n in m.graph.node)
+#         print(f'{name:<10}', dict(op_counts))

--- a/workloads/torch_basic_llm_fx.py
+++ b/workloads/torch_basic_llm_fx.py
@@ -1,0 +1,79 @@
+# #!/usr/bin/env python
+# # SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# # SPDX-License-Identifier: Apache-2.0
+# """
+# torch.fx-based op count for BasicLLM PyTorch port.
+# Uses symbolic tracing to capture the computation graph at nn.Module granularity,
+# which more closely matches TTSim's high-level op vocabulary than ONNX export.
+# """
+# import os, sys, json
+# sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+# from collections import Counter
+# import torch
+# from torch.fx import symbolic_trace
+
+# from workloads.torch_basic_llm import BasicLLM
+
+# FX_TO_TTSIM = {
+#     'Linear':           'MatMul',
+#     'LayerNorm':        'LayerNormalization',
+#     'Embedding':        'Gather',
+#     'GELU':             'Gelu',
+#     'Dropout':          'Dropout',
+#     'Softmax':          'Softmax',
+#     'matmul':           'MatMul',
+#     'softmax':          'Softmax',
+#     'add':              'Add',
+#     'mul':              'Mul',
+#     'truediv':          'Div',
+#     'reshape':          'Reshape',
+#     'transpose':        'Transpose',
+#     'chunk':            'Split',
+#     'getitem':          None,
+# }
+
+# def count_fx_ops(model):
+#     traced = symbolic_trace(model)
+#     counts: Counter[str] = Counter()
+#     for node in traced.graph.nodes:
+#         if node.op == 'call_module':
+#             mod = traced.get_submodule(node.target)
+#             cls = type(mod).__name__
+#             mapped = FX_TO_TTSIM.get(cls)
+#             if mapped:
+#                 counts[mapped] += 1
+#         elif node.op == 'call_function':
+#             fn_name = getattr(node.target, '__name__', str(node.target))
+#             mapped = FX_TO_TTSIM.get(fn_name)
+#             if mapped:
+#                 counts[mapped] += 1
+#         elif node.op == 'call_method':
+#             mapped = FX_TO_TTSIM.get(node.target)
+#             if mapped:
+#                 counts[mapped] += 1
+#     return counts
+
+# if __name__ == '__main__':
+#     INSTANCES = {
+#         'nano':   dict(nL=2,  nH=4,  dE=128,  nW=64),
+#         'micro':  dict(nL=4,  nH=4,  dE=256,  nW=128),
+#         'small':  dict(nL=8,  nH=8,  dE=384,  nW=512),
+#         'base':   dict(nL=12, nH=12, dE=768,  nW=1024),
+#         'large':  dict(nL=24, nH=16, dE=1024, nW=2048),
+#         'xlarge': dict(nL=24, nH=16, dE=1536, nW=2048),
+#     }
+#     vocab_sz = 256
+
+#     print(f'{"instance":<10} fx_op_counts')
+#     print('-'*70)
+
+#     for name, cfg in INSTANCES.items():
+#         model = BasicLLM(vocab_sz, cfg['nW'], cfg['dE'], cfg['nH'], cfg['nL'])
+#         model.eval()
+#         try:
+#             counts = count_fx_ops(model)
+#             print(f'{name:<10}', dict(sorted(counts.items())))
+#             with open(f'/tmp/basic_llm_{name}_fx.json', 'w') as f:
+#                 json.dump(dict(counts), f)
+#         except Exception as e:
+#             print(f'{name:<10}  FX trace failed: {e}')


### PR DESCRIPTION
## Summary

Adds the Titans Memory-as-Context (MAC) workload port to Polaris TTSim, a matched-dimension BasicLLM baseline, a PyTorch reference for graph-fidelity validation, and a MAC utilization analyzer. 
## Changes

- **`workloads/Titans/`** — TTSim port of Titans MAC implementing per-chunk weight recurrence (paper eqs. 13–14), per-chunk gradient (eq. 17), MemoryMLP forward/backward chains, persistent memory tokens, and SegmentedAttention. Structured as two proxy blocks (`t_mem`, `t_nomem`) to model MAC's mixed memory-bearing and plain layers.
- **`config/ip_workloads.yaml`** — 6 matched-dimension instances each for `TitansMAC` and `BasicLLM` (nano / micro / small / base / large / xlarge spanning 33K–683M params).
- **`workloads/torch_basic_llm.py`** — vanilla PyTorch `nn.Module` port of BasicLLM with ONNX export.
- **`workloads/torch_basic_llm_fx.py`** — `torch.fx` symbolic-trace op counter for direct per-op-type comparison against the TTSim BasicLLM graph.
- **`tools/mac_util.py`** — helper script that scans Polaris STATS `opstats.json` files to compute MAC utilization per workload.


