### PR TITLE
feat(468): llama3/transformer device ops in the TTNN shim + compute-pipe mapping

### DIFF
--- a/config/wl2archmapping.yaml
+++ b/config/wl2archmapping.yaml
@@ -41,7 +41,7 @@ op_fusion_spec:
 
 op_rsrc_spec:
   compute:
-    matrix: [Matmul, Conv, ConvTranspose, Gemm, MultiheadAttention]
+    matrix: [Matmul, Conv, ConvTranspose, Gemm, MultiheadAttention, ScaledDotProductAttention]
     vector: [Add, And, ArgMax, AveragePool,
              BatchNormalization,
              Cast, Clip, Concat, Constant, ConstantOfShape, Cos, CumSum,
@@ -55,7 +55,8 @@ op_rsrc_spec:
              Move,
              LayerNormalization, LeakyRelu, Log, Less,
              Max, MaxPool, Mean, Min, Mish, Mul,
-             Neg, ConcatHeads, CreateQKVHeads, NonMaxSuppression, NonZero, # transformer head ops from ttnn_shim
+             Neg, ConcatHeads, CreateQKVHeads, NLPCreateQKVHeadsDecode, NLPConcatHeadsDecode, # transformer head ops (prefill+decode) from ttnn_shim
+             RotaryEmbeddingLlama, RotaryEmbeddingLlamaFusedQK, PagedFillCache, PagedFusedUpdateCache, NonMaxSuppression, NonZero, # transformer rope/cache ops from ttnn_shim
              Pad, Permute, Pow,
              QuantizeLinear,
              Reciprocal, ReduceMax, ReduceMean, ReduceMin, ReduceProd, ReduceSum, Relu, Reshard, Reshape, Resize,

--- a/doc/SPEC_ops_perf_trace_replay_merge.md
+++ b/doc/SPEC_ops_perf_trace_replay_merge.md
@@ -1,0 +1,60 @@
+# SPEC: `ops_perf_trace_replay_merge.py`
+
+Merge three TT-Metal-style ops perf CSVs from a **non-iterative trace+replay** capture (ViT, llama3 decode/prefill) into one output CSV.
+
+This is the trace+replay sibling of [`ops_perf_three_csv_merge.py`](SPEC_ops_perf_three_csv_merge.md) (the iterative, VGG-style merge). It **reuses that tool's classification, header-validation, join, MemTraffic, duration-check, and output machinery verbatim** — the only difference is the **row-reduction** step. Everything in the iterative spec's *File discovery and classification*, *Join keys and sorting*, *Duration check*, *Aggregate kernel duration summary*, *MemTraffic*, and *Output columns* sections applies unchanged; only *Iteration filtering* is replaced by *Replay-session filtering* below.
+
+- **Implementation:** stdlib **`csv`** only; **`loguru`** for warnings/info. Imports the shared helpers from `ops_perf_three_csv_merge.py` (dual import: package path under pytest/`mypy`, bare name when run as an on-device flat-bundle script).
+- **Exit code:** `0` success, `1` on any validation error (message on stderr).
+
+## When to use which tool
+
+| Capture shape | Tool | Reduction |
+|---|---|---|
+| **Iterative** — `run_device_perf(num_iterations=N)` concatenates equal-size iterations (VGG-style) | `ops_perf_three_csv_merge.py` | select one **iteration** |
+| **Trace+replay** — one compile/warmup pass + N replays of a captured trace (ViT, llama3) | `ops_perf_trace_replay_merge.py` | select one **replay session** |
+
+The trace+replay tool errors (directing the user to the iterative tool) if the input has no populated `METAL TRACE REPLAY SESSION ID` — i.e. it is not a trace+replay capture. Until the unified pass-classifier is built, tool choice is explicit.
+
+## Why the iterative reducer fails on trace+replay
+
+A trace+replay capture is **not** equal-size iterations. TT-Metal dispatches a compile/warmup pass (each op built individually) and then replays a captured trace N times, tagging each op:
+
+- `METAL TRACE REPLAY SESSION ID`:
+  - `''` (blank) → the **compile/warmup** pass. Its op set overlaps the replay op set, so its rows share `(GLOBAL CALL COUNT, OP CODE, OP TYPE)` join keys with the replay rows.
+  - `'1'`, `'2'`, … → successive **replays** of the captured trace. Within one replay session the join keys are unique, and they are identical across the raw/perf/trace variants.
+
+The iterative tool's first-op marker heuristic mis-fires (the entry marker recurs intra-pass → unequal chunk sizes → the whole capture is wrongly treated as one iteration), and the downstream join then aborts on a **duplicate join key** (the same op present in the compile pass and each replay session).
+
+## Replay-session filtering (replaces *Iteration filtering*)
+
+1. **Detection column:** `METAL TRACE REPLAY SESSION ID`. Candidate sessions are the **distinct non-blank** ids, in first-appearance (capture) order. If none are present, error (not a trace+replay capture).
+2. **Drop the compile/warmup pass:** rows with a blank session id are always removed (steady-state only; compile cost excluded).
+3. **Select one session** on the **vanilla** CSV, then apply the same session id to all three variants (they share session layout):
+   - `median` (default) — lower-middle by total `DEVICE KERNEL DURATION [ns]` (stable; matches the iterative tool's `median`).
+   - `min` / `max` — least / greatest total kernel ns.
+   - `first` / `last` — earliest / latest replay session in capture order.
+4. **Result:** each variant is reduced to exactly the selected session's ops, whose join keys are unique — handed unchanged to the shared join.
+
+### Composition with iteration reduction (trace+replay+iterative)
+
+If a future capture is trace+replay **and** iterative (a replay session that itself contains several concatenated iterations), the selected session's join keys will **not** be unique. In that case the iterative reducer (`reduce_iterative`) is applied *within* the selected session, composing the two reductions. This is on by default; `--no-compose-iteration` turns it into a hard error instead. For the common one-inference-per-session case the keys are already unique, so no iteration reduction runs — and the iterative marker heuristic (and its warning) is never triggered.
+
+## CLI
+
+| Flag | Required | Default | Meaning |
+|------|----------|---------|---------|
+| `--input-dir` | yes | — | Root directory; recursively discovers exactly three `ops_perf_results_*.csv` files (falls back to `*.csv`). |
+| `--dram-peak-bw-gbps` | yes | — | Peak DRAM bandwidth in **GB/s** (MemTraffic). |
+| `--output` | no | `<input-dir>/merged_ops.csv` | Output CSV path. |
+| `--duration-rel-tol` | no | `0.05` | Relative tolerance for fpu vs vanilla `DEVICE KERNEL DURATION [ns]`. |
+| `--encoding` | no | `utf-8` | Input/output text encoding. |
+| `--select-session` | no | `median` | Which replay session to keep: `median`, `min`, `max`, `first`, `last`. The compile/warmup pass is always dropped. |
+| `--no-compose-iteration` | no | off | Disable the within-session iteration reducer; a session with duplicate keys becomes a hard error instead. |
+| `--ops-per-iteration` | no | — | Forwarded to the composed iteration reducer (trace+replay+iterative only). |
+| `--measured-iteration-indices` | no | — | Forwarded to the composed iteration reducer (trace+replay+iterative only). |
+| `--select-iteration` | no | `median` | Forwarded to the composed iteration reducer (trace+replay+iterative only). |
+
+## Shared behavior (unchanged from the iterative tool)
+
+Classification (noctrace / fpu / vanilla), header subsequence/omission rules, join keys and sorting, per-row and aggregate duration checks, MemTraffic derivation, and the full output column order are exactly as specified in [`SPEC_ops_perf_three_csv_merge.md`](SPEC_ops_perf_three_csv_merge.md). The reduction runs **after** classification/header validation and **before** the join, so the join always receives one unique-keyed row set per variant.

--- a/tests/test_tools/test_op_canonical.py
+++ b/tests/test_tools/test_op_canonical.py
@@ -111,6 +111,13 @@ def test_unary_op_chain_resolution():
         ("RMSNorm", "rms_norm"),
         ("Gelu", "gelu"),
         ("Relu", "relu"),
+        # llama3/transformer profiler op codes (real DeviceOperation forms).
+        ("RotaryEmbeddingLlamaFusedQKDeviceOperation", "rotaryembeddingllamafusedqk"),
+        ("RotaryEmbeddingLlamaDeviceOperation", "rotaryembeddingllama"),
+        ("PagedFusedUpdateCacheDeviceOperation", "pagedfusedupdatecache"),
+        ("PagedFillCacheDeviceOperation", "pagedfillcache"),
+        ("SDPAOperation", "scaleddotproductattention"),
+        ("SdpaDecodeDeviceOperation", "scaleddotproductattention"),
     ],
 )
 def test_bare_opcode_prefix_matching(raw, expected):

--- a/tests/test_tools/test_ops_perf_trace_replay_merge.py
+++ b/tests/test_tools/test_ops_perf_trace_replay_merge.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the trace+replay merge sibling (ops_perf_trace_replay_merge.py).
+
+Focus is the reduction step that differs from the iterative tool: dropping the
+compile/warmup pass and selecting one replay session so join keys are unique.
+The shared classify/join/output machinery is covered by
+test_ops_perf_three_csv_merge.py and is exercised here only end-to-end.
+"""
+
+import csv
+
+import pytest
+
+from tools.si_profiling_helpers.ops_perf_trace_replay_merge import (
+    COL_REPLAY_SESSION_ID,
+    MergeError,
+    main,
+    reduce_trace_replay,
+    replay_session_ids,
+    select_replay_session,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TR_COLS = [
+    'GLOBAL CALL COUNT', 'OP CODE', 'OP TYPE', 'DEVICE KERNEL DURATION [ns]',
+    'DRAM BW UTIL (%)', 'FPU Util Median (%)', 'SFPU Util Median (%)',
+    'NOC UTIL (%)', 'MULTICAST NOC UTIL (%)', 'ETH BW UTIL (%)', 'NPE CONG IMPACT (%)',
+    COL_REPLAY_SESSION_ID,
+]
+
+
+def _tr_row(gcc, op, ns, rsid, dram='', fpu=''):
+    return {
+        'GLOBAL CALL COUNT': str(gcc), 'OP CODE': op, 'OP TYPE': 'op',
+        'DEVICE KERNEL DURATION [ns]': str(ns), 'DRAM BW UTIL (%)': dram,
+        'FPU Util Median (%)': fpu, 'SFPU Util Median (%)': '',
+        'NOC UTIL (%)': '', 'MULTICAST NOC UTIL (%)': '', 'ETH BW UTIL (%)': '',
+        'NPE CONG IMPACT (%)': '', COL_REPLAY_SESSION_ID: rsid,
+    }
+
+
+def _capture_rows(ns_by_session, ops=(('1024', 'Matmul'), ('2048', 'Add')), dram='', fpu=''):
+    """Build a trace+replay capture: a compile pass (rsid='') plus one block per
+    replay session, every block carrying the same ops/join keys.
+
+    ``ns_by_session`` maps session id ('' for compile) -> per-op kernel ns, so a
+    session's total (and thus median/min/max selection) is controllable.
+    """
+    rows = []
+    for sid, ns in ns_by_session.items():
+        for gcc, op in ops:
+            rows.append(_tr_row(gcc, op, ns, sid, dram=dram, fpu=fpu))
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# replay_session_ids / select_replay_session
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_replay_session_ids_distinct_in_capture_order():
+    rows = _capture_rows({'': 999, '1': 100, '2': 200})
+    assert replay_session_ids(rows) == ['1', '2']  # blank excluded, first-appearance order
+
+
+@pytest.mark.unit
+def test_select_replay_session_median_lower_middle():
+    # session '1' total < session '2' total -> median (lower-middle of 2) picks '1'.
+    rows = _capture_rows({'': 999, '1': 100, '2': 200})
+    assert select_replay_session(rows, 'median') == '1'
+
+
+@pytest.mark.unit
+def test_select_replay_session_min_max():
+    rows = _capture_rows({'': 999, '1': 100, '2': 200})
+    assert select_replay_session(rows, 'min') == '1'
+    assert select_replay_session(rows, 'max') == '2'
+
+
+@pytest.mark.unit
+def test_select_replay_session_first_last_capture_order():
+    rows = _capture_rows({'': 999, '2': 200, '1': 100})  # session 2 appears first
+    assert select_replay_session(rows, 'first') == '2'
+    assert select_replay_session(rows, 'last') == '1'
+
+
+@pytest.mark.unit
+def test_select_replay_session_no_sessions_raises():
+    rows = _capture_rows({'': 999})  # compile pass only, no replay session
+    with pytest.raises(MergeError, match='trace\\+replay'):
+        select_replay_session(rows, 'median')
+
+
+# ---------------------------------------------------------------------------
+# reduce_trace_replay
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_reduce_trace_replay_drops_compile_and_selects_one_session():
+    rows = _capture_rows({'': 999, '1': 100, '2': 200})
+    noc, fpu, van = reduce_trace_replay(list(rows), list(rows), list(rows))
+    # 2 ops kept (one session), compile pass and the other session dropped.
+    assert len(van) == 2
+    # median picks session '1' (lower total) -> its distinguishing ns=100 survives.
+    assert {r['DEVICE KERNEL DURATION [ns]'] for r in van} == {'100'}
+    # join keys are now unique.
+    keys = [(r['GLOBAL CALL COUNT'], r['OP CODE'], r['OP TYPE']) for r in van]
+    assert len(keys) == len(set(keys))
+    assert len(noc) == len(fpu) == len(van)
+
+
+@pytest.mark.unit
+def test_reduce_trace_replay_requires_rsid_column():
+    row = {'GLOBAL CALL COUNT': '1', 'OP CODE': 'Matmul', 'OP TYPE': 'op',
+           'DEVICE KERNEL DURATION [ns]': '10'}  # no replay-session column
+    with pytest.raises(MergeError, match='trace\\+replay'):
+        reduce_trace_replay([row], [row], [row])
+
+
+@pytest.mark.unit
+def test_reduce_trace_replay_compose_iteration_within_session():
+    # A single replay session that itself holds two iterations (op sequence AB
+    # repeated with per-position join keys) -> keys not unique -> the iteration
+    # reducer composes to collapse it to one iteration.
+    seq = [('1024', 'A'), ('2048', 'B')]
+    rows = []
+    for _ in range(2):  # two iterations within session '1'
+        for gcc, op in seq:
+            rows.append(_tr_row(gcc, op, 100, '1'))
+    noc, fpu, van = reduce_trace_replay(list(rows), list(rows), list(rows))
+    assert len(van) == 2  # collapsed to a single iteration
+    keys = [(r['GLOBAL CALL COUNT'], r['OP CODE'], r['OP TYPE']) for r in van]
+    assert len(keys) == len(set(keys))
+
+
+@pytest.mark.unit
+def test_reduce_trace_replay_no_compose_raises_on_duplicate_keys():
+    seq = [('1024', 'A'), ('2048', 'B')]
+    rows = []
+    for _ in range(2):
+        for gcc, op in seq:
+            rows.append(_tr_row(gcc, op, 100, '1'))
+    with pytest.raises(MergeError, match='no-compose-iteration'):
+        reduce_trace_replay(list(rows), list(rows), list(rows), compose_iteration=False)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via main(): reproduces the duplicate-key failure and its fix
+# ---------------------------------------------------------------------------
+
+def _write_csv(path, rows):
+    with path.open('w', newline='') as fh:
+        w = csv.DictWriter(fh, fieldnames=_TR_COLS)
+        w.writeheader()
+        for r in rows:
+            w.writerow({c: r.get(c, '') for c in _TR_COLS})
+
+
+@pytest.mark.unit
+def test_main_merges_trace_replay_capture(tmp_path):
+    # Compile pass + two replay sessions, all sharing join keys -> the iterative
+    # tool would abort on a duplicate key; the trace+replay tool keeps one session.
+    _write_csv(tmp_path / 'trace.csv',
+               _capture_rows({'': 999, '1': 100, '2': 200}, dram='45.2'))
+    _write_csv(tmp_path / 'perf.csv',
+               _capture_rows({'': 999, '1': 100, '2': 200}, fpu='62.1'))
+    _write_csv(tmp_path / 'raw.csv',
+               _capture_rows({'': 999, '1': 100, '2': 200}))
+
+    out = tmp_path / 'merged_ops.csv'
+    rc = main([
+        '--input-dir', str(tmp_path), '--dram-peak-bw-gbps', '288.0',
+        '--output', str(out), '--duration-rel-tol', '1e9',
+    ])
+    assert rc == 0
+
+    with out.open(newline='') as fh:
+        rows = list(csv.DictReader(fh))
+    assert len(rows) == 2  # one replay session, compile pass dropped
+    keys = [(r['GLOBAL CALL COUNT'], r['OP CODE'], r['OP TYPE']) for r in rows]
+    assert len(keys) == len(set(keys))  # unique -> join did not abort
+    # median selected session '1' (lower total); its vanilla ns is canonical.
+    assert {r['DEVICE KERNEL DURATION [ns]'] for r in rows} == {'100'}
+
+
+@pytest.mark.unit
+def test_main_errors_on_non_trace_replay_capture(tmp_path):
+    # No populated replay-session id -> not a trace+replay capture -> exit 1.
+    _write_csv(tmp_path / 'trace.csv', _capture_rows({'': 100}, dram='45.2'))
+    _write_csv(tmp_path / 'perf.csv', _capture_rows({'': 100}, fpu='62.1'))
+    _write_csv(tmp_path / 'raw.csv', _capture_rows({'': 100}))
+    rc = main(['--input-dir', str(tmp_path), '--dram-peak-bw-gbps', '288.0'])
+    assert rc == 1

--- a/tests/test_ttnn/test_llama3_transformer_ops.py
+++ b/tests/test_ttnn/test_llama3_transformer_ops.py
@@ -1,0 +1,292 @@
+# SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for llama3 transformer device ops in the TTNN shim (issue #468).
+
+Shapes mirror the llama3-8B prefill/decode HW profiler traces
+(blackhole p100a, 2026-06-18).
+"""
+
+import pytest
+
+import ttsim.front.ttnn as ttnn
+from ttsim.front.ttnn.device import ARCH, Device
+from ttsim.front.ttnn.tensor import DataType, Layout, Tensor
+from ttsim.front.ttnn.ttnn_shim import (
+    nlp_concat_heads_decode_op,
+    nlp_create_qkv_heads_decode_op,
+    paged_fill_cache_op,
+    paged_fused_update_cache_op,
+    rotary_embedding_llama_fused_qk_op,
+    rotary_embedding_llama_op,
+    scaled_dot_product_attention_op,
+)
+
+
+def _make_device():
+    device = Device(device_id=0)
+    device.architecture = ARCH.BLACKHOLE
+    return device
+
+
+def _t(device, shape, name, dtype=DataType.BFLOAT16, layout=Layout.TILE_LAYOUT):
+    return Tensor(name=name, shape=shape, dtype=dtype, layout=layout, device=device)
+
+
+# =========================================================================
+# rotary_embedding_llama (prefill) — output = x shape
+# =========================================================================
+
+@pytest.mark.unit
+def test_rotary_embedding_llama_op_shape_and_perf():
+    device = _make_device()
+    x = _t(device, [1, 32, 128, 128], "rope_x")
+    cos = _t(device, [1, 1, 1024, 128], "rope_cos")
+    sin = _t(device, [1, 1, 1024, 128], "rope_sin")
+    trans = _t(device, [1, 1, 32, 32], "rope_trans")
+    out = rotary_embedding_llama_op(x, cos, sin, trans)
+    assert out.logical_shape().as_list() == [1, 32, 128, 128]
+    ops = [op for op in device.ops.values() if op.optype == "RotaryEmbeddingLlama"]
+    assert len(ops) == 1
+    assert x.name in ops[0].inList and cos.name in ops[0].inList
+    assert out.name in ops[0].outList
+    assert ops[0].perf_stats is not None
+
+
+@pytest.mark.unit
+def test_rotary_embedding_llama_via_experimental():
+    device = _make_device()
+    x = _t(device, [1, 32, 128, 128], "rope2_x")
+    cos = _t(device, [1, 1, 1024, 128], "rope2_cos")
+    sin = _t(device, [1, 1, 1024, 128], "rope2_sin")
+    trans = _t(device, [1, 1, 32, 32], "rope2_trans")
+    out = ttnn.experimental.rotary_embedding_llama(x, cos, sin, trans, is_decode_mode=False)
+    assert out.logical_shape().as_list() == [1, 32, 128, 128]
+    assert any(op.optype == "RotaryEmbeddingLlama" for op in device.ops.values())
+
+
+# =========================================================================
+# rotary_embedding_llama_fused_qk (decode) — multi-output (q, k)
+# =========================================================================
+
+@pytest.mark.unit
+def test_rotary_embedding_llama_fused_qk_op_shapes():
+    device = _make_device()
+    q = _t(device, [1, 1, 32, 128], "fqk_q")
+    k = _t(device, [1, 1, 32, 128], "fqk_k")
+    cos = _t(device, [1, 2, 32, 128], "fqk_cos")
+    sin = _t(device, [1, 2, 32, 128], "fqk_sin")
+    trans = _t(device, [1, 1, 64, 32], "fqk_trans")
+    q_out, k_out = rotary_embedding_llama_fused_qk_op(q, k, cos, sin, trans)
+    assert q_out.logical_shape().as_list() == [1, 1, 32, 128]
+    assert k_out.logical_shape().as_list() == [1, 1, 32, 128]
+    ops = [op for op in device.ops.values() if op.optype == "RotaryEmbeddingLlamaFusedQK"]
+    assert len(ops) == 1
+    assert len(ops[0].outList) == 2
+
+
+@pytest.mark.unit
+def test_rotary_embedding_llama_fused_qk_via_experimental():
+    device = _make_device()
+    q = _t(device, [1, 1, 32, 128], "fqk2_q")
+    k = _t(device, [1, 1, 32, 128], "fqk2_k")
+    cos = _t(device, [1, 2, 32, 128], "fqk2_cos")
+    sin = _t(device, [1, 2, 32, 128], "fqk2_sin")
+    trans = _t(device, [1, 1, 64, 32], "fqk2_trans")
+    q_out, k_out = ttnn.experimental.rotary_embedding_llama_fused_qk(q, k, cos, sin, trans)
+    assert q_out.logical_shape().as_list() == [1, 1, 32, 128]
+    assert k_out.logical_shape().as_list() == [1, 1, 32, 128]
+
+
+# =========================================================================
+# paged_fill_cache (prefill) — output = cache shape (passthrough)
+# =========================================================================
+
+@pytest.mark.unit
+def test_paged_fill_cache_op_shape():
+    device = _make_device()
+    cache = _t(device, [1024, 8, 32, 128], "pfc_cache")
+    inp = _t(device, [1, 8, 128, 128], "pfc_in")
+    page_table = _t(device, [1, 1, 1, 4], "pfc_pt", dtype=DataType.INT32,
+                    layout=Layout.ROW_MAJOR_LAYOUT)
+    out = paged_fill_cache_op(cache, inp, page_table=page_table, batch_idx=0)
+    assert out.logical_shape().as_list() == [1024, 8, 32, 128]
+    ops = [op for op in device.ops.values() if op.optype == "PagedFillCache"]
+    assert len(ops) == 1
+    assert ops[0].attrs["batch_idx"] == 0
+    assert cache.name in ops[0].inList and inp.name in ops[0].inList
+
+
+@pytest.mark.unit
+def test_paged_fill_cache_via_experimental():
+    device = _make_device()
+    cache = _t(device, [1024, 8, 32, 128], "pfc2_cache")
+    inp = _t(device, [1, 8, 128, 128], "pfc2_in")
+    pt = _t(device, [1, 1, 1, 4], "pfc2_pt", dtype=DataType.INT32,
+            layout=Layout.ROW_MAJOR_LAYOUT)
+    out = ttnn.experimental.paged_fill_cache(cache, inp, pt, batch_idx=3)
+    assert out.logical_shape().as_list() == [1024, 8, 32, 128]
+
+
+# =========================================================================
+# paged_fused_update_cache (decode) — multi-output (k_cache, v_cache)
+# =========================================================================
+
+@pytest.mark.unit
+def test_paged_fused_update_cache_op_shapes():
+    device = _make_device()
+    k_cache = _t(device, [1024, 8, 32, 128], "pfu_kc")
+    k = _t(device, [1, 1, 32, 128], "pfu_k")
+    v_cache = _t(device, [1024, 8, 32, 128], "pfu_vc")
+    v = _t(device, [1, 1, 32, 128], "pfu_v")
+    upd = _t(device, [1, 1, 1, 1], "pfu_upd", dtype=DataType.INT32,
+             layout=Layout.ROW_MAJOR_LAYOUT)
+    pt = _t(device, [1, 1, 1, 1024], "pfu_pt", dtype=DataType.INT32,
+            layout=Layout.ROW_MAJOR_LAYOUT)
+    k_out, v_out = paged_fused_update_cache_op(
+        k_cache, k, v_cache, v, update_idxs_tensor=upd, page_table=pt,
+    )
+    assert k_out.logical_shape().as_list() == [1024, 8, 32, 128]
+    assert v_out.logical_shape().as_list() == [1024, 8, 32, 128]
+    ops = [op for op in device.ops.values() if op.optype == "PagedFusedUpdateCache"]
+    assert len(ops) == 1
+    assert len(ops[0].outList) == 2
+
+
+@pytest.mark.unit
+def test_paged_fused_update_cache_via_experimental():
+    device = _make_device()
+    k_cache = _t(device, [1024, 8, 32, 128], "pfu2_kc")
+    k = _t(device, [1, 1, 32, 128], "pfu2_k")
+    v_cache = _t(device, [1024, 8, 32, 128], "pfu2_vc")
+    v = _t(device, [1, 1, 32, 128], "pfu2_v")
+    upd = _t(device, [1, 1, 1, 1], "pfu2_upd", dtype=DataType.INT32,
+             layout=Layout.ROW_MAJOR_LAYOUT)
+    pt = _t(device, [1, 1, 1, 1024], "pfu2_pt", dtype=DataType.INT32,
+            layout=Layout.ROW_MAJOR_LAYOUT)
+    k_out, v_out = ttnn.experimental.paged_fused_update_cache(
+        k_cache, k, v_cache, v, update_idxs_tensor=upd, page_table=pt,
+    )
+    assert k_out.logical_shape().as_list() == [1024, 8, 32, 128]
+    assert v_out.logical_shape().as_list() == [1024, 8, 32, 128]
+
+
+# =========================================================================
+# nlp_create_qkv_heads_decode (decode) — multi-output (q, k, v)
+# =========================================================================
+
+@pytest.mark.unit
+def test_nlp_create_qkv_heads_decode_op_shapes():
+    device = _make_device()
+    num_heads, num_kv_heads, head_dim = 32, 8, 128
+    hidden = (num_heads + 2 * num_kv_heads) * head_dim  # 6144
+    x = _t(device, [1, 1, 32, hidden], "ncqd_x")
+    q, k, v = nlp_create_qkv_heads_decode_op(
+        x, num_heads=num_heads, num_kv_heads=num_kv_heads, head_dim=head_dim,
+    )
+    assert q.logical_shape().as_list() == [1, 1, num_heads, head_dim]
+    assert k.logical_shape().as_list() == [1, 1, num_kv_heads, head_dim]
+    assert v.logical_shape().as_list() == [1, 1, num_kv_heads, head_dim]
+    ops = [op for op in device.ops.values() if op.optype == "NLPCreateQKVHeadsDecode"]
+    assert len(ops) == 1
+    assert len(ops[0].outList) == 3
+
+
+@pytest.mark.unit
+def test_nlp_create_qkv_heads_decode_via_experimental():
+    device = _make_device()
+    hidden = (32 + 2 * 8) * 128
+    x = _t(device, [1, 1, 32, hidden], "ncqd2_x")
+    q, k, v = ttnn.experimental.nlp_create_qkv_heads_decode(
+        x, num_heads=32, num_kv_heads=8,
+    )
+    assert q.logical_shape().as_list() == [1, 1, 32, 128]
+    assert k.logical_shape().as_list() == [1, 1, 8, 128]
+    assert v.logical_shape().as_list() == [1, 1, 8, 128]
+
+
+# =========================================================================
+# nlp_concat_heads_decode (decode) — single output, head_dim folded into X
+# =========================================================================
+
+@pytest.mark.unit
+def test_nlp_concat_heads_decode_op_shape():
+    device = _make_device()
+    x = _t(device, [1, 1, 32, 128], "nchd_x")
+    out = nlp_concat_heads_decode_op(x, num_heads=32)
+    assert out.logical_shape().as_list() == [1, 1, 32, 32 * 128]  # X = 4096
+    ops = [op for op in device.ops.values() if op.optype == "NLPConcatHeadsDecode"]
+    assert len(ops) == 1
+    assert ops[0].perf_stats is not None
+
+
+@pytest.mark.unit
+def test_nlp_concat_heads_decode_via_experimental():
+    device = _make_device()
+    x = _t(device, [1, 1, 32, 128], "nchd2_x")
+    out = ttnn.experimental.nlp_concat_heads_decode(x, num_heads=32)
+    assert out.logical_shape().as_list() == [1, 1, 32, 4096]
+
+
+# =========================================================================
+# scaled_dot_product_attention (prefill + decode) — output = q shape
+# =========================================================================
+
+@pytest.mark.unit
+def test_sdpa_prefill_op_shape():
+    device = _make_device()
+    q = _t(device, [1, 32, 128, 128], "sdpa_q")
+    k = _t(device, [1, 8, 128, 128], "sdpa_k")
+    v = _t(device, [1, 8, 128, 128], "sdpa_v")
+    out = scaled_dot_product_attention_op(q, k, v, is_causal=True, scale=0.088)
+    assert out.logical_shape().as_list() == [1, 32, 128, 128]
+    ops = [op for op in device.ops.values() if op.optype == "ScaledDotProductAttention"]
+    assert len(ops) == 1
+    assert ops[0].attrs["is_causal"] is True
+
+
+@pytest.mark.unit
+def test_sdpa_prefill_via_transformer():
+    device = _make_device()
+    q = _t(device, [1, 32, 128, 128], "sdpa2_q")
+    k = _t(device, [1, 8, 128, 128], "sdpa2_k")
+    v = _t(device, [1, 8, 128, 128], "sdpa2_v")
+    out = ttnn.transformer.scaled_dot_product_attention(q, k, v, is_causal=True, scale=0.088)
+    assert out.logical_shape().as_list() == [1, 32, 128, 128]
+
+
+@pytest.mark.unit
+def test_paged_sdpa_decode_via_transformer():
+    device = _make_device()
+    q = _t(device, [1, 1, 32, 128], "psd_q")
+    k_cache = _t(device, [1024, 8, 32, 128], "psd_kc")
+    v_cache = _t(device, [1024, 8, 32, 128], "psd_vc")
+    cur_pos = _t(device, [1, 1, 1, 1], "psd_cp", dtype=DataType.INT32,
+                 layout=Layout.ROW_MAJOR_LAYOUT)
+    pt = _t(device, [1, 1, 1, 1024], "psd_pt", dtype=DataType.INT32,
+            layout=Layout.ROW_MAJOR_LAYOUT)
+    out = ttnn.transformer.paged_scaled_dot_product_attention_decode(
+        q, k_cache, v_cache, page_table_tensor=pt, cur_pos_tensor=cur_pos, scale=0.088,
+    )
+    assert out.logical_shape().as_list() == [1, 1, 32, 128]
+    ops = [op for op in device.ops.values() if op.optype == "ScaledDotProductAttention"]
+    assert len(ops) == 1
+
+
+# =========================================================================
+# UnaryOpType — fused activation on a binary op (MLP silu fused into the Mul,
+# matching the HW BinaryNg single-op; no separate silu op emitted)
+# =========================================================================
+
+@pytest.mark.unit
+def test_binary_fused_activation_silu():
+    assert ttnn.UnaryOpType.SILU == "SILU"  # resolves on the shim path (mirrors ttnn.UnaryOpType)
+    device = _make_device()
+    a = _t(device, [1, 1, 32, 14336], "mlp_w1_out")
+    b = _t(device, [1, 1, 32, 14336], "mlp_w3_out")
+    out = ttnn.multiply(a, b, input_tensor_a_activations=[ttnn.UnaryOpType.SILU])
+    assert out.logical_shape().as_list() == [1, 1, 32, 14336]
+    # ONE Mul op carrying the fused activation as an attr — no separate silu op
+    muls = [op for op in device.ops.values() if op.optype == "Mul"]
+    assert len(muls) == 1
+    assert muls[0].attrs.get("input_tensor_a_activations") == [ttnn.UnaryOpType.SILU]

