### PR TITLE
fix(475): pin floating deps + ndarray-typed astype in grid_mask fromarray

### DIFF
--- a/envdev.yaml
+++ b/envdev.yaml
@@ -6,9 +6,9 @@ channels:
 dependencies:
   # Core dependencies (shared with environment.yaml, same order)
   # Essential packages required for running polaris
-  - deepdiff
+  - deepdiff=9.1.0
   - einops=0.8.2 # used by MapTracker
-  - gitpython
+  - gitpython=3.1.50
   - hydra-core=1.3.2
   - loguru=0.7.3
   - lxml=6.0.0
@@ -18,6 +18,7 @@ dependencies:
   - numpy=2.2.3
   - onnx=1.17.0
   - openpyxl=3.1.5
+  - pillow=11.1.0 # transitive (matplotlib); pinned to keep Image.fromarray typing stable
   - pydantic=2.10.6
   - pyelftools=0.31
   - python=3.13.2
@@ -30,20 +31,20 @@ dependencies:
   # Development-specific dependencies (alphabetical order)
   # Additional packages for development, testing, and code quality
   - coverage=7.6.12
-  - fabric
-  - isort
+  - fabric=3.2.3
+  - isort=8.0.1
   - mypy=1.15.0
   - pip=25.0.1
-  - pre-commit
-  - pytest-cov
-  - pytest-json-report
-  - pytest-mock
-  - pytest-xdist
-  - ruff
+  - pre-commit=4.6.0
+  - pytest-cov=6.3.0
+  - pytest-json-report=1.5.0
+  - pytest-mock=3.15.1
+  - pytest-xdist=3.8.0
+  - ruff=0.15.16
   - pip:
     - pytest==8.3.4
     - types-PYYAML==6.0.12.20241230
     - types-networkx==3.4.2.20241227
-    - types-requests
-    - types-openpyxl
-    - lxml-stubs
+    - types-requests==2.33.0.20260518
+    - types-openpyxl==3.1.5.20260518
+    - lxml-stubs==0.5.1

--- a/environment.yaml
+++ b/environment.yaml
@@ -6,9 +6,9 @@ channels:
 dependencies:
   # Core dependencies (alphabetical order)
   # Essential packages required for running polaris
-  - deepdiff
+  - deepdiff=9.1.0
   - einops=0.8.2 # used by MapTracker
-  - gitpython
+  - gitpython=3.1.50
   - hydra-core=1.3.2
   - loguru=0.7.3
   - lxml=6.0.0
@@ -18,6 +18,7 @@ dependencies:
   - numpy=2.2.3
   - onnx=1.17.0
   - openpyxl=3.1.5
+  - pillow=11.1.0 # transitive (matplotlib); pinned to keep Image.fromarray typing stable
   - pydantic=2.10.6
   - pyelftools=0.31
   - python=3.13.2

--- a/workloads/BEVFormer/ttsim_models/grid_mask.py
+++ b/workloads/BEVFormer/ttsim_models/grid_mask.py
@@ -171,7 +171,7 @@ class GridMask(SimNN.Module):
         # Apply random rotation
         if self.rotate > 0:
             r = rng.randint(self.rotate)
-            mask_img = Image.fromarray(np.uint8(mask * 255))
+            mask_img = Image.fromarray((mask * 255).astype(np.uint8))
             mask_img = mask_img.rotate(r)
             mask = np.asarray(mask_img).astype(np.float32) / 255.0  # type: ignore[assignment]
 

--- a/workloads/FusionAD/projects/mmdet_plugin/models/utils/grid_mask.py
+++ b/workloads/FusionAD/projects/mmdet_plugin/models/utils/grid_mask.py
@@ -211,7 +211,7 @@ class Grid(object):
                 mask[:, s:t] *= 0
 
         r = np.random.randint(self.rotate)
-        mask_img = Image.fromarray(np.uint8(mask))
+        mask_img = Image.fromarray(mask.astype(np.uint8))
         mask_img = mask_img.rotate(r)
         mask = np.asarray(mask_img).astype(np.float32)
         mask = mask[(hh - h) // 2:(hh - h) // 2 + h, (ww - w) // 2:(ww - w) // 2 + w]
@@ -352,7 +352,7 @@ class GridMask(SimNN.Module):
                 mask[:, s:t] *= 0
 
         r = np.random.randint(self.rotate)
-        mask_img = Image.fromarray(np.uint8(mask))
+        mask_img = Image.fromarray(mask.astype(np.uint8))
         mask_img = mask_img.rotate(r)
         mask = np.asarray(mask_img).astype(np.float32)
         mask = mask[(hh - h) // 2:(hh - h) // 2 + h, (ww - w) // 2:(ww - w) // 2 + w]

--- a/workloads/MapTracker/plugin/models/backbones/bevformer/grid_mask.py
+++ b/workloads/MapTracker/plugin/models/backbones/bevformer/grid_mask.py
@@ -307,7 +307,7 @@ class GridMask(SimNN.Module):
         # Apply random rotation
         if self.rotate > 0:
             r = rng.randint(self.rotate)
-            mask_img = Image.fromarray(np.uint8(mask * 255))
+            mask_img = Image.fromarray((mask * 255).astype(np.uint8))
             mask_img = mask_img.rotate(r)
             mask = np.asarray(mask_img).astype(np.float32) / 255.0
 


### PR DESCRIPTION
Fixes #475.

## Motivation

Unpinned **Pillow** floated to 11.1.0, whose inline stubs type `Image.fromarray`'s arg as `SupportsArrayInterface`. numpy's pinned stubs type `np.uint8(<array>)` as a scalar `unsignedinteger[_8Bit]` (no `__len__`), failing that protocol — reddening mypy across many PRs (#470, #471, …) on unchanged code. `main` only looks green because its last CI run predates the bump; it would go red on its next fresh env solve.

## Changes

Pillow was the trigger, but the real defect is a **class of unpinned deps** that can drift into red CI the same way. This PR fixes both:

1. **grid_mask.py** (BEVFormer / FusionAD / MapTracker): `np.uint8(arr)` → `arr.astype(np.uint8)` at all 4 sites. Runtime-identical, correctly typed as an ndarray, no `type: ignore` suppression.
2. **Pin every previously-unpinned dep** to its current installed version in `environment.yaml` + `envdev.yaml`:
   - core: `pillow=11.1.0`, `deepdiff=9.1.0`, `gitpython=3.1.50`
   - dev: `fabric`, `isort`, `pre-commit`, `pytest-cov`, `pytest-json-report`, `pytest-mock`, `pytest-xdist`, `ruff`
   - pip stubs: `types-requests`, `types-openpyxl`, `lxml-stubs`

   The stub packages and `ruff` are the same drift-into-red-CI hazard as Pillow.

## Verification

- `mypy` clean on all 3 grid_mask files (the 4 reported errors gone).
- pre-commit (SPDX / static checks / unit tests) passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)