--- a/tools/profiling/op_canonical.py
+++ b/tools/profiling/op_canonical.py
@@ -50,6 +50,15 @@ PROFILER_PREFIX_RULES: tuple[tuple[str, str], ...] = (
     ("CreateQKVHeads", "createqkvheads"),
     ("NLPConcatHeads", "concatheads"),
     ("ConcatHeads", "concatheads"),
+    # llama3/transformer ops — canonical = lowercased shim optype (ttsim/front/ttnn) so
+    # sim and profiler keys agree. FusedQK (decode) MUST precede the bare RotaryEmbeddingLlama
+    # prefix (first-match-wins). Sdpa covers profiler SDPAOperation + SdpaDecode → shim's
+    # single ScaledDotProductAttention optype.
+    ("RotaryEmbeddingLlamaFusedQK", "rotaryembeddingllamafusedqk"),
+    ("RotaryEmbeddingLlama", "rotaryembeddingllama"),
+    ("PagedFusedUpdateCache", "pagedfusedupdatecache"),
+    ("PagedFillCache", "pagedfillcache"),
+    ("Sdpa", "scaleddotproductattention"),
     ("UntilizeWithValUnpadding", "untilizewithunpadding"),  # Polaris variant with "Val"
     ("UntilizeWithUnpadding", "untilizewithunpadding"),
     ("Untilize", "untilize"),

--- a/tools/si_profiling_helpers/README.md
+++ b/tools/si_profiling_helpers/README.md
@@ -15,6 +15,7 @@ These scripts are part of the **Polaris** repository but are designed to work al
 ```
 workspace/
 ├── si_profiling_helpers/      # These helper scripts (from polaris/tools/si_profiling_helpers/)
+│   ├── setup-step-0-clean.sh
 │   ├── setup-step-1-fresh-build.sh
 │   ├── setup-step-2-new-login.sh
 │   ├── run-ttnn-profiler.py
@@ -69,6 +70,14 @@ source ../si_profiling_helpers/setup-step-2-new-login.sh
 ## Scripts Index
 
 ### Setup Scripts
+
+#### [`setup-step-0-clean.sh`](setup-step-0-clean.sh)
+Full clean of the workspace so a fresh build starts from scratch — the opposite of step-1.
+Runs three independent removals: `build_metal.sh --clean` (tt-metal C++/kernel artifacts, which
+does **not** touch `python_env`), `rm -rf python_env`, and `rm -rf ../tt-npe/build ../tt-npe/install`.
+- **When to use:** Clean before a fresh build — run this, then `setup-step-1-fresh-build.sh`.
+- **Usage:** `cd /path/to/tt-metal && bash setup-step-0-clean.sh`
+- **Prerequisites:** Run from the tt-metal repo root; no virtualenv active (`deactivate` first); tt-npe at `../tt-npe`
 
 #### [`setup-step-1-fresh-build.sh`](setup-step-1-fresh-build.sh)
 Initial setup script for fresh tt-metal installation.
@@ -243,6 +252,7 @@ See individual script headers for complete documentation.
 ```
 si_profiling_helpers/
 ├── README.md                      # This file
+├── setup-step-0-clean.sh          # Full workspace clean before a fresh build
 ├── setup-step-1-fresh-build.sh    # Initial build setup
 ├── setup-step-2-new-login.sh      # Session environment setup
 ├── run-ttnn-profiler.py           # TTNN profiler runner
@@ -268,4 +278,4 @@ When adding new scripts:
 
 ---
 
-**Last Updated:** April 8, 2026
+**Last Updated:** July 3, 2026

--- a/tools/si_profiling_helpers/ops_perf_three_csv_merge.py
+++ b/tools/si_profiling_helpers/ops_perf_three_csv_merge.py
@@ -16,8 +16,9 @@ import argparse
 import csv
 import math
 import sys
+from functools import partial
 from pathlib import Path
-from typing import Dict, FrozenSet, Iterable, List, Optional, Sequence, Tuple
+from typing import Callable, Dict, FrozenSet, Iterable, List, Optional, Sequence, Tuple
 
 from loguru import logger
 
@@ -659,6 +660,77 @@ def validate_iteration_args(
                 )
 
 
+# A row reducer takes the three variant row lists (noctrace, fpu, vanilla) and
+# returns reduced lists of equal length — one row per op for a single
+# representative pass.  It is injected into run_merge so alternate reduction
+# strategies (e.g. the trace+replay replay-session reducer in
+# ops_perf_trace_replay_merge.py) can replace the default iteration reducer
+# without duplicating the shared classify / header-check / join / output
+# machinery.  When run_merge is called without a reducer it builds the default
+# iteration reducer below from its CLI iteration args.
+Reducer = Callable[
+    [List[Dict[str, str]], List[Dict[str, str]], List[Dict[str, str]]],
+    Tuple[List[Dict[str, str]], List[Dict[str, str]], List[Dict[str, str]]],
+]
+
+
+def reduce_iterative(
+    rows_noc: List[Dict[str, str]],
+    rows_fpu: List[Dict[str, str]],
+    rows_van: List[Dict[str, str]],
+    *,
+    cli_num_iterations: Optional[int] = None,
+    cli_ops_per_iteration: Optional[int] = None,
+    cli_measured_indices: Optional[List[int]] = None,
+    cli_select_iteration: str = "median",
+) -> Tuple[List[Dict[str, str]], List[Dict[str, str]], List[Dict[str, str]]]:
+    """Reduce a multi-iteration capture to a single representative iteration.
+
+    Detect iterations on the vanilla CSV (canonical timing), pick one iteration
+    by ``cli_select_iteration`` (default: median total kernel duration), then
+    apply the same row range to all three CSVs (the three variants share
+    iteration layout — same model invocation pattern, same GCC numbering).
+    A single detected iteration passes all rows through unchanged.
+    """
+    iters = detect_iteration_boundaries(rows_van, ops_per_iteration=cli_ops_per_iteration)
+    summary = iteration_summary(rows_van, iters)
+    iter_size = iters[0][1] - iters[0][0] if iters else 0
+    validate_iteration_args(
+        summary,
+        cli_num_iterations=cli_num_iterations,
+        cli_measured_indices=cli_measured_indices,
+    )
+    if len(iters) > 1:
+        start, end, chosen_idx = pick_median_iteration(
+            summary,
+            measured_indices=cli_measured_indices,
+            select=cli_select_iteration,
+        )
+        # Sanity-check that all 3 CSVs have the same row count (synchronized iteration layout).
+        for label, r in (("noctrace", rows_noc), ("fpu", rows_fpu), ("vanilla", rows_van)):
+            if len(r) != len(rows_van):
+                raise MergeError(
+                    f"Pre-filter row count differs ({label}={len(r)} vs vanilla={len(rows_van)}); "
+                    "iteration layouts must be synchronized across the three variants."
+                )
+        rows_noc = filter_to_iteration(rows_noc, start, end)
+        rows_fpu = filter_to_iteration(rows_fpu, start, end)
+        rows_van = filter_to_iteration(rows_van, start, end)
+        logger.info(
+            "Iteration filter: detected {} iteration(s) of {} ops each ({} complete); "
+            "selected iter {} (rows {}..{}, total kdur={} ns, select={!r}).",
+            len(iters),
+            iter_size,
+            sum(1 for s in summary if s[2]),
+            chosen_idx,
+            start,
+            end - 1,
+            summary[chosen_idx][3],
+            cli_select_iteration,
+        )
+    return rows_noc, rows_fpu, rows_van
+
+
 def run_merge(
     input_dir: Path,
     output_path: Path,
@@ -669,6 +741,7 @@ def run_merge(
     cli_ops_per_iteration: Optional[int] = None,
     cli_measured_indices: Optional[List[int]] = None,
     cli_select_iteration: str = "median",
+    reducer: Optional[Reducer] = None,
 ) -> None:
     paths = discover_csv_paths(input_dir)
     if len(paths) != 3:
@@ -753,46 +826,20 @@ def run_merge(
     rows_fpu = next(r for p, _, r in loaded if p == path_fpu)
     rows_van = next(r for p, _, r in loaded if p == path_van)
 
-    # Iteration filtering: detect iterations on the vanilla CSV (canonical timing),
-    # pick one iteration by --select-iteration (default: median total kernel duration),
-    # then apply the same row range to all three CSVs (the three variants share
-    # iteration layout — same model invocation pattern, same GCC numbering).
-    iters = detect_iteration_boundaries(rows_van, ops_per_iteration=cli_ops_per_iteration)
-    summary = iteration_summary(rows_van, iters)
-    iter_size = iters[0][1] - iters[0][0] if iters else 0
-    validate_iteration_args(
-        summary,
-        cli_num_iterations=cli_num_iterations,
-        cli_measured_indices=cli_measured_indices,
-    )
-    if len(iters) > 1:
-        start, end, chosen_idx = pick_median_iteration(
-            summary,
-            measured_indices=cli_measured_indices,
-            select=cli_select_iteration,
+    # Row reduction: collapse the capture to a single representative pass (one
+    # row per op) before the join.  The default reducer detects and selects one
+    # iteration on the vanilla CSV, then applies the same range to all three
+    # (the three variants share iteration layout).  A caller-supplied reducer
+    # (e.g. the trace+replay replay-session reducer) replaces this strategy.
+    if reducer is None:
+        reducer = partial(
+            reduce_iterative,
+            cli_num_iterations=cli_num_iterations,
+            cli_ops_per_iteration=cli_ops_per_iteration,
+            cli_measured_indices=cli_measured_indices,
+            cli_select_iteration=cli_select_iteration,
         )
-        # Sanity-check that all 3 CSVs have the same row count (synchronized iteration layout).
-        for label, r in (("noctrace", rows_noc), ("fpu", rows_fpu), ("vanilla", rows_van)):
-            if len(r) != len(rows_van):
-                raise MergeError(
-                    f"Pre-filter row count differs ({label}={len(r)} vs vanilla={len(rows_van)}); "
-                    "iteration layouts must be synchronized across the three variants."
-                )
-        rows_noc = filter_to_iteration(rows_noc, start, end)
-        rows_fpu = filter_to_iteration(rows_fpu, start, end)
-        rows_van = filter_to_iteration(rows_van, start, end)
-        logger.info(
-            "Iteration filter: detected {} iteration(s) of {} ops each ({} complete); "
-            "selected iter {} (rows {}..{}, total kdur={} ns, select={!r}).",
-            len(iters),
-            iter_size,
-            sum(1 for s in summary if s[2]),
-            chosen_idx,
-            start,
-            end - 1,
-            summary[chosen_idx][3],
-            cli_select_iteration,
-        )
+    rows_noc, rows_fpu, rows_van = reducer(rows_noc, rows_fpu, rows_van)
 
     if len(rows_noc) != len(rows_fpu) or len(rows_noc) != len(rows_van):
         raise MergeError(

--- a/tools/si_profiling_helpers/ops_perf_trace_replay_merge.py
+++ b/tools/si_profiling_helpers/ops_perf_trace_replay_merge.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Merge three TT-Metal ops perf CSVs from a **non-iterative trace+replay** capture.
+
+Specification: doc/SPEC_ops_perf_trace_replay_merge.md
+
+This is the trace+replay sibling of ``ops_perf_three_csv_merge.py`` (the iterative,
+VGG-style merge).  It reuses that module's classify / header-check / join / output
+machinery verbatim and only swaps the *row-reduction* step: instead of detecting
+and selecting one iteration, it selects one **replay session** and drops the
+compile/warmup pass, so the join keys are unique.
+
+Why a separate reducer
+----------------------
+A trace+replay capture (ViT, llama3 decode/prefill) is *not* the concatenation of
+equal-size iterations that the iterative reducer expects.  It is one warmup/compile
+pass followed by N replays of a captured trace.  TT-Metal tags each op with
+``METAL TRACE REPLAY SESSION ID``:
+
+* ``''`` (blank)  -> the compile/warmup pass (ops dispatched individually before the
+  trace is captured); its op set overlaps the replay op set, so keeping it makes the
+  ``(GLOBAL CALL COUNT, OP CODE, OP TYPE)`` join key non-unique.
+* ``'1'``, ``'2'``, ...  -> successive replays of the captured trace; within any one
+  replay session the join keys are unique and identical across the raw/perf/trace
+  variants.
+
+The iterative reducer's first-op marker heuristic mis-fires here (the marker recurs
+intra-pass, giving unequal chunks), and the downstream join then aborts on the
+duplicate key.  This reducer instead keeps exactly one replay session — steady-state,
+compile cost excluded — and hands unique keys to the shared join.
+
+Composition (trace+replay+iterative)
+------------------------------------
+If a future capture is trace+replay **and** iterative (a replay session that itself
+contains several concatenated iterations), the selected session's join keys will not
+be unique.  In that case (unless ``--no-compose-iteration``) the iterative reducer is
+applied *within* the selected session, composing the two reductions.  For the common
+one-inference-per-session case the keys are already unique and no iteration reduction
+runs (so the iterative marker heuristic — and its warning — is never triggered).
+
+Uses stdlib **csv**; **loguru** for warnings/info.  Exit 0 on success, 1 on error.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from functools import partial
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from loguru import logger
+
+# Reuse the shared machinery from the iterative merge tool verbatim.  Only the
+# row-reduction strategy differs (replay-session selection vs iteration selection).
+# Dual import so this works both as a package module under pytest / `mypy ./`
+# (imported as tools.si_profiling_helpers.*) and as an on-device script, where the
+# rsynced bundle is a flat directory of scripts with no package path (the bare name
+# resolves because the script's own directory is sys.path[0]).  The package import
+# is listed first so `mypy ./` (run from the repo root) resolves the module.
+try:
+    from tools.si_profiling_helpers import ops_perf_three_csv_merge as _merge
+except ModuleNotFoundError:  # on-device flat script bundle: no package path
+    import ops_perf_three_csv_merge as _merge  # type: ignore[import-not-found, no-redef]
+
+COL_DEVICE_KERNEL_NS = _merge.COL_DEVICE_KERNEL_NS
+COL_GLOBAL_CALL_COUNT = _merge.COL_GLOBAL_CALL_COUNT
+COL_OP_CODE = _merge.COL_OP_CODE
+COL_OP_TYPE = _merge.COL_OP_TYPE
+MergeError = _merge.MergeError
+parse_finite_float = _merge.parse_finite_float
+reduce_iterative = _merge.reduce_iterative
+run_merge = _merge.run_merge
+_strip_cell = _merge._strip_cell
+
+# TT-Metal tags each op with the replay session it belongs to; the compile/warmup
+# pass carries a blank id.  (METAL TRACE ID also exists but is not needed for
+# reduction — the replay session id alone discriminates warmup from each replay.)
+COL_REPLAY_SESSION_ID = "METAL TRACE REPLAY SESSION ID"
+
+SESSION_SELECT_CHOICES: Tuple[str, ...] = ("median", "min", "max", "first", "last")
+
+
+def _session_id(row: Dict[str, str]) -> str:
+    """Stripped replay-session id for a row ('' = compile/warmup pass)."""
+    return _strip_cell(row.get(COL_REPLAY_SESSION_ID))
+
+
+def replay_session_ids(rows: Sequence[Dict[str, str]]) -> List[str]:
+    """Distinct non-blank replay-session ids, in first-appearance (capture) order."""
+    seen: set = set()
+    out: List[str] = []
+    for r in rows:
+        sid = _session_id(r)
+        if sid and sid not in seen:
+            seen.add(sid)
+            out.append(sid)
+    return out
+
+
+def _session_total_kdur_ns(rows: Sequence[Dict[str, str]], sid: str) -> float:
+    """Sum of DEVICE KERNEL DURATION [ns] over the rows of one replay session."""
+    total = 0.0
+    for r in rows:
+        if _session_id(r) == sid:
+            v = parse_finite_float(r.get(COL_DEVICE_KERNEL_NS))
+            if v is not None:
+                total += v
+    return total
+
+
+def select_replay_session(rows_van: Sequence[Dict[str, str]], select: str) -> str:
+    """Return the replay-session id to keep, chosen from the vanilla CSV.
+
+    Selection vocabulary matches the iterative tool's ``--select-iteration``:
+      * ``median`` — lower-middle by total kernel ns (stable; the default).
+      * ``min`` / ``max`` — least / greatest total kernel ns.
+      * ``first`` / ``last`` — earliest / latest replay session in capture order.
+
+    The compile/warmup pass (blank session id) is never a candidate.
+    """
+    sessions = replay_session_ids(rows_van)
+    if not sessions:
+        raise MergeError(
+            f"No populated {COL_REPLAY_SESSION_ID!r} values found — this does not look like a "
+            "trace+replay capture. Use ops_perf_three_csv_merge.py for iterative (VGG-style) runs."
+        )
+    if select in ("first", "last"):
+        chosen = sessions[0] if select == "first" else sessions[-1]
+    else:
+        totals = [(sid, _session_total_kdur_ns(rows_van, sid)) for sid in sessions]
+        if select == "min":
+            chosen = min(totals, key=lambda x: x[1])[0]
+        elif select == "max":
+            chosen = max(totals, key=lambda x: x[1])[0]
+        elif select == "median":
+            ordered = sorted(totals, key=lambda x: x[1])
+            chosen = ordered[(len(ordered) - 1) // 2][0]  # lower-middle for even counts
+        else:
+            raise MergeError(f"Unknown --select-session value: {select!r}")
+    return chosen
+
+
+def _keys_unique(rows: Sequence[Dict[str, str]]) -> bool:
+    """True if every (GLOBAL CALL COUNT, OP CODE, OP TYPE) join key in rows is distinct."""
+    seen: set = set()
+    for r in rows:
+        k = (
+            _strip_cell(r.get(COL_GLOBAL_CALL_COUNT)),
+            _strip_cell(r.get(COL_OP_CODE)),
+            _strip_cell(r.get(COL_OP_TYPE)),
+        )
+        if k in seen:
+            return False
+        seen.add(k)
+    return True
+
+
+def reduce_trace_replay(
+    rows_noc: List[Dict[str, str]],
+    rows_fpu: List[Dict[str, str]],
+    rows_van: List[Dict[str, str]],
+    *,
+    select_session: str = "median",
+    compose_iteration: bool = True,
+    cli_ops_per_iteration: Optional[int] = None,
+    cli_measured_indices: Optional[List[int]] = None,
+    cli_select_iteration: str = "median",
+) -> Tuple[List[Dict[str, str]], List[Dict[str, str]], List[Dict[str, str]]]:
+    """Reduce a trace+replay capture to a single replay session.
+
+    Steps: choose one replay session from the vanilla CSV, then filter all three
+    variants to that session (dropping the compile/warmup pass and the other
+    sessions).  If the kept session still has duplicate join keys (a trace+replay
+    *and* iterative capture) and ``compose_iteration`` is set, apply the iterative
+    reducer within the session to collapse it to one iteration.
+    """
+    if COL_REPLAY_SESSION_ID not in (rows_van[0] if rows_van else {}):
+        raise MergeError(
+            f"Vanilla CSV has no {COL_REPLAY_SESSION_ID!r} column — not a trace+replay capture. "
+            "Use ops_perf_three_csv_merge.py for iterative (VGG-style) runs."
+        )
+
+    sessions = replay_session_ids(rows_van)
+    chosen = select_replay_session(rows_van, select_session)
+
+    def _keep(rows: List[Dict[str, str]]) -> List[Dict[str, str]]:
+        return [r for r in rows if _session_id(r) == chosen]
+
+    n_compile = sum(1 for r in rows_van if not _session_id(r))
+    rows_noc, rows_fpu, rows_van = _keep(rows_noc), _keep(rows_fpu), _keep(rows_van)
+    logger.info(
+        "Replay-session filter: {} session(s) {}; dropped {} compile/warmup op(s); "
+        "selected session {!r} (select={!r}) -> {} op(s) per variant.",
+        len(sessions),
+        sessions,
+        n_compile,
+        chosen,
+        select_session,
+        len(rows_van),
+    )
+
+    if not _keys_unique(rows_van):
+        if compose_iteration:
+            logger.info(
+                "Selected replay session {!r} has duplicate join keys "
+                "(trace+replay+iterative); composing the iteration reducer within the session.",
+                chosen,
+            )
+            rows_noc, rows_fpu, rows_van = reduce_iterative(
+                rows_noc,
+                rows_fpu,
+                rows_van,
+                cli_ops_per_iteration=cli_ops_per_iteration,
+                cli_measured_indices=cli_measured_indices,
+                cli_select_iteration=cli_select_iteration,
+            )
+        else:
+            raise MergeError(
+                f"Selected replay session {chosen!r} has duplicate join keys and "
+                "--no-compose-iteration was given; the join requires unique keys. "
+                "Re-run without --no-compose-iteration to reduce iterations within the session."
+            )
+    return rows_noc, rows_fpu, rows_van
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=(
+            "Merge three TT-Metal ops perf CSVs from a non-iterative trace+replay capture "
+            "(ViT, llama3) under --input-dir into one CSV, keeping a single replay session."
+        ),
+        epilog=(
+            "Default --output is <input-dir>/merged_ops.csv. For iterative (VGG-style) runs use "
+            "ops_perf_three_csv_merge.py instead. See doc/SPEC_ops_perf_trace_replay_merge.md."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--input-dir",
+        type=Path,
+        required=True,
+        help=(
+            "Root directory; recursively discovers exactly three ops_perf_results_*.csv files "
+            "(falls back to *.csv when none match), classified by content."
+        ),
+    )
+    p.add_argument(
+        "--dram-peak-bw-gbps",
+        type=float,
+        required=True,
+        help="Peak DRAM bandwidth in GB/s (used with DRAM BW UTIL (%%) for MemTraffic).",
+    )
+    p.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Output CSV path (default: <input-dir>/merged_ops.csv).",
+    )
+    p.add_argument(
+        "--duration-rel-tol",
+        type=float,
+        default=0.05,
+        help="Relative tolerance comparing DEVICE KERNEL DURATION [ns] between fpu and vanilla rows.",
+    )
+    p.add_argument(
+        "--encoding",
+        default="utf-8",
+        help="Text encoding for input and output CSV files.",
+    )
+    p.add_argument(
+        "--select-session",
+        choices=SESSION_SELECT_CHOICES,
+        default="median",
+        help=(
+            "How to choose the replay session to keep: 'median' (lower-middle by total kernel "
+            "ns), 'min', 'max', 'first', or 'last' (capture order). The compile/warmup pass "
+            "(blank session id) is always dropped."
+        ),
+    )
+    p.add_argument(
+        "--no-compose-iteration",
+        action="store_true",
+        help=(
+            "Disable the iteration reducer that otherwise runs when the selected replay session "
+            "still has duplicate join keys (a trace+replay+iterative capture). With this flag such "
+            "a capture is a hard error instead."
+        ),
+    )
+    # Forwarded to the composed iteration reducer; only take effect for a
+    # trace+replay+iterative capture (a replay session with duplicate keys).
+    p.add_argument(
+        "--ops-per-iteration",
+        type=int,
+        default=None,
+        help="Ops per iteration for the composed iteration reducer (trace+replay+iterative only).",
+    )
+    p.add_argument(
+        "--measured-iteration-indices",
+        type=str,
+        default=None,
+        help="Comma-separated 0-based iteration indices for the composed iteration reducer.",
+    )
+    p.add_argument(
+        "--select-iteration",
+        choices=("median", "min", "max", "first", "last"),
+        default="median",
+        help="Iteration selection for the composed iteration reducer (trace+replay+iterative only).",
+    )
+    return p
+
+
+def _parse_measured_indices(s: Optional[str]) -> Optional[List[int]]:
+    if s is None:
+        return None
+    out: List[int] = []
+    for part in s.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            out.append(int(part))
+        except ValueError as e:
+            raise MergeError(f"--measured-iteration-indices: cannot parse {part!r} as int") from e
+    return out if out else None
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = build_arg_parser().parse_args(list(argv) if argv is not None else None)
+    input_dir = args.input_dir.resolve()
+    out = args.output
+    out = input_dir / "merged_ops.csv" if out is None else Path(out).resolve()
+    try:
+        measured = _parse_measured_indices(args.measured_iteration_indices)
+        reducer = partial(
+            reduce_trace_replay,
+            select_session=args.select_session,
+            compose_iteration=not args.no_compose_iteration,
+            cli_ops_per_iteration=args.ops_per_iteration,
+            cli_measured_indices=measured,
+            cli_select_iteration=args.select_iteration,
+        )
+        run_merge(
+            input_dir=input_dir,
+            output_path=out,
+            dram_peak_bw_gbps=float(args.dram_peak_bw_gbps),
+            duration_rel_tol=float(args.duration_rel_tol),
+            encoding=str(args.encoding),
+            reducer=reducer,
+        )
+    except MergeError as e:
+        print(str(e), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/si_profiling_helpers/presets/README.md
+++ b/tools/si_profiling_helpers/presets/README.md
@@ -47,11 +47,17 @@ The profiler runs the command three times (basic / perf-counters / noc-traces) u
 producing `raw/`, `perf/`, and `trace/` CSVs under the `RUNID` output directory.
 
 > **Merging:** consolidating the three CSVs into a single `merged_ops_<RUNID>.csv` (RUNID =
-> the output-dir name) uses `tools/si_profiling_helpers/ops_perf_three_csv_merge.py`. It is
-> co-located with these presets (one directory up), so it ships with the rsynced bundle and
+> the output-dir name) uses one of two reducers, selected by the profiler wrapper's
+> `--merge-variant`: **`iterative`** (`ops_perf_three_csv_merge.py`, the default — for
+> multi-iteration workloads like **VGG UNet**) or **`trace_replay`**
+> (`ops_perf_trace_replay_merge.py` — for non-iterative trace+replay workloads like **ViT**
+> and **llama3**, which have a single compile pass + replay session(s), no iteration loop).
+> The `vit/` and `llama3/` presets pass `--merge-variant trace_replay`; `vggunet/` uses the
+> default. Both tools are
+> co-located with these presets (one directory up), so they ship with the rsynced bundle and
 > the merge runs **on the hardware node** right after capture (the profiler wrapper passes an
 > explicit `--output`; the tool's own default is plain `merged_ops.csv`). Only
-> `merged_ops_<RUNID>.csv` (plus `hw_id.json`) needs to be copied back. Its only third-party dependency is `loguru`, which is already in
+> `merged_ops_<RUNID>.csv` (plus `hw_id.json`, and the run-status sidecar `run_status.json` / `STATUS.txt`) needs to be copied back. Its only third-party dependency is `loguru`, which is already in
 > the tt-metal run environment. (The follow-on compare-vs-refrun step pulls in polaris/ttsim
 > and stays on a polaris checkout.)
 
@@ -112,5 +118,54 @@ and minor spelling variants still pass.
 | `vit/run-vitdual-bh.sh`         | BH | polaris dual-mode ViT |
 | `vit/run-vitref-wh.sh`          | WH | upstream tt-metal ViT device-ops |
 | `vit/run-vitref-bh.sh`          | BH | upstream tt-metal ViT device-ops |
+| `llama3/run-llama3ref-decode-b32-wh.sh`  | WH | upstream tt-metal llama3, batch-32 (decode phase) |
+| `llama3/run-llama3ref-decode-b32-bh.sh`  | BH | upstream tt-metal llama3, batch-32 (decode phase) |
+| `llama3/run-llama3ref-prefill-b32-wh.sh` | WH | upstream tt-metal llama3, batch-32 (prefill phase) — ⛔ blocked, see below |
+| `llama3/run-llama3ref-prefill-b32-bh.sh` | BH | upstream tt-metal llama3, batch-32 (prefill phase) |
+| `llama3/run-llama3ref-decode-b1-wh.sh`   | WH | upstream tt-metal llama3, batch-1 (decode phase) — batch-matched to the b1 dual |
+| `llama3/run-llama3ref-decode-b1-bh.sh`   | BH | upstream tt-metal llama3, batch-1 (decode phase) — batch-matched to the b1 dual |
+| `llama3/run-llama3ref-prefill-b1-wh.sh`  | WH | upstream tt-metal llama3, batch-1 (prefill phase) — ⛔ blocked, see below |
+| `llama3/run-llama3ref-prefill-b1-bh.sh`  | BH | upstream tt-metal llama3, batch-1 (prefill phase) |
+| `llama3/run-llama3dual-decode-wh.sh`  | WH | polaris dual-mode llama3, batch-1 (decode phase) |
+| `llama3/run-llama3dual-decode-bh.sh`  | BH | polaris dual-mode llama3, batch-1 (decode phase) |
+| `llama3/run-llama3dual-prefill-wh.sh` | WH | polaris dual-mode llama3, batch-1 (prefill phase) — ⛔ blocked, see below |
+| `llama3/run-llama3dual-prefill-bh.sh` | BH | polaris dual-mode llama3, batch-1 (prefill phase) |
 
 `check_arch.sh` is a sourced helper, not a run-script (see "Arch matching").
+
+## llama3 reference command & capture matrix
+
+The llama3 `ref` presets run the upstream tt-metal demo with the **finalized reference command**:
+
+```
+models/tt_transformers/demo/simple_text_demo.py -k "performance and batch-32" --mode {decode,prefill}
+```
+
+`-k "performance and batch-32"` selects the perf case at batch-32 (the primary batch for **both**
+p100a and n150); `--mode` splits the run into its decode and prefill phases for per-phase LUT prep.
+**Every other knob is left at the marked case's default** — no `--num_layers`,
+`--max_generated_tokens`, `--batch_size`, `--paged_attention`, `--use_prefetcher`, or seq_len. The
+reference must run the *complete* command; earlier `--num_layers 1 --max_generated_tokens 1` trial
+limits have been dropped and must not be re-added.
+
+> **Why the scripts wrap the `-k` value in nested quotes** (`-k '"performance and batch-32"'`): tracy's
+> report mode re-joins its argv with spaces and re-runs the command under `shell=True`
+> (tt-metal `tools/tracy/__main__.py`), which would split the bare words of a spaced `-k` expression
+> (`ERROR: file or directory not found: and`). The nested quotes keep the expression as one literal
+> token through both `shlex.split` (in `run-ttnn-profiler.py`) and tracy's shell re-parse. Don't
+> "simplify" them away.
+
+The `dual` presets run the migrated Polaris llama3 workload
+(`workloads/ttnn/llama3/test_llama3_{decode,prefill}.py`) through its real-`ttnn` branch on hardware,
+to validate that dual-mode perf tracks the HW reference. The dual workload runs at **batch-1**
+(decode default `bs=1`; prefill only supports `bs=1`), so the `…-b1-…` ref presets
+(`-k "performance and batch-1 and not log-probs"`) exist to give a **batch-matched** reference for
+that dual comparison; the `…-b32-…` ref presets are the primary LUT reference. The output-dir RUNID
+carries the batch tag (`b32` / `b1`) so captures at different batches don't collide.
+
+| Arch | Phase | Full-command capture available? |
+|------|-------|---------------------------------|
+| BH p100a | decode  | ✅ unblocked |
+| BH p100a | prefill | ✅ unblocked |
+| WH n150  | decode  | ✅ unblocked |
+| WH n150  | prefill | ⛔ **BLOCKED** — the WH prefill phase currently fails NoC-trace capture. This is a NoC-trace tooling issue (raised and owned by the user), **not** worked around by limiting the command. The WH prefill presets (`run-llama3ref-prefill-b32-wh.sh`, `run-llama3ref-prefill-b1-wh.sh`, `run-llama3dual-prefill-wh.sh`) carry a matching block/note; run them only after the issue is resolved, then remove the flag. |

--- a/tools/si_profiling_helpers/presets/hw_id.sh
+++ b/tools/si_profiling_helpers/presets/hw_id.sh
@@ -27,6 +27,14 @@ hw_id_board() {
 
 hw_id_write() {
     local dir="$1"
+    # A --fail-check-only run (run-ttnn-profiler.py) writes to <dir>--failcheckonly and produces NO
+    # capture (no perf CSVs, no merge), so there is nothing to attribute to a board — intentionally
+    # skip hw_id for it, quietly (this is expected, not an error). The '--failcheckonly' suffix is
+    # kept in sync with run-ttnn-profiler.py's --fail-check-only behavior.
+    if [ -n "$dir" ] && [ ! -d "$dir" ] && [ -d "${dir}--failcheckonly" ]; then
+        echo "hw_id: --fail-check-only run (${dir}--failcheckonly) — no capture provenance to record" >&2
+        return 0
+    fi
     if [ -z "$dir" ] || [ ! -d "$dir" ]; then
         echo "hw_id_write: output dir '$dir' not found — skipping hw_id capture" >&2
         return 0

--- a/tools/si_profiling_helpers/presets/llama3/run-llama3dual-decode-bh.sh
+++ b/tools/si_profiling_helpers/presets/llama3/run-llama3dual-decode-bh.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+# Run from the tt-metal checkout root. Prereqs: see ../si_profiling_helpers/presets/README.md
+# Dual-mode-on-HW validation: runs the migrated Polaris llama3 decode workload through its
+# real-ttnn branch (selected because IRD_ARCH_NAME is set). Compare against the matching
+# run-llama3ref-decode preset to confirm dual-mode perf tracks the HW reference.
+source "$(dirname "$0")/../check_arch.sh"; require_arch blackhole
+source "$(dirname "$0")/../hw_id.sh"
+BOARD=$(hw_id_board)
+HEAD=$(git rev-parse --short=7 HEAD)
+RUNID=llama3dual-decode-b1-${HEAD}-${IRD_ARCH_NAME}${BOARD:+-$BOARD}-$(date +%y%m%d)
+CMD=workloads/ttnn/llama3_dualmode/test_llama3_decode.py
+require_dual_cmd "$CMD"
+python ../si_profiling_helpers/run-ttnn-profiler.py --command "$CMD" --output-dir $RUNID --report-name $RUNID --disable-logging --merge-variant trace_replay "$@"
+rc=$?
+hw_id_write "$RUNID"
+exit "$rc"

--- a/tools/si_profiling_helpers/presets/llama3/run-llama3dual-decode-wh.sh
+++ b/tools/si_profiling_helpers/presets/llama3/run-llama3dual-decode-wh.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+# Run from the tt-metal checkout root. Prereqs: see ../si_profiling_helpers/presets/README.md
+# Dual-mode-on-HW validation: runs the migrated Polaris llama3 decode workload through its
+# real-ttnn branch (selected because IRD_ARCH_NAME is set). Compare against the matching
+# run-llama3ref-decode preset to confirm dual-mode perf tracks the HW reference.
+source "$(dirname "$0")/../check_arch.sh"; require_arch wormhole_b0
+source "$(dirname "$0")/../hw_id.sh"
+BOARD=$(hw_id_board)
+HEAD=$(git rev-parse --short=7 HEAD)
+RUNID=llama3dual-decode-b1-${HEAD}-${IRD_ARCH_NAME}${BOARD:+-$BOARD}-$(date +%y%m%d)
+CMD=workloads/ttnn/llama3_dualmode/test_llama3_decode.py
+require_dual_cmd "$CMD"
+python ../si_profiling_helpers/run-ttnn-profiler.py --command "$CMD" --output-dir $RUNID --report-name $RUNID --disable-logging --merge-variant trace_replay "$@"
+rc=$?
+hw_id_write "$RUNID"
+exit "$rc"

--- a/tools/si_profiling_helpers/presets/llama3/run-llama3dual-prefill-bh.sh
+++ b/tools/si_profiling_helpers/presets/llama3/run-llama3dual-prefill-bh.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+# Run from the tt-metal checkout root. Prereqs: see ../si_profiling_helpers/presets/README.md
+# Dual-mode-on-HW validation: runs the migrated Polaris llama3 prefill workload through its
+# real-ttnn branch (selected because IRD_ARCH_NAME is set). Compare against the matching
+# run-llama3ref-prefill preset to confirm dual-mode perf tracks the HW reference.
+source "$(dirname "$0")/../check_arch.sh"; require_arch blackhole
+source "$(dirname "$0")/../hw_id.sh"
+BOARD=$(hw_id_board)
+HEAD=$(git rev-parse --short=7 HEAD)
+RUNID=llama3dual-prefill-b1-${HEAD}-${IRD_ARCH_NAME}${BOARD:+-$BOARD}-$(date +%y%m%d)
+CMD=workloads/ttnn/llama3_dualmode/test_llama3_prefill.py
+require_dual_cmd "$CMD"
+python ../si_profiling_helpers/run-ttnn-profiler.py --command "$CMD" --output-dir $RUNID --report-name $RUNID --disable-logging --merge-variant trace_replay "$@"
+rc=$?
+hw_id_write "$RUNID"
+exit "$rc"

--- a/tools/si_profiling_helpers/presets/llama3/run-llama3dual-prefill-wh.sh
+++ b/tools/si_profiling_helpers/presets/llama3/run-llama3dual-prefill-wh.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+# Run from the tt-metal checkout root. Prereqs: see ../si_profiling_helpers/presets/README.md
+# Dual-mode-on-HW validation: runs the migrated Polaris llama3 prefill workload through its
+# real-ttnn branch (selected because IRD_ARCH_NAME is set). Compare against the matching
+# run-llama3ref-prefill preset to confirm dual-mode perf tracks the HW reference.
+#
+# ############################################################################################
+# ⛔ NOTE — WH PREFILL NoC-TRACE CAPTURE IS CURRENTLY BLOCKED (same issue as the ref preset).
+# The WH prefill phase fails NoC-trace capture (see run-llama3ref-prefill-wh.sh and the
+# capture matrix in presets/README.md). This dual capture may not complete on Wormhole until
+# that NoC-trace tooling issue — raised and owned by the user — is resolved. Decode is fine on
+# WH; both phases are fine on BH. Remove this note once the issue is fixed.
+# ############################################################################################
+# Enforce the block above until the NoC-trace issue is fixed: refuse to run by default so a
+# known-failing long capture isn't started accidentally. Set ALLOW_WH_PREFILL=1 to deliberately
+# override; remove this guard together with the block once the issue is resolved.
+[ -n "${ALLOW_WH_PREFILL:-}" ] || { echo "⛔ WH prefill capture blocked (NoC-trace issue); set ALLOW_WH_PREFILL=1 to override." >&2; exit 2; }
+source "$(dirname "$0")/../check_arch.sh"; require_arch wormhole_b0
+source "$(dirname "$0")/../hw_id.sh"
+BOARD=$(hw_id_board)
+HEAD=$(git rev-parse --short=7 HEAD)
+RUNID=llama3dual-prefill-b1-${HEAD}-${IRD_ARCH_NAME}${BOARD:+-$BOARD}-$(date +%y%m%d)
+CMD=workloads/ttnn/llama3_dualmode/test_llama3_prefill.py
+require_dual_cmd "$CMD"
+python ../si_profiling_helpers/run-ttnn-profiler.py --command "$CMD" --output-dir $RUNID --report-name $RUNID --disable-logging --merge-variant trace_replay "$@"
+rc=$?
+hw_id_write "$RUNID"
+exit "$rc"

--- a/tools/si_profiling_helpers/presets/llama3/run-llama3ref-decode-b1-bh.sh
+++ b/tools/si_profiling_helpers/presets/llama3/run-llama3ref-decode-b1-bh.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+# Run from the tt-metal checkout root. Prereqs: see ../si_profiling_helpers/presets/README.md
+source "$(dirname "$0")/../check_arch.sh"; require_arch blackhole
+source "$(dirname "$0")/../hw_id.sh"
+BOARD=$(hw_id_board)
+HEAD=$(git rev-parse --short=7 HEAD)
+RUNID=llama3-decode-b1-${HEAD}-${IRD_ARCH_NAME}${BOARD:+-$BOARD}-$(date +%y%m%d)
+# Batch-1 reference (cross-batch match test / batch-matched pair for the b1 dual), decode phase.
+# All knobs other than the batch (from the -k marker) and the phase split (--mode) are defaults.
+# NOTE on quoting: the -k value must reach pytest as ONE token. tracy's report mode re-joins its
+# argv with spaces and re-runs the command under `shell=True` (tt-metal tools/tracy/__main__.py),
+# which would otherwise split the bare words of "performance and batch-1". The nested '"..."'
+# keeps literal quotes on the token so it survives BOTH shlex.split here and tracy's shell re-parse.
+CMD="models/tt_transformers/demo/simple_text_demo.py -k '\"performance and batch-1 and not log-probs\"' --mode decode"
+require_ref_cmd "$CMD"
+export PYTEST_TIMEOUT=3600  # long device-perf capture+replay; avoid pytest-timeout abort
+python ../si_profiling_helpers/run-ttnn-profiler.py --command "$CMD" --pytest --output-dir $RUNID --report-name $RUNID --disable-logging --merge-variant trace_replay "$@"
+rc=$?
+hw_id_write "$RUNID"
+exit "$rc"

--- a/tools/si_profiling_helpers/presets/llama3/run-llama3ref-decode-b1-wh.sh
+++ b/tools/si_profiling_helpers/presets/llama3/run-llama3ref-decode-b1-wh.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+# Run from the tt-metal checkout root. Prereqs: see ../si_profiling_helpers/presets/README.md
+source "$(dirname "$0")/../check_arch.sh"; require_arch wormhole_b0
+source "$(dirname "$0")/../hw_id.sh"
+BOARD=$(hw_id_board)
+HEAD=$(git rev-parse --short=7 HEAD)
+RUNID=llama3-decode-b1-${HEAD}-${IRD_ARCH_NAME}${BOARD:+-$BOARD}-$(date +%y%m%d)
+# Batch-1 reference (cross-batch match test / batch-matched pair for the b1 dual), decode phase.
+# All knobs other than the batch (from the -k marker) and the phase split (--mode) are defaults.
+# NOTE on quoting: the -k value must reach pytest as ONE token. tracy's report mode re-joins its
+# argv with spaces and re-runs the command under `shell=True` (tt-metal tools/tracy/__main__.py),
+# which would otherwise split the bare words of "performance and batch-1". The nested '"..."'
+# keeps literal quotes on the token so it survives BOTH shlex.split here and tracy's shell re-parse.
+CMD="models/tt_transformers/demo/simple_text_demo.py -k '\"performance and batch-1 and not log-probs\"' --mode decode"
+require_ref_cmd "$CMD"
+export PYTEST_TIMEOUT=3600  # long device-perf capture+replay; avoid pytest-timeout abort
+python ../si_profiling_helpers/run-ttnn-profiler.py --command "$CMD" --pytest --output-dir $RUNID --report-name $RUNID --disable-logging --merge-variant trace_replay "$@"
+rc=$?
+hw_id_write "$RUNID"
+exit "$rc"

--- a/tools/si_profiling_helpers/presets/llama3/run-llama3ref-decode-b32-bh.sh
+++ b/tools/si_profiling_helpers/presets/llama3/run-llama3ref-decode-b32-bh.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+# Run from the tt-metal checkout root. Prereqs: see ../si_profiling_helpers/presets/README.md
+source "$(dirname "$0")/../check_arch.sh"; require_arch blackhole
+source "$(dirname "$0")/../hw_id.sh"
+BOARD=$(hw_id_board)
+HEAD=$(git rev-parse --short=7 HEAD)
+RUNID=llama3-decode-b32-${HEAD}-${IRD_ARCH_NAME}${BOARD:+-$BOARD}-$(date +%y%m%d)
+# Finalized reference command: complete batch-32 run, decode phase. All knobs other than the
+# batch (from the -k marker) and the phase split (--mode) are left at the marked case's defaults.
+# NOTE on quoting: the -k value must reach pytest as ONE token. tracy's report mode re-joins its
+# argv with spaces and re-runs the command under `shell=True` (tt-metal tools/tracy/__main__.py),
+# which would otherwise split the bare words of "performance and batch-32". The nested '"..."'
+# keeps literal quotes on the token so it survives BOTH shlex.split here and tracy's shell re-parse.
+CMD="models/tt_transformers/demo/simple_text_demo.py -k '\"performance and batch-32 and not log-probs\"' --mode decode"
+require_ref_cmd "$CMD"
+export PYTEST_TIMEOUT=3600  # long device-perf capture+replay; avoid pytest-timeout abort
+python ../si_profiling_helpers/run-ttnn-profiler.py --command "$CMD" --pytest --output-dir $RUNID --report-name $RUNID --disable-logging --merge-variant trace_replay "$@"
+rc=$?
+hw_id_write "$RUNID"
+exit "$rc"

--- a/tools/si_profiling_helpers/presets/llama3/run-llama3ref-decode-b32-wh.sh
+++ b/tools/si_profiling_helpers/presets/llama3/run-llama3ref-decode-b32-wh.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+# Run from the tt-metal checkout root. Prereqs: see ../si_profiling_helpers/presets/README.md
+source "$(dirname "$0")/../check_arch.sh"; require_arch wormhole_b0
+source "$(dirname "$0")/../hw_id.sh"
+BOARD=$(hw_id_board)
+HEAD=$(git rev-parse --short=7 HEAD)
+RUNID=llama3-decode-b32-${HEAD}-${IRD_ARCH_NAME}${BOARD:+-$BOARD}-$(date +%y%m%d)
+# Finalized reference command: complete batch-32 run, decode phase. All knobs other than the
+# batch (from the -k marker) and the phase split (--mode) are left at the marked case's defaults.
+# NOTE on quoting: the -k value must reach pytest as ONE token. tracy's report mode re-joins its
+# argv with spaces and re-runs the command under `shell=True` (tt-metal tools/tracy/__main__.py),
+# which would otherwise split the bare words of "performance and batch-32". The nested '"..."'
+# keeps literal quotes on the token so it survives BOTH shlex.split here and tracy's shell re-parse.
+CMD="models/tt_transformers/demo/simple_text_demo.py -k '\"performance and batch-32 and not log-probs\"' --mode decode"
+require_ref_cmd "$CMD"
+export PYTEST_TIMEOUT=3600  # long device-perf capture+replay; avoid pytest-timeout abort
+python ../si_profiling_helpers/run-ttnn-profiler.py --command "$CMD" --pytest --output-dir $RUNID --report-name $RUNID --disable-logging --merge-variant trace_replay "$@"
+rc=$?
+hw_id_write "$RUNID"
+exit "$rc"

--- a/tools/si_profiling_helpers/presets/llama3/run-llama3ref-prefill-b1-bh.sh
+++ b/tools/si_profiling_helpers/presets/llama3/run-llama3ref-prefill-b1-bh.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+# Run from the tt-metal checkout root. Prereqs: see ../si_profiling_helpers/presets/README.md
+source "$(dirname "$0")/../check_arch.sh"; require_arch blackhole
+source "$(dirname "$0")/../hw_id.sh"
+BOARD=$(hw_id_board)
+HEAD=$(git rev-parse --short=7 HEAD)
+RUNID=llama3-prefill-b1-${HEAD}-${IRD_ARCH_NAME}${BOARD:+-$BOARD}-$(date +%y%m%d)
+# Batch-1 reference (cross-batch match test / batch-matched pair for the b1 dual), prefill phase.
+# All knobs other than the batch (from the -k marker) and the phase split (--mode) are defaults.
+# NOTE on quoting: the -k value must reach pytest as ONE token. tracy's report mode re-joins its
+# argv with spaces and re-runs the command under `shell=True` (tt-metal tools/tracy/__main__.py),
+# which would otherwise split the bare words of "performance and batch-1". The nested '"..."'
+# keeps literal quotes on the token so it survives BOTH shlex.split here and tracy's shell re-parse.
+CMD="models/tt_transformers/demo/simple_text_demo.py -k '\"performance and batch-1 and not log-probs\"' --mode prefill"
+require_ref_cmd "$CMD"
+export PYTEST_TIMEOUT=3600  # long device-perf capture+replay; avoid pytest-timeout abort
+python ../si_profiling_helpers/run-ttnn-profiler.py --command "$CMD" --pytest --output-dir $RUNID --report-name $RUNID --disable-logging --merge-variant trace_replay "$@"
+rc=$?
+hw_id_write "$RUNID"
+exit "$rc"

--- a/tools/si_profiling_helpers/presets/llama3/run-llama3ref-prefill-b1-wh.sh
+++ b/tools/si_profiling_helpers/presets/llama3/run-llama3ref-prefill-b1-wh.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+# Run from the tt-metal checkout root. Prereqs: see ../si_profiling_helpers/presets/README.md
+#
+# ############################################################################################
+# ⛔ TEMPORARY BLOCK — WH PREFILL CANNOT COMPLETE A FULL CAPTURE YET.
+# The reference command below fails NoC-trace capture on Wormhole in the *prefill* phase only
+# (decode is fine on WH; both phases are fine on BH). This is a NoC-trace tooling issue that the
+# user has raised and owns — it is NOT worked around by limiting the command (do NOT re-add
+# --num_layers/--max_generated_tokens). It is arch+phase specific (WH prefill), independent of
+# batch. Run this preset only after the NoC-trace issue is resolved; remove this block at that
+# point. See presets/README.md capture matrix.
+# ############################################################################################
+# Enforce the block above until the NoC-trace issue is fixed: refuse to run by default so a
+# known-failing long capture isn't started accidentally. Set ALLOW_WH_PREFILL=1 to deliberately
+# override; remove this guard together with the block once the issue is resolved.
+[ -n "${ALLOW_WH_PREFILL:-}" ] || { echo "⛔ WH prefill capture blocked (NoC-trace issue); set ALLOW_WH_PREFILL=1 to override." >&2; exit 2; }
+source "$(dirname "$0")/../check_arch.sh"; require_arch wormhole_b0
+source "$(dirname "$0")/../hw_id.sh"
+BOARD=$(hw_id_board)
+HEAD=$(git rev-parse --short=7 HEAD)
+RUNID=llama3-prefill-b1-${HEAD}-${IRD_ARCH_NAME}${BOARD:+-$BOARD}-$(date +%y%m%d)
+# Batch-1 reference (cross-batch match test / batch-matched pair for the b1 dual), prefill phase.
+# All knobs other than the batch (from the -k marker) and the phase split (--mode) are defaults.
+# NOTE on quoting: the -k value must reach pytest as ONE token. tracy's report mode re-joins its
+# argv with spaces and re-runs the command under `shell=True` (tt-metal tools/tracy/__main__.py),
+# which would otherwise split the bare words of "performance and batch-1". The nested '"..."'
+# keeps literal quotes on the token so it survives BOTH shlex.split here and tracy's shell re-parse.
+CMD="models/tt_transformers/demo/simple_text_demo.py -k '\"performance and batch-1 and not log-probs\"' --mode prefill"
+require_ref_cmd "$CMD"
+export PYTEST_TIMEOUT=3600  # long device-perf capture+replay; avoid pytest-timeout abort
+python ../si_profiling_helpers/run-ttnn-profiler.py --command "$CMD" --pytest --output-dir $RUNID --report-name $RUNID --disable-logging --merge-variant trace_replay "$@"
+rc=$?
+hw_id_write "$RUNID"
+exit "$rc"

--- a/tools/si_profiling_helpers/presets/llama3/run-llama3ref-prefill-b32-bh.sh
+++ b/tools/si_profiling_helpers/presets/llama3/run-llama3ref-prefill-b32-bh.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+# Run from the tt-metal checkout root. Prereqs: see ../si_profiling_helpers/presets/README.md
+source "$(dirname "$0")/../check_arch.sh"; require_arch blackhole
+source "$(dirname "$0")/../hw_id.sh"
+BOARD=$(hw_id_board)
+HEAD=$(git rev-parse --short=7 HEAD)
+RUNID=llama3-prefill-b32-${HEAD}-${IRD_ARCH_NAME}${BOARD:+-$BOARD}-$(date +%y%m%d)
+# Finalized reference command: complete batch-32 run, prefill phase. All knobs other than the
+# batch (from the -k marker) and the phase split (--mode) are left at the marked case's defaults.
+# NOTE on quoting: the -k value must reach pytest as ONE token. tracy's report mode re-joins its
+# argv with spaces and re-runs the command under `shell=True` (tt-metal tools/tracy/__main__.py),
+# which would otherwise split the bare words of "performance and batch-32". The nested '"..."'
+# keeps literal quotes on the token so it survives BOTH shlex.split here and tracy's shell re-parse.
+CMD="models/tt_transformers/demo/simple_text_demo.py -k '\"performance and batch-32 and not log-probs\"' --mode prefill"
+require_ref_cmd "$CMD"
+export PYTEST_TIMEOUT=3600  # long device-perf capture+replay; avoid pytest-timeout abort
+python ../si_profiling_helpers/run-ttnn-profiler.py --command "$CMD" --pytest --output-dir $RUNID --report-name $RUNID --disable-logging --merge-variant trace_replay "$@"
+rc=$?
+hw_id_write "$RUNID"
+exit "$rc"

--- a/tools/si_profiling_helpers/presets/llama3/run-llama3ref-prefill-b32-wh.sh
+++ b/tools/si_profiling_helpers/presets/llama3/run-llama3ref-prefill-b32-wh.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+# Run from the tt-metal checkout root. Prereqs: see ../si_profiling_helpers/presets/README.md
+#
+# ############################################################################################
+# ⛔ TEMPORARY BLOCK — WH PREFILL CANNOT COMPLETE A FULL CAPTURE YET.
+# The finalized reference command below fails NoC-trace capture on Wormhole in the *prefill*
+# phase only (decode is fine on WH; both phases are fine on BH). This is a NoC-trace tooling
+# issue that the user has raised and owns — it is NOT worked around by limiting the command
+# (do NOT re-add --num_layers/--max_generated_tokens). Run this preset only after the NoC-trace
+# issue is resolved; remove this block at that point. See presets/README.md capture matrix.
+# ############################################################################################
+# Enforce the block above until the NoC-trace issue is fixed: refuse to run by default so a
+# known-failing long capture isn't started accidentally. Set ALLOW_WH_PREFILL=1 to deliberately
+# override; remove this guard together with the block once the issue is resolved.
+[ -n "${ALLOW_WH_PREFILL:-}" ] || { echo "⛔ WH prefill capture blocked (NoC-trace issue); set ALLOW_WH_PREFILL=1 to override." >&2; exit 2; }
+source "$(dirname "$0")/../check_arch.sh"; require_arch wormhole_b0
+source "$(dirname "$0")/../hw_id.sh"
+BOARD=$(hw_id_board)
+HEAD=$(git rev-parse --short=7 HEAD)
+RUNID=llama3-prefill-b32-${HEAD}-${IRD_ARCH_NAME}${BOARD:+-$BOARD}-$(date +%y%m%d)
+# Finalized reference command: complete batch-32 run, prefill phase. All knobs other than the
+# batch (from the -k marker) and the phase split (--mode) are left at the marked case's defaults.
+# NOTE on quoting: the -k value must reach pytest as ONE token. tracy's report mode re-joins its
+# argv with spaces and re-runs the command under `shell=True` (tt-metal tools/tracy/__main__.py),
+# which would otherwise split the bare words of "performance and batch-32". The nested '"..."'
+# keeps literal quotes on the token so it survives BOTH shlex.split here and tracy's shell re-parse.
+CMD="models/tt_transformers/demo/simple_text_demo.py -k '\"performance and batch-32 and not log-probs\"' --mode prefill"
+require_ref_cmd "$CMD"
+export PYTEST_TIMEOUT=3600  # long device-perf capture+replay; avoid pytest-timeout abort
+python ../si_profiling_helpers/run-ttnn-profiler.py --command "$CMD" --pytest --output-dir $RUNID --report-name $RUNID --disable-logging --merge-variant trace_replay "$@"
+rc=$?
+hw_id_write "$RUNID"
+exit "$rc"

--- a/tools/si_profiling_helpers/presets/vit/run-vitdual-bh.sh
+++ b/tools/si_profiling_helpers/presets/vit/run-vitdual-bh.sh
@@ -14,7 +14,7 @@ HEAD=$(git rev-parse --short=7 HEAD)
 RUNID=vitdual-${HEAD}-${IRD_ARCH_NAME}${BOARD:+-$BOARD}-$(date +%y%m%d)
 CMD=workloads/ttnn/vit/bh/test_vit_device_perf_bh.py
 require_dual_cmd "$CMD"
-python ../si_profiling_helpers/run-ttnn-profiler.py --command "$CMD" --output-dir $RUNID --report-name $RUNID "$@"
+python ../si_profiling_helpers/run-ttnn-profiler.py --command "$CMD" --output-dir $RUNID --report-name $RUNID --merge-variant trace_replay "$@"
 rc=$?
 hw_id_write "$RUNID"
 exit "$rc"

--- a/tools/si_profiling_helpers/presets/vit/run-vitdual-wh.sh
+++ b/tools/si_profiling_helpers/presets/vit/run-vitdual-wh.sh
@@ -9,7 +9,7 @@ HEAD=$(git rev-parse --short=7 HEAD)
 RUNID=vitdual-${HEAD}-${IRD_ARCH_NAME}${BOARD:+-$BOARD}-$(date +%y%m%d)
 CMD=workloads/ttnn/vit/wh/test_vit_device_perf_wh.py
 require_dual_cmd "$CMD"
-python ../si_profiling_helpers/run-ttnn-profiler.py --command "$CMD" --output-dir $RUNID --report-name $RUNID "$@"
+python ../si_profiling_helpers/run-ttnn-profiler.py --command "$CMD" --output-dir $RUNID --report-name $RUNID --merge-variant trace_replay "$@"
 rc=$?
 hw_id_write "$RUNID"
 exit "$rc"

--- a/tools/si_profiling_helpers/presets/vit/run-vitref-bh.sh
+++ b/tools/si_profiling_helpers/presets/vit/run-vitref-bh.sh
@@ -13,7 +13,7 @@ HEAD=$(git rev-parse --short=7 HEAD)
 RUNID=vitref-${HEAD}-${IRD_ARCH_NAME}${BOARD:+-$BOARD}-$(date +%y%m%d)
 CMD=models/demos/vision/classification/vit/blackhole/tests/test_vit_device_perf.py::test_vit_device_ops
 require_ref_cmd "$CMD"
-python ../si_profiling_helpers/run-ttnn-profiler.py --command "$CMD" --pytest --output-dir $RUNID --report-name $RUNID "$@"
+python ../si_profiling_helpers/run-ttnn-profiler.py --command "$CMD" --pytest --output-dir $RUNID --report-name $RUNID --merge-variant trace_replay "$@"
 rc=$?
 hw_id_write "$RUNID"
 exit "$rc"

--- a/tools/si_profiling_helpers/presets/vit/run-vitref-wh.sh
+++ b/tools/si_profiling_helpers/presets/vit/run-vitref-wh.sh
@@ -9,7 +9,7 @@ HEAD=$(git rev-parse --short=7 HEAD)
 RUNID=vitref-${HEAD}-${IRD_ARCH_NAME}${BOARD:+-$BOARD}-$(date +%y%m%d)
 CMD=models/demos/vision/classification/vit/wormhole/tests/test_vit_device_perf.py::test_vit_device_ops
 require_ref_cmd "$CMD"
-python ../si_profiling_helpers/run-ttnn-profiler.py --command "$CMD" --pytest --output-dir $RUNID --report-name $RUNID "$@"
+python ../si_profiling_helpers/run-ttnn-profiler.py --command "$CMD" --pytest --output-dir $RUNID --report-name $RUNID --merge-variant trace_replay "$@"
 rc=$?
 hw_id_write "$RUNID"
 exit "$rc"

--- a/tools/si_profiling_helpers/run-ttnn-profiler.py
+++ b/tools/si_profiling_helpers/run-ttnn-profiler.py
@@ -59,11 +59,27 @@ Optional Arguments:
                         These generated directories can be very large; use this flag
                         if their contents are not needed for analysis.
     --dryrun, -n        Show commands without executing them
+    --skip-fail-check   Skip the no-tracy pre-flight run (go straight to the Tracy passes).
+                        By default a fast pre-flight runs the command once WITHOUT tracy and
+                        aborts before the expensive Tracy passes if it fails.
+    --fail-check-only   Run ONLY the no-tracy pre-flight, then stop (no Tracy passes, no merge).
+                        Exits non-zero if the command fails. Use to validate a command before
+                        committing to a full capture. Mutually exclusive with --skip-fail-check.
+                        The output dir gets a '--failcheckonly' suffix so it can't collide with
+                        or be mistaken for a full capture written to the same --output-dir.
+    --disable-dram-drop-guard  Disable the DRAM-drop guard (on by default). Normally, if the
+                        profiler DRAM-buffer-overflow marker appears too frequently (capture likely
+                        incomplete), the command is given a grace period and then force-stopped.
 
 Output Structure:
     <output-dir>/
-        ├── <pass>_results_typescript.txt  # Per-pass output: raw_/perf_/trace_/merge_
+        ├── <pass>_results_typescript.txt  # Per-pass output (failcheck_/raw_/perf_/trace_/merge_),
+        │                                  # streamed live + flushed per line so a Ctrl-C on a hang
+        │                                  # keeps it; stderr lines tagged "[stderr]"
+        ├── run_status.json        # Live run-status sidecar: overall + per-step state (machine-readable)
+        ├── STATUS.txt             # Same, rendered as a human table (watch/cat it during a run)
         ├── merged_ops_<RUNID>.csv  # 3-CSV merge (full mode only; RUNID = output-dir name)
+        ├── failcheck/              # No-tracy pre-flight artifacts (unless --skip-fail-check)
         ├── raw/                    # Tracy raw profiling output (.logs/, reports/, generated/)
         ├── perf/                   # Tracy performance counter output (full mode only)
         └── trace/                  # Tracy NOC trace output (full mode only)
@@ -81,16 +97,28 @@ Prerequisites:
     - loguru package must be installed
 
 Notes:
-    - The script runs up to 3 profiling passes:
+    - Before the profiling passes, a fast no-tracy pre-flight runs the command once (unless
+      --skip-fail-check) so a trivially-broken command (import error, bad -k selector, arg
+      error) fails fast instead of wasting the expensive Tracy capture. With --fail-check-only
+      the script runs just that pre-flight and stops (no Tracy passes, no merge).
+    - The script then runs up to 3 profiling passes:
       1. Raw profiling with TTNN config overrides
       2. Performance counter collection (unless --basic-only)
       3. NOC trace collection (unless --basic-only)
-    - Execution stops if any pass fails
+    - Execution stops if the pre-flight or any pass fails
+    - DRAM-drop guard (on by default; --disable-dram-drop-guard turns it off): if the profiler
+      DRAM-buffer-overflow marker ("Profiler DRAM buffers were full, markers were dropped!") is
+      seen too frequently, the command is given a grace period to finish and then force-stopped,
+      since its capture is almost certainly incomplete. With the guard off, the marker is still
+      counted and the run-status step flagged dram_drop_tripped (a rc-0 pass is not silently trusted).
+    - A live status sidecar (run_status.json + STATUS.txt) is written to the output dir, updated on
+      every step transition and on a ~2s heartbeat, so `watch cat <dir>/STATUS.txt` shows overall +
+      per-step progress (including stalls via last-output age, interrupts, and force-stops).
     - All tt-metal artifacts land directly under each pass dir (no cwd/generated);
       concurrent runs from one directory therefore do not collide
     - After a successful full run (raw+perf+trace), the three CSVs are merged into
-      merged_ops_<RUNID>.csv on this node, so only it (+ hw_id.json) need be copied off the
-      board. The per-board DRAM peak BW is resolved from an internal interim table
+      merged_ops_<RUNID>.csv on this node, so only it (+ hw_id.json, run_status.json, STATUS.txt)
+      need be copied off the board. The per-board DRAM peak BW is resolved from an internal interim table
       keyed on tt-smi board_type (interim/placeholder values pending the DRAM-BW
       review). Skipped for --basic-only or when the board can't be resolved.
 """
@@ -98,6 +126,7 @@ Notes:
 import os
 import sys
 import argparse
+import datetime
 import importlib.util
 import json
 import re
@@ -105,6 +134,8 @@ import shlex
 import shutil
 import subprocess
 import threading
+import time
+from collections import deque
 
 from loguru import logger
 
@@ -113,17 +144,60 @@ def is_npe_on_path() -> bool:
     return importlib.util.find_spec('npe_analyze_noc_trace_dir') is not None
 
 
-def run_and_capture(argv: list[str], show_output: bool = False) -> subprocess.CompletedProcess[str]:
-    """Execute a command and capture its output.
+# DRAM-drop guard: tt-metal emits this exact line when the on-device profiler's DRAM marker buffer
+# overflows and drops markers. Sustained bursts mean the capture is losing data and is likely
+# incomplete. When the guard is enabled (default), if the marker is seen >= _DRAM_DROP_RATE_COUNT
+# times within any _DRAM_DROP_RATE_WINDOW_S-second rolling window, the command is given
+# _DRAM_DROP_GRACE_S to finish on its own; if it is still running after that, it is force-stopped.
+_DRAM_DROP_MARKER = 'Profiler DRAM buffers were full, markers were dropped!'
+_DRAM_DROP_RATE_COUNT = 25
+_DRAM_DROP_RATE_WINDOW_S = 10.0
+_DRAM_DROP_GRACE_S = 30.0
+_DRAM_DROP_POLL_S = 0.5
+
+# run_status sidecar: how often to rewrite run_status.json / STATUS.txt while a step is running.
+_STATUS_HEARTBEAT_S = 2.0
+
+
+def run_and_capture(argv: list[str], show_output: bool = False,
+                    log_path: str | None = None,
+                    dram_drop_guard: bool = True,
+                    status: "RunStatus | None" = None,
+                    step_name: str | None = None) -> subprocess.CompletedProcess[str]:
+    """Execute a command, capturing its output and (if log_path is given) streaming it to disk live.
+
+    When ``log_path`` is set, each output line is written to the file and flushed AS IT ARRIVES
+    (independent of ``show_output``), and the file is finalized in a ``finally`` block. So if the
+    command hangs and is Ctrl-C'd, the output produced up to that point is already on disk rather
+    than lost with the un-returned in-memory buffer. stdout is written verbatim; stderr lines are
+    tagged with a "[stderr] " prefix; the two streams are interleaved in arrival order (a true
+    typescript). On SIGINT the child is terminated and the run reported as returncode 130.
+
+    When ``dram_drop_guard`` is True (default), the output is watched for the profiler
+    DRAM-buffer-overflow marker; if it appears too frequently (see the _DRAM_DROP_* constants) the
+    command is given a grace period to finish and then force-stopped (reported as returncode 124),
+    because such a run's capture is almost certainly incomplete.
 
     Args:
         argv (list[str]): Command and arguments as a list (shell=False).
-        show_output (bool): If True, display stdout/stderr in real-time while capturing.
-                           If False (default), only capture output silently.
+        show_output (bool): If True, also echo stdout/stderr to this process's terminal in real time.
+        log_path (str | None): If set, stream output there live (<mode>_results_typescript.txt).
+        dram_drop_guard (bool): If True, force-stop the command on sustained DRAM-drop markers.
+        status (RunStatus | None): If set, the run-status sidecar updated with this step's
+            last-output heartbeat and DRAM-drop annotation.
+        step_name (str | None): Name of this step in the run-status sidecar.
 
     Returns:
-        subprocess.CompletedProcess: Result object with returncode, stdout, stderr
+        subprocess.CompletedProcess: Result object with returncode, stdout, stderr.
     """
+    logf = open(log_path, 'w', buffering=1) if log_path is not None else None  # line-buffered
+    write_lock = threading.Lock()
+    if logf is not None:
+        logf.write(f'Command: {" ".join(argv)}\n')
+        logf.write(f'Started (UTC): {datetime.datetime.now(datetime.timezone.utc).isoformat()}\n')
+        logf.write('---- live output (stdout verbatim, stderr tagged "[stderr]"), flushed per line ----\n')
+        logf.flush()
+
     try:
         process = subprocess.Popen(
             argv,
@@ -137,6 +211,9 @@ def run_and_capture(argv: list[str], show_output: bool = False) -> subprocess.Co
         # e.g. tt-smi not installed; surface as a failed run (returncode 127) rather
         # than crashing, so callers can detect it via anyfails() and exit non-zero.
         logger.error(f'command not found: {argv[0]!r} ({e})')
+        if logf is not None:
+            logf.write(f'{e}\n---- end (return code: 127; command not found) ----\n')
+            logf.close()
         return subprocess.CompletedProcess(argv, returncode=127, stdout='', stderr=str(e))
     proc_stdout = process.stdout
     proc_stderr = process.stderr
@@ -146,44 +223,182 @@ def run_and_capture(argv: list[str], show_output: bool = False) -> subprocess.Co
     stdout_lines: list[str] = []
     stderr_lines: list[str] = []
 
+    # DRAM-drop guard state: rolling window of marker-sighting timestamps; drop_trigger fires once
+    # the rate threshold is crossed; force_stopped records that the watchdog killed the command.
+    drop_times: deque[float] = deque()
+    drop_lock = threading.Lock()
+    drop_trigger = threading.Event()
+    force_stopped = threading.Event()
+
+    def note_drop_marker() -> None:
+        if drop_trigger.is_set():
+            return
+        now = time.monotonic()
+        with drop_lock:
+            drop_times.append(now)
+            while drop_times and now - drop_times[0] > _DRAM_DROP_RATE_WINDOW_S:
+                drop_times.popleft()
+            tripped = len(drop_times) >= _DRAM_DROP_RATE_COUNT
+        if tripped:
+            drop_trigger.set()
+            if dram_drop_guard:
+                msg = (f'DRAM-drop guard: profiler DRAM-buffer-overflow marker seen '
+                       f'>={_DRAM_DROP_RATE_COUNT}x within {_DRAM_DROP_RATE_WINDOW_S:.0f}s -- capture is '
+                       f'dropping data and is likely incomplete. Giving the command {_DRAM_DROP_GRACE_S:.0f}s '
+                       f'to finish, then force-stopping.')
+            else:
+                msg = (f'DRAM-drop marker seen >={_DRAM_DROP_RATE_COUNT}x within '
+                       f'{_DRAM_DROP_RATE_WINDOW_S:.0f}s -- capture is dropping data and is likely INCOMPLETE '
+                       f'(guard disabled: NOT force-stopping; flagged in run_status).')
+            logger.warning(msg)
+            if logf is not None:
+                with write_lock:
+                    logf.write(f'---- {msg} ----\n')
+                    logf.flush()
+            if status is not None and step_name is not None:
+                status.mark_dram_tripped(step_name)
+
+    def emit(line: str, is_stderr: bool) -> None:
+        # Buffer (for the returned CompletedProcess), stream to the log file live, and optionally
+        # echo to the terminal. The file write is gated on log_path only -- NOT on show_output --
+        # so a silent (default) run still lands its output on disk as it is produced.
+        (stderr_lines if is_stderr else stdout_lines).append(line)
+        if logf is not None:
+            with write_lock:
+                logf.write(f'[stderr] {line}' if is_stderr else line)
+                logf.flush()
+        if show_output:
+            stream = sys.stderr if is_stderr else sys.stdout
+            print(line, end='', file=stream)
+            stream.flush()
+        if status is not None and step_name is not None:
+            status.note_output(step_name)
+        # Count the DRAM-drop marker regardless of the guard: with the guard on it drives the
+        # force-stop; with it off it still flags the step (dram_drop_tripped) as likely incomplete.
+        if _DRAM_DROP_MARKER in line:
+            note_drop_marker()
+
     def read_stdout() -> None:
         for line in iter(proc_stdout.readline, ''):
             if line:
-                if show_output:
-                    print(line, end='')
-                    sys.stdout.flush()
-                stdout_lines.append(line)
+                emit(line, False)
         proc_stdout.close()
 
     def read_stderr() -> None:
         for line in iter(proc_stderr.readline, ''):
             if line:
-                if show_output:
-                    print(line, end='', file=sys.stderr)
-                    sys.stderr.flush()
-                stderr_lines.append(line)
+                emit(line, True)
         proc_stderr.close()
+
+    def dram_watchdog() -> None:
+        # Wait until the guard trips or the process ends (whichever first). poll() is used (never
+        # wait()) so we never contend with the main thread's process.wait() for reaping.
+        while process.poll() is None and not drop_trigger.is_set():
+            time.sleep(_DRAM_DROP_POLL_S)
+        if not drop_trigger.is_set():
+            return  # process finished before the threshold was crossed
+        # Threshold crossed while still running: grace period, then force-stop if it hasn't ended.
+        deadline = time.monotonic() + _DRAM_DROP_GRACE_S
+        while process.poll() is None and time.monotonic() < deadline:
+            time.sleep(_DRAM_DROP_POLL_S)
+        if process.poll() is None:
+            force_stopped.set()
+            logger.error(f'DRAM-drop guard: command still running {_DRAM_DROP_GRACE_S:.0f}s after the '
+                         'threshold -- force-stopping.')
+            process.terminate()
+            kill_deadline = time.monotonic() + 10
+            while process.poll() is None and time.monotonic() < kill_deadline:
+                time.sleep(_DRAM_DROP_POLL_S)
+            if process.poll() is None:
+                process.kill()
+
+    hb_stop = threading.Event()
+
+    def status_heartbeat() -> None:
+        # Refresh the run_status sidecar every ~2s while this step runs, so a reader sees liveness
+        # (elapsed + last-output age). Stopped promptly when the process ends (hb_stop).
+        while not hb_stop.wait(_STATUS_HEARTBEAT_S):
+            if status is not None and step_name is not None:
+                status.heartbeat(step_name)
 
     stdout_thread = threading.Thread(target=read_stdout)
     stderr_thread = threading.Thread(target=read_stderr)
-
+    watchdog_thread = threading.Thread(target=dram_watchdog) if dram_drop_guard else None
+    heartbeat_thread = (threading.Thread(target=status_heartbeat)
+                        if (status is not None and step_name is not None) else None)
     stdout_thread.start()
     stderr_thread.start()
+    if watchdog_thread is not None:
+        watchdog_thread.start()
+    if heartbeat_thread is not None:
+        heartbeat_thread.start()
 
-    process.wait()
+    interrupted = False
+    try:
+        process.wait()
+    except KeyboardInterrupt:
+        # Ctrl-C on a hung command: stop waiting, reap the child, and let the finally block finalize
+        # the (already-flushed) log. Report as 130 so anyfails() trips and the run aborts cleanly.
+        interrupted = True
+        logger.error('Interrupted (SIGINT) -- terminating command; output captured so far is saved.')
+        process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+    finally:
+        hb_stop.set()
+        stdout_thread.join()
+        stderr_thread.join()
+        if watchdog_thread is not None:
+            watchdog_thread.join()
+        if heartbeat_thread is not None:
+            heartbeat_thread.join()
+        if logf is not None:
+            with write_lock:
+                if interrupted:
+                    logf.write(f'\n---- INTERRUPTED (SIGINT); child return code: {process.returncode} '
+                               '-- partial output above ----\n')
+                elif force_stopped.is_set():
+                    logf.write(f'\n---- FORCE-STOPPED by DRAM-drop guard (marker >={_DRAM_DROP_RATE_COUNT}x/'
+                               f'{_DRAM_DROP_RATE_WINDOW_S:.0f}s, not finished within {_DRAM_DROP_GRACE_S:.0f}s); '
+                               f'child return code {process.returncode} -- capture incomplete ----\n')
+                elif drop_trigger.is_set():
+                    # Reached only when the command finished on its own after tripping the threshold.
+                    # With the guard on that means it beat the grace period; with the guard off there
+                    # was no grace period at all -- word it accordingly so the typescript isn't misleading.
+                    detail = 'finished within grace' if dram_drop_guard else 'ran to completion (guard disabled)'
+                    logf.write(f'---- end (return code: {process.returncode}); WARNING: DRAM-drop threshold '
+                               f'was tripped but the command {detail} -- capture may be incomplete ----\n')
+                else:
+                    logf.write(f'---- end (return code: {process.returncode}) at '
+                               f'{datetime.datetime.now(datetime.timezone.utc).isoformat()} ----\n')
+                logf.flush()
+            logf.close()
 
-    stdout_thread.join()
-    stderr_thread.join()
-
+    if interrupted:
+        returncode = 130
+    elif force_stopped.is_set():
+        returncode = 124
+    else:
+        returncode = process.returncode
     result = subprocess.CompletedProcess(
         args=argv,
-        returncode=process.returncode,
+        returncode=returncode,
         stdout=''.join(stdout_lines),
         stderr=''.join(stderr_lines),
     )
 
-    if result.returncode == 0:
-        logger.info('Command ran successfully.')
+    if interrupted:
+        logger.error('Command interrupted.')
+    elif force_stopped.is_set():
+        logger.error('Command force-stopped by DRAM-drop guard (capture incomplete).')
+    elif result.returncode == 0:
+        if drop_trigger.is_set():
+            logger.warning('Command finished, but the DRAM-drop threshold was tripped -- capture may be incomplete.')
+        else:
+            logger.info('Command ran successfully.')
     else:
         logger.error('Command failed to run.')
 
@@ -243,6 +458,41 @@ def setup_environment(report_name: str, enable_logging: bool = True) -> None:
     # path, so it is not used here or in the presets.
 
 
+def run_failcheck(command: str, pytest_mode: bool, failcheck_dir: str,
+                  show_output: bool = False, dryrun: bool = False,
+                  log_path: str | None = None,
+                  dram_drop_guard: bool = True,
+                  status: "RunStatus | None" = None,
+                  step_name: str | None = None) -> subprocess.CompletedProcess[str] | None:
+    """Fast pre-flight: run the workload command ONCE WITHOUT tracy, to fail fast on a
+    trivially-broken command (import error, bad -k selector, collection/arg error) before the
+    expensive 3-pass Tracy capture. Returns CompletedProcess (None on dryrun). NOT a profiling
+    pass -- no tracy, no perf/noc collection."""
+    # The --command is encoded to survive tracy's report-mode round-trip: tracy joins its argv back
+    # into one string and re-runs it under shell=True, so a spaced -k expression is wrapped in
+    # nested quotes in the presets (e.g. -k '"performance and batch-32"'). This pre-flight runs the
+    # command WITHOUT tracy, so mirror that same shlex.split -> join -> shell re-split to recover the
+    # argv the workload actually runs with. A single shlex.split would leave literal quotes on the
+    # -k value and pytest would reject it ("Wrong expression passed to '-k'").
+    real_args = shlex.split(' '.join(shlex.split(command)))
+    if pytest_mode:
+        argv = [sys.executable, '-m', 'pytest'] + real_args
+    else:
+        argv = [sys.executable] + real_args
+    logger.info(f'no-tracy fail-check: {" ".join(argv)}')
+    if dryrun:
+        return None
+    # Pin tt-metal's artifact roots to a throwaway failcheck dir so this pre-run does not drop
+    # 'generated/' into the cwd (mirrors the per-pass isolation in run_profiler; keeps concurrent
+    # runs from a shared tt-metal checkout from colliding). No setup_environment/tracy overrides --
+    # this is a plain run; TT_METAL_HOME/PYTHONPATH come from the shell env (setup-step-2).
+    os.makedirs(failcheck_dir, exist_ok=True)
+    os.environ['TT_METAL_LOGS_PATH'] = failcheck_dir
+    os.environ['TT_METAL_PROFILER_DIR'] = failcheck_dir
+    return run_and_capture(argv, show_output=show_output, log_path=log_path,
+                           dram_drop_guard=dram_drop_guard, status=status, step_name=step_name)
+
+
 def run_profiler(
     command: str,
     output_dir: str,
@@ -254,6 +504,10 @@ def run_profiler(
     show_output: bool = False,
     dryrun: bool = False,
     op_support_count: int = 100000,
+    log_path: str | None = None,
+    dram_drop_guard: bool = True,
+    status: "RunStatus | None" = None,
+    step_name: str | None = None,
 ) -> subprocess.CompletedProcess[str] | None:
     """Run the TTNN profiler with specified options.
 
@@ -323,7 +577,8 @@ def run_profiler(
     if dryrun:
         return None
 
-    result = run_and_capture(argv, show_output=show_output)
+    result = run_and_capture(argv, show_output=show_output, log_path=log_path,
+                             dram_drop_guard=dram_drop_guard, status=status, step_name=step_name)
     if result.returncode == 0:
         logger.info(f'Profiler {mode} mode output saved to: {output_dir} with report name: {report_name}')
 
@@ -359,18 +614,8 @@ def cleanup_directories(output_dir: str) -> None:
     logger.info('Cleanup completed.')
 
 
-def write_result_file(output_dir: str, mode: str, res: subprocess.CompletedProcess[str] | None) -> None:
-    """Write a single profiling result to <mode>_results_typescript.txt."""
-    if res is None:
-        return
-    output_filename = os.path.join(output_dir, f'{mode}_results_typescript.txt')
-    with open(output_filename, 'w') as summary_file:
-        summary_file.write(f'Command: {" ".join(res.args)}\n')
-        summary_file.write(f'Return code: {res.returncode}\n')
-        summary_file.write(f'Stdout:\n{res.stdout}\n')
-        summary_file.write(f'Stderr:\n{res.stderr}\n')
-        summary_file.write(f'{"="*120}\n')
-    logger.info('output saved in {}', output_filename)
+# Per-pass output goes to <output_dir>/<mode>_results_typescript.txt, written LIVE by
+# run_and_capture (see its log_path arg) so it survives a Ctrl-C on a hung command.
 
 
 # Interim board_type -> DRAM peak bandwidth (GB/s), used to merge a capture on the
@@ -407,10 +652,30 @@ def resolve_interim_dram_peak_bw(board_type: str) -> float | None:
     return None
 
 
-def run_merge(output_dir: str, dram_peak_bw_gbps: float, show_output: bool = False) -> subprocess.CompletedProcess[str] | None:
+_MERGE_TOOL_BY_VARIANT = {
+    # multi-iteration workloads (VGG UNet): the iterative reducer detects iteration
+    # boundaries and medians across them.
+    'iterative': 'ops_perf_three_csv_merge.py',
+    # non-iterative trace+replay workloads (ViT, llama3): a single compile pass +
+    # replay session(s), no iteration loop — drops the compile pass, medians replays.
+    'trace_replay': 'ops_perf_trace_replay_merge.py',
+}
+
+
+def run_merge(output_dir: str, dram_peak_bw_gbps: float, show_output: bool = False,
+              merge_variant: str = 'iterative',
+              log_path: str | None = None,
+              dram_drop_guard: bool = True,
+              status: "RunStatus | None" = None,
+              step_name: str | None = None) -> subprocess.CompletedProcess[str] | None:
     """Consolidate the three per-pass CSVs (raw/perf/trace) under output_dir into
     output_dir/merged_ops_<RUNID>.csv (RUNID = output_dir basename), ON THE HARDWARE
     NODE, right after a successful capture.
+
+    ``merge_variant`` selects the reducer: 'iterative' (ops_perf_three_csv_merge, for
+    multi-iteration workloads like VGG) or 'trace_replay' (ops_perf_trace_replay_merge,
+    for non-iterative trace+replay workloads like ViT/llama3). Both share the same CLI
+    (--input-dir / --dram-peak-bw-gbps / --output).
 
     The merge tool ships alongside this wrapper (same dir), so it is part of the
     rsynced si_profiling_helpers bundle and its only third-party dep (loguru) is
@@ -418,7 +683,7 @@ def run_merge(output_dir: str, dram_peak_bw_gbps: float, show_output: bool = Fal
     (plus hw_id.json) need be copied off the board, not three raw CSVs. The follow-on
     compare-vs-refrun step needs polaris/ttsim and stays off-device.
     """
-    merge_tool = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'ops_perf_three_csv_merge.py')
+    merge_tool = os.path.join(os.path.dirname(os.path.realpath(__file__)), _MERGE_TOOL_BY_VARIANT[merge_variant])
     if not os.path.exists(merge_tool):
         logger.error(f'merge tool not found at {merge_tool}; skipping merge')
         return None
@@ -430,12 +695,208 @@ def run_merge(output_dir: str, dram_peak_bw_gbps: float, show_output: bool = Fal
     argv = [sys.executable, merge_tool, '--input-dir', output_dir,
             '--dram-peak-bw-gbps', str(dram_peak_bw_gbps), '--output', merged_csv]
     logger.info(f'merging three CSVs in {output_dir} (--dram-peak-bw-gbps {dram_peak_bw_gbps})')
-    result = run_and_capture(argv, show_output=show_output)
+    result = run_and_capture(argv, show_output=show_output, log_path=log_path,
+                             dram_drop_guard=dram_drop_guard, status=status, step_name=step_name)
     if result.returncode == 0:
         logger.info(f'{os.path.basename(merged_csv)} written under {output_dir}')
     else:
         logger.error('merge step failed (see output above)')
     return result
+
+
+def _utcnow() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+def _step_status_from_rc(rc: "int | None") -> str:
+    """Map a run_and_capture returncode to a per-step status."""
+    if rc is None:
+        return 'skipped'
+    if rc == 0:
+        return 'succeeded'
+    if rc == 130:
+        return 'interrupted'   # SIGINT
+    if rc == 124:
+        return 'force_stopped'  # DRAM-drop guard
+    return 'failed'
+
+
+class RunStatus:
+    """Live run-status sidecar for a profiler run.
+
+    Writes two files into the run's output dir, rewritten on every step transition and on a ~2s
+    heartbeat while a step runs:
+      * run_status.json -- canonical, machine-readable (overall + per-step state, timings,
+        last-output timestamps, DRAM-drop flags).
+      * STATUS.txt      -- the same rendered as a human table.
+    Lets an operator cat/watch overall + per-step progress, including stalls (last-output age),
+    SIGINT interrupts, and DRAM-drop force-stops. Copied off-board alongside hw_id.json.
+
+    main() drives the step transitions (start/finish/skip/finalize); run_and_capture feeds each
+    step's last-output heartbeat and the DRAM-drop annotation. The pipeline is sequential, so
+    transitions are single-threaded; a lock guards writes against the heartbeat thread.
+    """
+
+    _BAD = ('failed', 'interrupted', 'force_stopped')
+
+    def __init__(self, output_dir: str, command: str, pytest_mode: bool, step_names: list[str]) -> None:
+        self._json_path = os.path.join(output_dir, 'run_status.json')
+        self._txt_path = os.path.join(output_dir, 'STATUS.txt')
+        self._lock = threading.Lock()
+        self._start_mono: dict[str, float] = {}
+        self._last_out_mono: dict[str, float] = {}
+        now = _utcnow()
+        self._d: dict = {
+            'runid': os.path.basename(output_dir),
+            'output_dir': output_dir,
+            'command': command,
+            'pytest': pytest_mode,
+            'overall_status': 'pending',
+            'started_utc': now,
+            'updated_utc': now,
+            'ended_utc': None,
+            'failed_steps': [],
+            'steps': [
+                {
+                    'name': n, 'status': 'pending', 'returncode': None,
+                    'started_utc': None, 'ended_utc': None, 'duration_s': None,
+                    'last_output_utc': None, 'dram_drop_tripped': False,
+                    'log': (None if n == 'board_reset' else f'{n}_results_typescript.txt'),
+                }
+                for n in step_names
+            ],
+        }
+        with self._lock:
+            self._write_locked()
+
+    def _find(self, name: str) -> "dict | None":
+        for s in self._d['steps']:
+            if s['name'] == name:
+                return s
+        return None
+
+    def start(self, name: str) -> None:
+        with self._lock:
+            s = self._find(name)
+            if s is not None:
+                s['status'] = 'running'
+                s['started_utc'] = _utcnow()
+                self._start_mono[name] = time.monotonic()
+                self._last_out_mono[name] = time.monotonic()
+                self._recompute_locked()
+                self._write_locked()
+        logger.info(f'step {name} -> running')
+
+    def note_output(self, name: str) -> None:
+        # Per-output-line, deliberately lock-free and cheap: record last-activity monotonic time
+        # (the key already exists from start()); the heartbeat/transition writes fold it into UTC.
+        self._last_out_mono[name] = time.monotonic()
+
+    def mark_dram_tripped(self, name: str) -> None:
+        with self._lock:
+            s = self._find(name)
+            if s is not None and not s['dram_drop_tripped']:
+                s['dram_drop_tripped'] = True
+                self._write_locked()
+
+    def heartbeat(self, name: str) -> None:
+        with self._lock:
+            self._write_locked()
+
+    def finish(self, name: str, res: "subprocess.CompletedProcess[str] | None") -> None:
+        rc = None if res is None else res.returncode
+        new_status = _step_status_from_rc(rc)
+        dur = None
+        with self._lock:
+            s = self._find(name)
+            if s is not None:
+                s['returncode'] = rc
+                s['status'] = new_status
+                s['ended_utc'] = _utcnow()
+                if name in self._start_mono:
+                    s['duration_s'] = round(time.monotonic() - self._start_mono[name], 1)
+                dur = s['duration_s']
+                self._recompute_locked()
+                self._write_locked()
+        logger.info(f'step {name} -> {new_status}' + (f' ({dur}s)' if dur is not None else ''))
+
+    def skip(self, name: str) -> None:
+        with self._lock:
+            s = self._find(name)
+            if s is not None and s['status'] == 'pending':
+                s['status'] = 'skipped'
+                self._recompute_locked()
+                self._write_locked()
+
+    def finalize(self) -> None:
+        with self._lock:
+            for s in self._d['steps']:
+                if s['status'] in ('pending', 'running'):
+                    s['status'] = 'skipped'
+            self._recompute_locked()
+            self._d['ended_utc'] = _utcnow()
+            self._write_locked()
+
+    def _recompute_locked(self) -> None:
+        statuses = [s['status'] for s in self._d['steps']]
+        self._d['failed_steps'] = [s['name'] for s in self._d['steps'] if s['status'] in self._BAD]
+        if 'interrupted' in statuses:
+            overall = 'interrupted'
+        elif 'force_stopped' in statuses:
+            overall = 'force_stopped'
+        elif 'failed' in statuses:
+            overall = 'failed'
+        elif 'running' in statuses:
+            overall = 'running'
+        elif 'pending' in statuses:
+            # some steps not yet started: 'pending' only at the very start; else in-between -> running
+            overall = 'pending' if all(st == 'pending' for st in statuses) else 'running'
+        else:
+            overall = 'succeeded'  # every step succeeded or skipped
+        self._d['overall_status'] = overall
+
+    def _write_locked(self) -> None:
+        now_mono = time.monotonic()
+        now_dt = datetime.datetime.now(datetime.timezone.utc)
+        self._d['updated_utc'] = now_dt.isoformat()
+        for s in self._d['steps']:
+            lo = self._last_out_mono.get(s['name'])
+            if lo is not None:
+                s['last_output_utc'] = (now_dt - datetime.timedelta(seconds=now_mono - lo)).isoformat()
+        tmp = self._json_path + '.tmp'
+        with open(tmp, 'w') as f:
+            json.dump(self._d, f, indent=2)
+        os.replace(tmp, self._json_path)  # atomic swap: a reader never sees a half-written JSON
+        with open(self._txt_path, 'w') as f:
+            f.write(self._render_txt(now_mono))
+
+    def _render_txt(self, now_mono: float) -> str:
+        d = self._d
+        out = [
+            f"RUN  {d['runid']}      [{d['overall_status'].upper()}]",
+            f"cmd  {d['command']}",
+            (f"started {d['started_utc']}   updated {d['updated_utc']}"
+             + (f"   ended {d['ended_utc']}" if d['ended_utc'] else "")),
+        ]
+        if d['failed_steps']:
+            out.append(f"failed_steps: {', '.join(d['failed_steps'])}")
+        out.append("")
+        out.append(f"{'STEP':<12} {'STATUS':<13} {'DUR/ELAPSED':>12}  {'LAST-OUT':>9}  LOG")
+        for s in d['steps']:
+            if s['status'] == 'running' and s['name'] in self._start_mono:
+                dur = f"({round(now_mono - self._start_mono[s['name']], 1)}s…)"
+            elif s['duration_s'] is not None:
+                dur = f"{s['duration_s']}s"
+            else:
+                dur = "-"
+            lo = self._last_out_mono.get(s['name'])
+            lastout = f"{int(now_mono - lo)}s ago" if (s['status'] == 'running' and lo is not None) else "-"
+            st = s['status'] + ('*' if s['dram_drop_tripped'] else '')
+            out.append(f"{s['name']:<12} {st:<13} {dur:>12}  {lastout:>9}  {s['log'] or '-'}")
+        if any(s['dram_drop_tripped'] for s in d['steps']):
+            out.append("")
+            out.append("* DRAM-drop marker threshold tripped -- capture may be incomplete.")
+        return "\n".join(out) + "\n"
 
 
 def main() -> int:
@@ -444,6 +905,12 @@ def main() -> int:
     parser.add_argument('--pytest', action='store_true', help='Run the profiler in pytest mode')
     parser.add_argument('--report-name', type=str, required=True, help='Name of the profiler report')
     parser.add_argument('--output-dir', type=str, required=True, help='Directory to save the profiler output')
+    parser.add_argument(
+        '--merge-variant', choices=['iterative', 'trace_replay'], default='iterative',
+        help='On-device 3-CSV merge reducer: "iterative" (ops_perf_three_csv_merge, multi-iteration '
+             'workloads like VGG UNet — the default) or "trace_replay" (ops_perf_trace_replay_merge, '
+             'non-iterative trace+replay workloads like ViT / llama3).',
+    )
     parser.add_argument(
         '--basic-only', action='store_true', help='Only run basic profiling (skip NOC traces and performance counters)'
     )
@@ -463,6 +930,16 @@ def main() -> int:
         help='Remove npe_viz and .logs directories from output directory after run. These directories can be very large; use this flag if their contents are not needed.',
     )
     parser.add_argument('--dryrun', '-n', action='store_true', help='show but do not execute commands')
+    parser.add_argument('--skip-fail-check', action='store_true',
+                        help='Skip the no-tracy pre-flight run (go straight to the Tracy passes)')
+    parser.add_argument('--fail-check-only', action='store_true',
+                        help='Run ONLY the no-tracy pre-flight, then stop (no Tracy passes, no merge). '
+                             'Exits non-zero if the command fails. Appends a "--failcheckonly" suffix to '
+                             'the output dir. Mutually exclusive with --skip-fail-check.')
+    parser.add_argument('--disable-dram-drop-guard', action='store_true',
+                        help='Disable the DRAM-drop guard (on by default). Normally, if the profiler '
+                             'DRAM-buffer-overflow marker appears too frequently (capture likely incomplete), '
+                             'the command is given a grace period and then force-stopped.')
     parser.add_argument(
         '--op-support-count',
         type=int,
@@ -471,12 +948,20 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    if args.fail_check_only and args.skip_fail_check:
+        parser.error('--fail-check-only and --skip-fail-check are mutually exclusive.')
+
     command = args.command
     output_dir = os.path.realpath(args.output_dir)
+    if args.fail_check_only:
+        # Mark a fail-check-only run's output dir so it can't collide with / be mistaken for a
+        # full capture written to the same --output-dir.
+        output_dir += '--failcheckonly'
     pytest_mode = args.pytest
     report_name = args.report_name
     enable_logging = not args.disable_logging
     show_output = args.show_output
+    dram_guard = not args.disable_dram_drop_guard
     logger.remove()
     logger.add(sys.stdout, level='INFO')
 
@@ -488,7 +973,7 @@ def main() -> int:
         # pass now pins TT_METAL_LOGS_PATH / TT_METAL_PROFILER_DIR to its own
         # output dir (see run_profiler), so tt-metal writes nothing into cwd and
         # concurrent runs from the same directory no longer collide.
-        if not args.basic_only and not is_npe_on_path():
+        if not args.basic_only and not args.fail_check_only and not is_npe_on_path():
             logger.error('NPE not on path; source tt-npe/ENV_SETUP')
             return 1
         os.makedirs(output_dir)
@@ -503,48 +988,116 @@ def main() -> int:
     raw_dir = os.path.join(output_dir, 'raw')
     perf_dir = os.path.join(output_dir, 'perf')
     trace_dir = os.path.join(output_dir, 'trace')
+    failcheck_dir = os.path.join(output_dir, 'failcheck')
+
+    # Plan the pipeline steps for the live run-status sidecar (no sidecar in dryrun). 'merge' is
+    # planned only for a full capture (not --basic-only / --fail-check-only). Steps that never start
+    # (short-circuited after an earlier failure) are marked 'skipped' at finalize().
+    step_names = ['board_reset']
+    if not args.skip_fail_check:
+        step_names.append('failcheck')
+    if not args.fail_check_only:
+        step_names.append('raw')
+        if not args.basic_only:
+            step_names += ['perf', 'trace', 'merge']
+    status = RunStatus(output_dir, command, pytest_mode, step_names) if not args.dryrun else None
+
+    def _start(step: str) -> None:
+        if status is not None:
+            status.start(step)
+
+    def _finish(step: str, res: "subprocess.CompletedProcess[str] | None") -> None:
+        if status is not None:
+            status.finish(step, res)
+
+    def _skip(step: str) -> None:
+        if status is not None:
+            status.skip(step)
+
+    def _finalize() -> None:
+        if status is not None:
+            status.finalize()
 
     results: list[subprocess.CompletedProcess[str] | None] = []
 
     if not args.dryrun:
-        results.append(run_and_capture(['tt-smi', '-r'], show_output=args.show_output))
+        _start('board_reset')
+        reset_res = run_and_capture(['tt-smi', '-r'], show_output=args.show_output,
+                                    dram_drop_guard=dram_guard, status=status, step_name='board_reset')
+        results.append(reset_res)
+        _finish('board_reset', reset_res)
+
+    # Pre-flight: run the command once WITHOUT tracy so a trivially-broken command aborts before
+    # the expensive 3-pass Tracy capture. Appending to results makes the pass guards below and the
+    # merge short-circuit, and main() already exits non-zero when anyfails.
+    if not anyfails(results) and not args.skip_fail_check:
+        _start('failcheck')
+        fc = run_failcheck(command, pytest_mode, failcheck_dir, show_output=show_output, dryrun=args.dryrun,
+                           log_path=os.path.join(output_dir, 'failcheck_results_typescript.txt'),
+                           dram_drop_guard=dram_guard, status=status, step_name='failcheck')
+        results.append(fc)
+        _finish('failcheck', fc)
+        if anyfails(results):
+            logger.error('no-tracy fail-check failed -- aborting before the Tracy capture passes. '
+                         'Fix the command; see failcheck_results_typescript.txt.')
+
+    # --fail-check-only: stop after the pre-flight; no Tracy passes, no merge. Exit code reflects
+    # whether the command (or the preceding board reset) passed.
+    if args.fail_check_only:
+        _finalize()
+        if not args.dryrun:
+            if anyfails(results):
+                logger.error('--fail-check-only: pre-flight (or board reset) failed; exiting non-zero. '
+                             'See failcheck_results_typescript.txt.')
+                return 1
+            logger.info('--fail-check-only: command passed the no-tracy pre-flight; skipping Tracy passes and merge.')
+        return 0
 
     if not anyfails(results):
         logger.info('board reset successful, starting profiling runs')
+        _start('raw')
         result1 = run_profiler(
             command, raw_dir, pytest_mode, report_name,
             collect_noc_traces=False, collect_perf_counters=False,
             enable_logging=enable_logging, show_output=show_output, dryrun=args.dryrun,
             op_support_count=args.op_support_count,
+            log_path=os.path.join(output_dir, 'raw_results_typescript.txt'),
+            dram_drop_guard=dram_guard, status=status, step_name='raw',
         )
         results.append(result1)
-        write_result_file(output_dir, 'raw', result1)
+        _finish('raw', result1)
 
     if not args.basic_only:
         if not anyfails(results):
+            _start('perf')
             result2 = run_profiler(
                 command, perf_dir, pytest_mode, report_name,
                 collect_noc_traces=False, collect_perf_counters=True,
                 enable_logging=enable_logging, show_output=show_output, dryrun=args.dryrun,
                 op_support_count=args.op_support_count,
+                log_path=os.path.join(output_dir, 'perf_results_typescript.txt'),
+                dram_drop_guard=dram_guard, status=status, step_name='perf',
             )
             results.append(result2)
-            write_result_file(output_dir, 'perf', result2)
+            _finish('perf', result2)
         if not anyfails(results):
+            _start('trace')
             result3 = run_profiler(
                 command, trace_dir, pytest_mode, report_name,
                 collect_noc_traces=True, collect_perf_counters=False,
                 enable_logging=enable_logging, show_output=show_output, dryrun=args.dryrun,
                 op_support_count=args.op_support_count,
+                log_path=os.path.join(output_dir, 'trace_results_typescript.txt'),
+                dram_drop_guard=dram_guard, status=status, step_name='trace',
             )
             results.append(result3)
-            write_result_file(output_dir, 'trace', result3)
+            _finish('trace', result3)
 
     if args.dryrun:
         return 0
 
     # On-device merge: produce merged_ops_<RUNID>.csv as the final artifact of a successful
-    # full capture, so only it (+ hw_id.json) need be copied off the board. The
+    # full capture, so only it (+ hw_id.json, run_status.json, STATUS.txt) need be copied off the board. The
     # per-board DRAM peak BW is resolved from an INTERNAL interim table keyed on the
     # tt-smi board_type -- no CLI value needed. Needs raw+perf+trace, so skipped for
     # --basic-only / any failed pass; skipped (non-fatal) when the board is unknown
@@ -554,6 +1107,7 @@ def main() -> int:
         logger.info('--basic-only: skipping merge (needs raw+perf+trace).')
     elif anyfails(results):
         logger.warning('a profiling pass failed; skipping merge.')
+        _skip('merge')
     else:
         board = detect_board_type()
         bw = resolve_interim_dram_peak_bw(board) if board else None
@@ -563,11 +1117,15 @@ def main() -> int:
                 f'(known prefixes: {sorted(_INTERIM_BOARD_DRAM_PEAK_BW_GBPS)}). Merge manually: '
                 f'ops_perf_three_csv_merge.py --input-dir {output_dir} --dram-peak-bw-gbps <gbps>.'
             )
+            _skip('merge')
         else:
             logger.info(f'on-device merge: board_type={board} -> interim DRAM peak BW {bw} GB/s (PLACEHOLDER)')
-            merge_res = run_merge(output_dir, bw, show_output=show_output)
+            _start('merge')
+            merge_res = run_merge(output_dir, bw, show_output=show_output, merge_variant=args.merge_variant,
+                                  log_path=os.path.join(output_dir, 'merge_results_typescript.txt'),
+                                  dram_drop_guard=dram_guard, status=status, step_name='merge')
             results.append(merge_res)
-            write_result_file(output_dir, 'merge', merge_res)
+            _finish('merge', merge_res)
 
     if args.cleanup:
         cleanup_directories(output_dir)
@@ -575,6 +1133,7 @@ def main() -> int:
     # Propagate failures (board reset, any profiling pass, or the merge) as a non-zero
     # exit so automation/presets can detect them. Per-pass result files are already
     # written above, so a failed run still leaves its captured output on disk.
+    _finalize()
     if anyfails(results):
         logger.error('one or more steps failed; exiting non-zero (see per-pass results files).')
         return 1

--- a/tools/si_profiling_helpers/setup-step-0-clean.sh
+++ b/tools/si_profiling_helpers/setup-step-0-clean.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+# setup-step-0-clean.sh
+set -euo pipefail
+#
+# Description:
+#   Full clean of a tt-metal + python_env + tt-npe workspace, so
+#   setup-step-1-fresh-build.sh runs from scratch. Opposite of step-1.
+#
+# Usage:
+#   cd /path/to/tt-metal
+#   bash setup-step-0-clean.sh        # then: bash setup-step-1-fresh-build.sh
+#
+# Prerequisites:
+#   - Run from the tt-metal repository root (build_metal.sh must exist).
+#   - tt-npe is a sibling at ../tt-npe.
+
+if [[ ! -f build_metal.sh ]]; then
+    echo "ERROR: run from the tt-metal repository root (build_metal.sh not found)." >&2
+    exit 1
+fi
+
+# venv must not be active while we delete it.
+if [[ -n "${VIRTUAL_ENV:-}" ]]; then
+    echo "ERROR: a virtualenv is active ($VIRTUAL_ENV). Run 'deactivate' first." >&2
+    exit 1
+fi
+
+# 1. tt-metal C++/kernel artifacts + CPM/kernel caches (does NOT touch python_env).
+./build_metal.sh --clean
+
+# 2. Python venv (not covered by --clean).
+rm -rf python_env
+
+# 3. tt-npe build + install trees.
+rm -rf ../tt-npe/build ../tt-npe/install
+
+if [[ -n "${TT_METAL_CACHE:-}" ]]; then
+    echo "NOTE: TT_METAL_CACHE is set ($TT_METAL_CACHE) — delete it manually to fully clean."
+fi
+echo "Clean complete. Next: bash setup-step-1-fresh-build.sh"

--- a/tools/si_profiling_helpers/setup-step-1-fresh-build.sh
+++ b/tools/si_profiling_helpers/setup-step-1-fresh-build.sh
@@ -36,11 +36,16 @@ set -euo pipefail
 ./build_metal.sh
 
 # Create Python virtual environment
+# uv download hardening: defaults (30s timeout, 50 parallel downloads) starve
+# individual wheels on throttled links and abort mid-extract. Raise the read
+# timeout and cap concurrency so each stream keeps enough bandwidth.
+export UV_HTTP_TIMEOUT="${UV_HTTP_TIMEOUT:-600}"
+export UV_CONCURRENT_DOWNLOADS="${UV_CONCURRENT_DOWNLOADS:-8}"
 ./create_venv.sh
 
 # Activate venv so tt-npe build picks up the right Python interpreter
 source python_env/bin/activate
 
-# Build tt-npe with clang-20 compiler
-cd ../tt-npe
-bash build-npe.sh
+# Build tt-npe with clang-20 compiler (in a subshell so we return to the
+# tt-metal root afterwards, whether this script is run with bash or sourced).
+( cd ../tt-npe && bash build-npe.sh )

--- a/ttsim/front/ttnn/op.py
+++ b/ttsim/front/ttnn/op.py
@@ -482,20 +482,19 @@ def rms_norm(
         weight_tensor = require_ttnn_tensor(weight_tensor, "ttnn.rms_norm weight")
     if bias_tensor is not None:
         bias_tensor = require_ttnn_tensor(bias_tensor, "ttnn.rms_norm bias")
-    # Compute RMS (using layernorm for now)
-    rms = layer_norm(input_tensor, weight=weight_tensor, epsilon=epsilon, axis=-1)
-    normalized = div(input_tensor, rms)
-    if weight_tensor is not None:
-        weight_tensor = reshape(weight_tensor, (1, 1, 1, dim))
-        if normalized.shape[-1] != weight_tensor.shape[-1]:
-            weight_tensor = weight_tensor.repeat(
-                (1, 1, 1, normalized.shape[-1] // dim)
-            )  ## only repeat if needed
-        normalized = multiply(normalized, weight_tensor)
-
-    if bias_tensor is not None:
-        normalized = add(normalized, bias_tensor)
-    return normalized
+    # HW computes RMS-normalization (gamma scale + optional bias) in a SINGLE
+    # LayerNormDeviceOperation, so emit one op to match the silicon capture. The previous
+    # layer_norm + div + multiply decomposition over-emitted (3 ops vs 1 on HW) and was not a
+    # sound mimic. `dim` is retained for call-site compatibility but is no longer needed.
+    return layer_norm(
+        input_tensor,
+        weight=weight_tensor,
+        bias=bias_tensor,
+        epsilon=epsilon,
+        axis=-1,
+        memory_config=memory_config,
+        compute_kernel_config=compute_kernel_config,
+    )
 
 
 def max_pool2d_pp(args_list, kwargs_dict):
@@ -662,8 +661,39 @@ class transformer:
     def __init__(self, config):
         pass
 
-    def paged_scaled_dot_product_attention_decode(self, *args, **kwargs):
-        pass
+    @staticmethod
+    def scaled_dot_product_attention(q, k, v, *, is_causal=True, scale=None,
+                                     sliding_window_size=None, compute_kernel_config=None,
+                                     program_config=None, memory_config=None, **kwargs):
+        """Prefill SDPA (non-paged, non-chunked); output = q shape."""
+        from .ttnn_shim import scaled_dot_product_attention_op as _sdpa
+        # Pass scale through unchanged: when the caller omits it (None), the shim op
+        # drops it from the recorded attrs rather than fabricating a 0.0 (which is not
+        # a valid SDPA scale and would pollute attrs / LUT keys vs an omitted attribute).
+        return _sdpa(q, k, v, memory_config=memory_config, is_causal=bool(is_causal),
+                     scale=scale)
+
+    @staticmethod
+    def scaled_dot_product_attention_decode(q, k, v, *, cur_pos_tensor=None, scale=None,
+                                            sliding_window_size=None, program_config=None,
+                                            compute_kernel_config=None, memory_config=None,
+                                            **kwargs):
+        """Decode SDPA (non-paged); output = q shape."""
+        from .ttnn_shim import scaled_dot_product_attention_op as _sdpa
+        return _sdpa(q, k, v, cur_pos_tensor, memory_config=memory_config,
+                     scale=scale)
+
+    @staticmethod
+    def paged_scaled_dot_product_attention_decode(q, k, v, *, page_table_tensor=None,
+                                                  cur_pos_tensor=None, scale=None,
+                                                  sliding_window_size=None, program_config=None,
+                                                  compute_kernel_config=None, memory_config=None,
+                                                  **kwargs):
+        """Paged decode SDPA; output = q shape."""
+        from .ttnn_shim import scaled_dot_product_attention_op as _sdpa
+        return _sdpa(q, k, v, cur_pos_tensor, page_table_tensor,
+                     memory_config=memory_config,
+                     scale=scale)
 
 
 class experimental:
@@ -690,6 +720,51 @@ class experimental:
         """Delegate to ttnn_shim; mirrors HW's single-op head concatenation."""
         from .ttnn_shim import nlp_concat_heads as _nlp_concat_heads
         return _nlp_concat_heads(input_tensor, memory_config=memory_config)
+
+    @staticmethod
+    def rotary_embedding_llama(x, cos, sin, trans_mat, is_decode_mode=False,
+                               memory_config=None):
+        """Prefill rotary embedding (called separately for q and k); output = x shape."""
+        from .ttnn_shim import rotary_embedding_llama_op as _rope
+        return _rope(x, cos, sin, trans_mat, is_decode_mode=is_decode_mode,
+                     memory_config=memory_config)
+
+    @staticmethod
+    def rotary_embedding_llama_fused_qk(q, k, cos, sin, trans_mat, memory_config=None):
+        """Decode fused rotary embedding; returns (q, k), each = its input shape."""
+        from .ttnn_shim import rotary_embedding_llama_fused_qk_op as _rope_qk
+        return _rope_qk(q, k, cos, sin, trans_mat, memory_config=memory_config)
+
+    @staticmethod
+    def paged_fill_cache(cache, input_tensor, page_table=None, *, batch_idx=0,
+                         memory_config=None):
+        """Prefill KV-cache fill (in place); output = cache shape."""
+        from .ttnn_shim import paged_fill_cache_op as _fill
+        return _fill(cache, input_tensor, page_table=page_table, batch_idx=batch_idx,
+                     memory_config=memory_config)
+
+    @staticmethod
+    def paged_fused_update_cache(k_cache, k, v_cache, v, *, update_idxs_tensor=None,
+                                 page_table=None, memory_config=None):
+        """Decode fused KV-cache update (in place); returns (k_cache, v_cache)."""
+        from .ttnn_shim import paged_fused_update_cache_op as _upd
+        return _upd(k_cache, k, v_cache, v, update_idxs_tensor=update_idxs_tensor,
+                    page_table=page_table, memory_config=memory_config)
+
+    @staticmethod
+    def nlp_create_qkv_heads_decode(input_tensor, *, num_heads, num_kv_heads=None,
+                                    head_dim=None, memory_config=None, **kwargs):
+        """Decode QKV head split; returns (q, k, v) with heads on the Y axis."""
+        from .ttnn_shim import nlp_create_qkv_heads_decode_op as _create
+        return _create(input_tensor, num_heads=num_heads, num_kv_heads=num_kv_heads,
+                       head_dim=head_dim, memory_config=memory_config)
+
+    @staticmethod
+    def nlp_concat_heads_decode(input_tensor, *, num_heads=None, memory_config=None,
+                                **kwargs):
+        """Decode head concatenation; output folds head_dim into the X axis."""
+        from .ttnn_shim import nlp_concat_heads_decode_op as _concat
+        return _concat(input_tensor, num_heads=num_heads, memory_config=memory_config)
 
 
 def all_gather(*args, **kwargs):
@@ -747,6 +822,23 @@ log         = single_output_immediate_op('Log')
 min         = single_output_immediate_op('Min')
 max         = single_output_immediate_op('Max')
 sqrt        = single_output_immediate_op('Sqrt')
+
+class UnaryOpType:
+    """Fused unary activations for binary ops — mirrors ttnn.UnaryOpType.
+
+    Pass e.g. ``input_tensor_a_activations=[UnaryOpType.SILU]`` to a binary op
+    (``multiply``/``add``) so the fused activation is modeled as a SINGLE op — the HW
+    BinaryNg carries the activation (cf. tt-metal mlp.py:239 SILU-fused gate*up). The
+    kwarg is forwarded into the SimOp attrs by single_output_immediate_op, so NO
+    separate activation op is emitted (which would over-emit vs HW). Values mirror the
+    ttnn.UnaryOpType enum names.
+    """
+    SILU = 'SILU'
+    GELU = 'GELU'
+    RELU = 'RELU'
+    SIGMOID = 'SIGMOID'
+    TANH = 'TANH'
+
 
 # Pointwise Binary
 add = single_output_immediate_op("Add")

--- a/ttsim/front/ttnn/ttnn_shim.py
+++ b/ttsim/front/ttnn/ttnn_shim.py
@@ -2950,3 +2950,307 @@ def nlp_create_qkv_heads(input_tensor, kv_input_tensor=None, *,
         device=input_tensor.device, data=v_data,
     )
     return q, k, v
+
+
+# ---------------------------------------------------------------------------
+# Llama3 transformer device ops (rotary embedding, KV cache, head split/concat,
+# SDPA). Tracking-only: each emits a single SimOp matching the HW profiler trace
+# and returns synthetic output Tensor(s) whose shapes mirror tt-metal semantics.
+# ---------------------------------------------------------------------------
+
+def rotary_embedding_llama_op(x, cos, sin, trans_mat, is_decode_mode=False,
+                               memory_config=None, element_size=2):
+    """RotaryEmbeddingLlama (prefill): apply rotary embedding to x; output shape = x.
+
+    Called separately for q and k in tt-metal. cos/sin/trans_mat are auxiliary
+    inputs recorded on the op but do not change the output shape.
+    """
+    assert x.device is not None, "rotary_embedding_llama_op requires x on device"
+    op_name = generate_new_op_name()
+    in_tensors = [t for t in (x, cos, sin, trans_mat) if t is not None]
+    out_tensor = Tensor(
+        name=op_name + '.out',
+        shape=x.logical_shape()._shape,
+        dtype=x.dtype,
+        layout=x.get_layout(),
+        op_out=[op_name],
+        device=x.device,
+    )
+    for t in in_tensors:
+        t.op_in.append(op_name)
+    opinfo = {
+        'name': op_name,
+        'optype': 'RotaryEmbeddingLlama',
+        'inList': [t.name for t in in_tensors],
+        'outList': [out_tensor.name],
+        'attrs': {'is_decode_mode': bool(is_decode_mode), 'element_size': element_size},
+    }
+    opobj = SimOp(opinfo)
+    opobj.get_perf_counts(in_tensors, [out_tensor])
+    opobj.update_tensor_counts(in_tensors, [out_tensor])
+    _propagate_ttnn_dtype([x], [out_tensor])
+    out_tensor._memory_config = memory_config if memory_config is not None else getattr(x, '_memory_config', None)
+    x.device.add_op(opobj)
+    return out_tensor
+
+
+def rotary_embedding_llama_fused_qk_op(q, k, cos, sin, trans_mat,
+                                        memory_config=None, element_size=2):
+    """RotaryEmbeddingLlamaFusedQK (decode): rotary on q and k in one op.
+
+    Returns (q_out, k_out), each with the shape of its corresponding input.
+    """
+    assert q.device is not None, "rotary_embedding_llama_fused_qk_op requires q on device"
+    op_name = generate_new_op_name()
+    in_tensors = [t for t in (q, k, cos, sin, trans_mat) if t is not None]
+    q_out = Tensor(
+        name=op_name + '.out.0', shape=q.logical_shape()._shape, dtype=q.dtype,
+        layout=q.get_layout(), op_out=[op_name], device=q.device,
+    )
+    k_out = Tensor(
+        name=op_name + '.out.1', shape=k.logical_shape()._shape, dtype=k.dtype,
+        layout=k.get_layout(), op_out=[op_name], device=q.device,
+    )
+    for t in in_tensors:
+        t.op_in.append(op_name)
+    opinfo = {
+        'name': op_name,
+        'optype': 'RotaryEmbeddingLlamaFusedQK',
+        'inList': [t.name for t in in_tensors],
+        'outList': [q_out.name, k_out.name],
+        'attrs': {'element_size': element_size},
+    }
+    opobj = SimOp(opinfo)
+    out_tensors = [q_out, k_out]
+    opobj.get_perf_counts(in_tensors, out_tensors)
+    opobj.update_tensor_counts(in_tensors, out_tensors)
+    _propagate_ttnn_dtype([q], [q_out])
+    _propagate_ttnn_dtype([k], [k_out])
+    if memory_config is not None:
+        q_out._memory_config = memory_config
+        k_out._memory_config = memory_config
+    else:
+        q_out._memory_config = getattr(q, '_memory_config', None)
+        k_out._memory_config = getattr(k, '_memory_config', None)
+    q.device.add_op(opobj)
+    return q_out, k_out
+
+
+def paged_fill_cache_op(cache, input_tensor, page_table=None, batch_idx=0,
+                         memory_config=None, element_size=2):
+    """PagedFillCache (prefill): fill the KV cache in place; output shape = cache.
+
+    The cache tensor is updated in place on hardware; we emit a passthrough
+    SimOp and return a tensor with the cache's shape so the graph edge exists.
+    """
+    assert cache.device is not None, "paged_fill_cache_op requires cache on device"
+    op_name = generate_new_op_name()
+    in_tensors = [t for t in (cache, input_tensor, page_table) if t is not None]
+    out_tensor = Tensor(
+        name=op_name + '.out',
+        shape=cache.logical_shape()._shape,
+        dtype=cache.dtype,
+        layout=cache.get_layout(),
+        op_out=[op_name],
+        device=cache.device,
+    )
+    for t in in_tensors:
+        t.op_in.append(op_name)
+    opinfo = {
+        'name': op_name,
+        'optype': 'PagedFillCache',
+        'inList': [t.name for t in in_tensors],
+        'outList': [out_tensor.name],
+        'attrs': {'batch_idx': batch_idx, 'element_size': element_size},
+    }
+    opobj = SimOp(opinfo)
+    opobj.get_perf_counts(in_tensors, [out_tensor])
+    opobj.update_tensor_counts(in_tensors, [out_tensor])
+    _propagate_ttnn_dtype([cache], [out_tensor])
+    out_tensor._memory_config = memory_config if memory_config is not None else getattr(cache, '_memory_config', None)
+    cache.device.add_op(opobj)
+    return out_tensor
+
+
+def paged_fused_update_cache_op(k_cache, k, v_cache, v, update_idxs_tensor=None,
+                                 page_table=None, memory_config=None, element_size=2):
+    """PagedFusedUpdateCache (decode): update K and V caches in place.
+
+    Returns (k_cache_out, v_cache_out), each with its cache input's shape.
+    """
+    assert k_cache.device is not None, "paged_fused_update_cache_op requires k_cache on device"
+    op_name = generate_new_op_name()
+    in_tensors = [t for t in (k_cache, k, v_cache, v, update_idxs_tensor, page_table) if t is not None]
+    k_out = Tensor(
+        name=op_name + '.out.0', shape=k_cache.logical_shape()._shape, dtype=k_cache.dtype,
+        layout=k_cache.get_layout(), op_out=[op_name], device=k_cache.device,
+    )
+    v_out = Tensor(
+        name=op_name + '.out.1', shape=v_cache.logical_shape()._shape, dtype=v_cache.dtype,
+        layout=v_cache.get_layout(), op_out=[op_name], device=k_cache.device,
+    )
+    for t in in_tensors:
+        t.op_in.append(op_name)
+    opinfo = {
+        'name': op_name,
+        'optype': 'PagedFusedUpdateCache',
+        'inList': [t.name for t in in_tensors],
+        'outList': [k_out.name, v_out.name],
+        'attrs': {'element_size': element_size},
+    }
+    opobj = SimOp(opinfo)
+    out_tensors = [k_out, v_out]
+    opobj.get_perf_counts(in_tensors, out_tensors)
+    opobj.update_tensor_counts(in_tensors, out_tensors)
+    _propagate_ttnn_dtype([k_cache], [k_out])
+    _propagate_ttnn_dtype([v_cache], [v_out])
+    if memory_config is not None:
+        k_out._memory_config = memory_config
+        v_out._memory_config = memory_config
+    else:
+        k_out._memory_config = getattr(k_cache, '_memory_config', None)
+        v_out._memory_config = getattr(v_cache, '_memory_config', None)
+    k_cache.device.add_op(opobj)
+    return k_out, v_out
+
+
+def nlp_create_qkv_heads_decode_op(input_tensor, *, num_heads, num_kv_heads=None,
+                                    head_dim=None, memory_config=None, element_size=2):
+    """NLPCreateQKVHeadsDecode (decode): split fused QKV into Q, K, V.
+
+    Decode WZYX convention: input [..., 1, hidden] -> heads on the Y axis, head_dim on X:
+      Q = [..lead.., num_heads, head_dim]
+      K = V = [..lead.., num_kv_heads, head_dim]
+    where lead is the leading dims (typically [1, 1]).
+    """
+    assert input_tensor.device is not None, "nlp_create_qkv_heads_decode_op requires input on device"
+    if num_kv_heads is None:
+        num_kv_heads = num_heads
+    in_shape = input_tensor.logical_shape()._shape
+    hidden = in_shape[-1]
+    if head_dim is None:
+        total_heads = num_heads + 2 * num_kv_heads
+        if hidden % total_heads != 0:
+            raise ValueError(
+                f"nlp_create_qkv_heads_decode_op: hidden {hidden} not divisible by "
+                f"num_heads + 2*num_kv_heads ({total_heads})"
+            )
+        head_dim = hidden // total_heads
+
+    lead = list(in_shape[:-2]) if len(in_shape) >= 2 else [1, 1]
+    while len(lead) < 2:
+        lead = [1] + lead
+    q_shape = lead + [num_heads, head_dim]
+    k_shape = lead + [num_kv_heads, head_dim]
+    v_shape = lead + [num_kv_heads, head_dim]
+
+    op_name = generate_new_op_name()
+    q_tensor = Tensor(name=f"{op_name}.out.0", shape=q_shape, dtype=input_tensor.dtype,
+                      layout=input_tensor.get_layout(), op_out=[op_name], device=input_tensor.device)
+    k_tensor = Tensor(name=f"{op_name}.out.1", shape=k_shape, dtype=input_tensor.dtype,
+                      layout=input_tensor.get_layout(), op_out=[op_name], device=input_tensor.device)
+    v_tensor = Tensor(name=f"{op_name}.out.2", shape=v_shape, dtype=input_tensor.dtype,
+                      layout=input_tensor.get_layout(), op_out=[op_name], device=input_tensor.device)
+    input_tensor.op_in.append(op_name)
+    opinfo = {
+        'name': op_name,
+        'optype': 'NLPCreateQKVHeadsDecode',
+        'inList': [input_tensor.name],
+        'outList': [q_tensor.name, k_tensor.name, v_tensor.name],
+        'attrs': {
+            'num_heads': num_heads,
+            'num_kv_heads': num_kv_heads,
+            'head_dim': head_dim,
+            'element_size': element_size,
+        },
+    }
+    opobj = SimOp(opinfo)
+    out_tensors = [q_tensor, k_tensor, v_tensor]
+    opobj.get_perf_counts([input_tensor], out_tensors)
+    opobj.update_tensor_counts([input_tensor], out_tensors)
+    _propagate_ttnn_dtype([input_tensor], out_tensors)
+    out_mc = memory_config if memory_config is not None else MemoryConfig(
+        TensorMemoryLayout.HEIGHT_SHARDED, BufferType.L1,
+    )
+    for t in out_tensors:
+        t._memory_config = out_mc
+    input_tensor.device.add_op(opobj)
+    return q_tensor, k_tensor, v_tensor
+
+
+def nlp_concat_heads_decode_op(input_tensor, num_heads=None, memory_config=None, element_size=2):
+    """NLPConcatHeadsDecode (decode): concatenate heads on the X axis.
+
+    Decode WZYX convention: input [..lead.., num_heads, head_dim] (heads on Y) ->
+    output [..lead.., num_heads, num_heads*head_dim] (head_dim folded into X).
+    """
+    assert input_tensor.device is not None, "nlp_concat_heads_decode_op requires input on device"
+    in_shape = input_tensor.logical_shape()._shape
+    assert len(in_shape) >= 2, f"NLPConcatHeadsDecode expects rank>=2 input, got {len(in_shape)}"
+    if num_heads is None:
+        num_heads = in_shape[-2]
+    head_dim = in_shape[-1]
+    out_shape = list(in_shape[:-1]) + [num_heads * head_dim]
+
+    op_name = generate_new_op_name()
+    out_tensor = Tensor(
+        name=op_name + '.out', shape=out_shape, dtype=input_tensor.dtype,
+        layout=input_tensor.get_layout(), op_out=[op_name], device=input_tensor.device,
+    )
+    input_tensor.op_in.append(op_name)
+    opinfo = {
+        'name': op_name,
+        'optype': 'NLPConcatHeadsDecode',
+        'inList': [input_tensor.name],
+        'outList': [out_tensor.name],
+        'attrs': {'num_heads': num_heads, 'element_size': element_size},
+    }
+    opobj = SimOp(opinfo)
+    opobj.get_perf_counts([input_tensor], [out_tensor])
+    opobj.update_tensor_counts([input_tensor], [out_tensor])
+    _propagate_ttnn_dtype([input_tensor], [out_tensor])
+    out_tensor._memory_config = memory_config if memory_config is not None else MemoryConfig(
+        TensorMemoryLayout.WIDTH_SHARDED, BufferType.L1,
+    )
+    input_tensor.device.add_op(opobj)
+    return out_tensor
+
+
+def scaled_dot_product_attention_op(q, k, v, *extra_inputs, memory_config=None,
+                                    element_size=2, **attrs):
+    """ScaledDotProductAttention: prefill (q,k,v) or decode/paged (q, k_cache, v_cache, ...).
+
+    Output shape always equals q. Extra positional tensor inputs (cur_pos,
+    page_table) are recorded on the op. Non-shape kwargs (scale, is_causal, ...)
+    are stored in attrs.
+    """
+    assert q.device is not None, "scaled_dot_product_attention_op requires q on device"
+    op_name = generate_new_op_name()
+    in_tensors = [t for t in (q, k, v, *extra_inputs)
+                  if t is not None and isinstance(t, Tensor)]
+    out_tensor = Tensor(
+        name=op_name + '.out',
+        shape=q.logical_shape()._shape,
+        dtype=q.dtype,
+        layout=q.get_layout(),
+        op_out=[op_name],
+        device=q.device,
+    )
+    for t in in_tensors:
+        t.op_in.append(op_name)
+    op_attrs = {k_: v_ for k_, v_ in attrs.items() if isinstance(v_, (int, float, bool, str))}
+    op_attrs['element_size'] = element_size
+    opinfo = {
+        'name': op_name,
+        'optype': 'ScaledDotProductAttention',
+        'inList': [t.name for t in in_tensors],
+        'outList': [out_tensor.name],
+        'attrs': op_attrs,
+    }
+    opobj = SimOp(opinfo)
+    opobj.get_perf_counts(in_tensors, [out_tensor])
+    opobj.update_tensor_counts(in_tensors, [out_tensor])
+    _propagate_ttnn_dtype([q], [out_tensor])
+    out_tensor._memory_config = memory_config if memory_config is not None else getattr(q, '_memory_config', None)
+    q.device.add_op(opobj)
+    return out_tensor

--- a/ttsim/ops/desc/ttsim_layout.py
+++ b/ttsim/ops/desc/ttsim_layout.py
@@ -527,6 +527,226 @@ def move_sinf(iTList, oTList, op, **kwargs):
     return
 
 
+def _passthrough_perf(in_shapes, out_shape, elem_size):
+    """Build a passthrough perf_stats dict: 1 mov per output element."""
+    in_elems = sum(_nelems(s) for s in in_shapes if s)
+    out_elems = _nelems(out_shape)
+    return {
+        'inElems': in_elems,
+        'outElems': out_elems,
+        'inBytes': in_elems * elem_size,
+        'outBytes': out_elems * elem_size,
+        'instrs': {'mov': out_elems},
+    }
+
+
+def rotary_embedding_llama_sinf(iTList, oTList, op, **kwargs):
+    """Shape inference for RotaryEmbeddingLlama (prefill): output = in0 (x) shape.
+
+    Inputs: x, cos, sin, trans_mat (rotary applied in-place on x's layout).
+    """
+    assert 1 <= len(iTList) <= 4 and len(oTList) == 1
+    X = iTList[0]
+    in_shape = require_shape_list(
+        X.shape,
+        "RotaryEmbeddingLlama shape inference: input tensor shape must be known",
+    )
+    oTList[0].shape = list(in_shape)
+    oTList[0].dtype = X.dtype
+
+    elem_size = op.attrs.get('element_size', 2)
+    op.perf_stats = _passthrough_perf([t.shape for t in iTList], in_shape, elem_size)
+    return
+
+
+def rotary_embedding_llama_fused_qk_sinf(iTList, oTList, op, **kwargs):
+    """Shape inference for RotaryEmbeddingLlamaFusedQK (decode): 2 outputs (q, k).
+
+    Inputs: q, k, cos, sin, trans_mat. out0 = q shape, out1 = k shape.
+    """
+    assert 2 <= len(iTList) <= 5 and len(oTList) == 2
+    Q = iTList[0]
+    K = iTList[1]
+    q_shape = require_shape_list(
+        Q.shape, "RotaryEmbeddingLlamaFusedQK shape inference: q shape must be known",
+    )
+    k_shape = require_shape_list(
+        K.shape, "RotaryEmbeddingLlamaFusedQK shape inference: k shape must be known",
+    )
+    oTList[0].shape = list(q_shape)
+    oTList[0].dtype = Q.dtype
+    oTList[1].shape = list(k_shape)
+    oTList[1].dtype = K.dtype
+
+    elem_size = op.attrs.get('element_size', 2)
+    in_elems = sum(_nelems(t.shape) for t in iTList if t.shape)
+    out_elems = _nelems(q_shape) + _nelems(k_shape)
+    op.perf_stats = {
+        'inElems': in_elems,
+        'outElems': out_elems,
+        'inBytes': in_elems * elem_size,
+        'outBytes': out_elems * elem_size,
+        'instrs': {'mov': out_elems},
+    }
+    return
+
+
+def paged_fill_cache_sinf(iTList, oTList, op, **kwargs):
+    """Shape inference for PagedFillCache (prefill): output = in0 (cache) shape.
+
+    Inputs: cache, input (k or v), page_table. The cache is filled in place;
+    the op returns the cache tensor unchanged in shape.
+    """
+    # PagedFillCache requires (cache, input) at minimum; page_table is optional.
+    assert 2 <= len(iTList) <= 3 and len(oTList) == 1
+    cache = iTList[0]
+    cache_shape = require_shape_list(
+        cache.shape, "PagedFillCache shape inference: cache shape must be known",
+    )
+    oTList[0].shape = list(cache_shape)
+    oTList[0].dtype = cache.dtype
+
+    elem_size = op.attrs.get('element_size', 2)
+    op.perf_stats = _passthrough_perf([t.shape for t in iTList], cache_shape, elem_size)
+    return
+
+
+def paged_fused_update_cache_sinf(iTList, oTList, op, **kwargs):
+    """Shape inference for PagedFusedUpdateCache (decode): 2 outputs (k_cache, v_cache).
+
+    Inputs: k_cache, k, v_cache, v, update_idxs_tensor, page_table.
+    out0 = k_cache (in0) shape, out1 = v_cache (in2) shape; updated in place.
+    """
+    # Op semantics require (k_cache, k, v_cache, v) at minimum; update_idxs/page_table optional.
+    assert 4 <= len(iTList) <= 6 and len(oTList) == 2
+    k_cache = iTList[0]
+    v_cache = iTList[2]
+    k_cache_shape = require_shape_list(
+        k_cache.shape, "PagedFusedUpdateCache shape inference: k_cache shape must be known",
+    )
+    v_cache_shape = require_shape_list(
+        v_cache.shape, "PagedFusedUpdateCache shape inference: v_cache shape must be known",
+    )
+    oTList[0].shape = list(k_cache_shape)
+    oTList[0].dtype = k_cache.dtype
+    oTList[1].shape = list(v_cache_shape)
+    oTList[1].dtype = v_cache.dtype
+
+    elem_size = op.attrs.get('element_size', 2)
+    in_elems = sum(_nelems(t.shape) for t in iTList if t.shape)
+    out_elems = _nelems(k_cache_shape) + _nelems(v_cache_shape)
+    op.perf_stats = {
+        'inElems': in_elems,
+        'outElems': out_elems,
+        'inBytes': in_elems * elem_size,
+        'outBytes': out_elems * elem_size,
+        'instrs': {'mov': out_elems},
+    }
+    return
+
+
+def nlp_create_qkv_heads_decode_sinf(iTList, oTList, op, **kwargs):
+    """Shape inference for NLPCreateQKVHeadsDecode: 1 input -> 3 outputs (Q, K, V).
+
+    Decode WZYX convention: input [1, 1, B, (num_q + 2*num_kv) * head_dim],
+    outputs put heads on the Y axis and head_dim on X:
+      Q = [1, 1, num_q_heads, head_dim]
+      K = [1, 1, num_kv_heads, head_dim]
+      V = [1, 1, num_kv_heads, head_dim]
+    """
+    assert len(iTList) == 1 and len(oTList) == 3
+    X = iTList[0]
+    in_shape = require_shape_list(
+        X.shape, "NLPCreateQKVHeadsDecode shape inference: input shape must be known",
+    )
+
+    num_q_heads = op.attrs.get('num_heads', 1)
+    num_kv_heads = op.attrs.get('num_kv_heads', num_q_heads)
+    head_dim = op.attrs.get('head_dim', None)
+    hidden = in_shape[-1]
+    if head_dim is None:
+        total_heads = num_q_heads + 2 * num_kv_heads
+        if hidden % total_heads != 0:
+            # Mirror nlp_create_qkv_heads_decode_op, which raises for this case.
+            raise ValueError(
+                f"NLPCreateQKVHeadsDecode shape inference: hidden {hidden} not divisible by "
+                f"num_heads + 2*num_kv_heads ({total_heads})"
+            )
+        head_dim = hidden // total_heads
+
+    lead = list(in_shape[:-2]) if len(in_shape) >= 2 else [1, 1]
+    while len(lead) < 2:
+        lead = [1] + lead
+    q_shape = lead + [num_q_heads, head_dim]
+    k_shape = lead + [num_kv_heads, head_dim]
+    v_shape = lead + [num_kv_heads, head_dim]
+
+    oTList[0].shape = q_shape
+    oTList[0].dtype = X.dtype
+    oTList[1].shape = k_shape
+    oTList[1].dtype = X.dtype
+    oTList[2].shape = v_shape
+    oTList[2].dtype = X.dtype
+
+    elem_size = op.attrs.get('element_size', 2)
+    in_elems = _nelems(in_shape)
+    out_elems = _nelems(q_shape) + _nelems(k_shape) + _nelems(v_shape)
+    op.perf_stats = {
+        'inElems': in_elems,
+        'outElems': out_elems,
+        'inBytes': in_elems * elem_size,
+        'outBytes': out_elems * elem_size,
+        'instrs': {'mov': out_elems},
+    }
+    return
+
+
+def nlp_concat_heads_decode_sinf(iTList, oTList, op, **kwargs):
+    """Shape inference for NLPConcatHeadsDecode: concatenate heads on the X axis.
+
+    Decode WZYX convention: input [1, 1, num_heads, head_dim] (heads on Y),
+    output [1, 1, num_heads, num_heads * head_dim] -- the input Y dim (in_shape[-2])
+    is kept and head_dim is folded into X. HW keeps the Y dim (batch placeholder) and
+    grows X = num_heads * head_dim.
+    """
+    assert len(iTList) == 1 and len(oTList) == 1
+    X = iTList[0]
+    in_shape = require_shape_list(
+        X.shape, "NLPConcatHeadsDecode shape inference: input shape must be known",
+    )
+    assert len(in_shape) >= 2, f"NLPConcatHeadsDecode expects rank>=2 input, got {len(in_shape)}"
+    num_heads = op.attrs.get('num_heads', in_shape[-2])
+    head_dim = in_shape[-1]
+    out_shape = list(in_shape[:-1]) + [num_heads * head_dim]
+
+    oTList[0].shape = out_shape
+    oTList[0].dtype = X.dtype
+
+    elem_size = op.attrs.get('element_size', 2)
+    op.perf_stats = _passthrough_perf([in_shape], out_shape, elem_size)
+    return
+
+
+def sdpa_sinf(iTList, oTList, op, **kwargs):
+    """Shape inference for ScaledDotProductAttention (prefill + decode): output = q (in0) shape.
+
+    Inputs (prefill): q, k, v. Inputs (decode/paged): q, k_cache, v_cache, cur_pos, page_table.
+    Output has the same shape as q in all cases.
+    """
+    # Match the op-table registration ARITY_VARIADIC[3-5]: prefill=3 (q,k,v), decode/paged up to 5.
+    assert 3 <= len(iTList) <= 5 and len(oTList) == 1
+    Q = iTList[0]
+    q_shape = require_shape_list(
+        Q.shape, "ScaledDotProductAttention shape inference: q shape must be known",
+    )
+    oTList[0].shape = list(q_shape)
+    oTList[0].dtype = Q.dtype
+
+    elem_size = op.attrs.get('element_size', 2)
+    op.perf_stats = _passthrough_perf([t.shape for t in iTList], q_shape, elem_size)
+    return
+
+
 def register_layout_ops():
     d = _TTNN_OP_DOMAIN
     _optbl = [
@@ -541,6 +761,13 @@ def register_layout_ops():
         ['Move', 'ARITY_1->1', d, 'COMMON', 24, 21, 1, 1, 1, 1, move_sinf, True, True, True, True, True],
         ['ConcatHeads', 'ARITY_1->1', d, 'COMMON', 24, 21, 1, 1, 1, 1, nlp_concat_heads_sinf, True, True, True, True, True],
         ['CreateQKVHeads', 'ARITY_VARIADIC[1-2]->3', d, 'COMMON', 24, 21, 2, 1, 3, 3, nlp_create_qkv_heads_sinf, True, True, True, True, True],
+        ['RotaryEmbeddingLlama', 'ARITY_VARIADIC[1-4]->1', d, 'COMMON', 24, 21, 4, 1, 1, 1, rotary_embedding_llama_sinf, True, True, True, True, True],
+        ['RotaryEmbeddingLlamaFusedQK', 'ARITY_VARIADIC[2-5]->2', d, 'COMMON', 24, 21, 5, 2, 2, 2, rotary_embedding_llama_fused_qk_sinf, True, True, True, True, True],
+        ['PagedFillCache', 'ARITY_VARIADIC[2-3]->1', d, 'COMMON', 24, 21, 3, 2, 1, 1, paged_fill_cache_sinf, True, True, True, True, True],
+        ['PagedFusedUpdateCache', 'ARITY_VARIADIC[4-6]->2', d, 'COMMON', 24, 21, 6, 4, 2, 2, paged_fused_update_cache_sinf, True, True, True, True, True],
+        ['NLPCreateQKVHeadsDecode', 'ARITY_1->3', d, 'COMMON', 24, 21, 1, 1, 3, 3, nlp_create_qkv_heads_decode_sinf, True, True, True, True, True],
+        ['NLPConcatHeadsDecode', 'ARITY_1->1', d, 'COMMON', 24, 21, 1, 1, 1, 1, nlp_concat_heads_decode_sinf, True, True, True, True, True],
+        ['ScaledDotProductAttention', 'ARITY_VARIADIC[3-5]->1', d, 'COMMON', 24, 21, 5, 3, 1, 1, sdpa_sinf, True, True, True, True, True],
     ]
     register_ops('layout', _optbl)
     return


### PR DESCRIPTION
Adds the llama3/transformer device ops to the TTNN shim and maps them onto compute pipes, so llama3 (and other transformer workloads) can be built analytically by Polaris.

## What's included
- **Shim transformer ops** — `rotary_embedding_llama` / `rotary_embedding_llama_fused_qk`, paged-cache fill/update (`PagedFillCache`, `PagedFusedUpdateCache`), decode QKV/concat heads (`NLPCreateQKVHeadsDecode`, `NLPConcatHeadsDecode`), prefill create/concat heads, and SDPA — with shape descriptors.
- **`UnaryOpType` (SILU)** for fused activations on binary ops.
- **`rms_norm` emitted as a single `LayerNorm` op** — a sound mimic of the real ttnn op (not decomposed), matching the HW capture.
- **Compute-pipe mapping** for the new prefill + decode ops in `wl2archmapping.yaml`.

## Verification
Exercised end-to-end by the dual-mode llama3 workloads (the stacked PR below): a full 32-layer llama3-8B graph builds for both prefill and decode on BH p100a with every new op mapped (no unmapped/generic op types).

## Stacking
Base of a stacked pair — the dual-mode workloads PR (#466) builds on this branch. Review/merge this first.

Closes #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)