### PR TITLE
Arch-aware lm_head column-split transform (config-driven wl2archmap)

### DIFF
--- a/config/wl2archmapping.yaml
+++ b/config/wl2archmapping.yaml
@@ -66,3 +66,12 @@ op_rsrc_spec:
              Unsqueeze, Untilize, UntilizeWithUnpadding, Upsample,
              VoxelPooling,
              Where]
+
+# Arch-aware column split (issue #477): the llama3 lm_head is emitted as ONE canonical
+# GEMM (dim x vocab) in the device-independent front end; the backend expands it into the
+# arch's L1-sized vocab column tiles + Concat (BH: 8 x 16032; WH: 3 x 42752), matching the
+# HW capture. Only the lm_head produces a vocab(128256)-wide matmul, so match on output_x.
+op_split_spec:
+  - op_type: MatMul
+    match_output_x: 128256   # llama3 vocab_size
+    kind: lm_head_vocab

--- a/tests/test_back/test_lm_head_column_split.py
+++ b/tests/test_back/test_lm_head_column_split.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the arch-aware lm_head column-split transform (issue #477).
+
+The front-end lm_head emits ONE canonical GEMM (dim x vocab); the backend
+Device._split_column_ops expands it into the arch's L1-sized vocab column tiles + Concat,
+mirroring tt-metal ModelArgs.get_lm_head_max_columns_per_device + LMHead dram_sharded split
+(models/tt_transformers/tt/{model_config,lm_head}.py):
+  - BH single-chip: vocab // 8      -> 8 x 16032 (vocab=128256)
+  - WH:             668 * cores(dim) -> 3 x 42752 (dim=4096, 8x8 grid)
+"""
+import pytest
+
+import ttsim.front.ttnn as ttnn
+from ttsim.back.device import Device
+from ttsim.config.wl2archmap import WL2ArchColumnSplit
+from ttsim.front.ttnn.device import close_device, open_device, set_default_device
+
+_VOCAB = 128256
+_DIM = 4096
+
+
+def _build_lm_head_graph():
+    """A one-matmul graph mimicking the POLARIS lm_head: x[1,1,32,dim] @ W[dim,vocab] -> [1,1,32,vocab]."""
+    dev = open_device()
+    set_default_device(dev)
+    x = ttnn.zeros([1, 1, 32, _DIM], dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=dev)
+    w = ttnn.zeros([_DIM, _VOCAB], dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=dev)
+    ttnn.linear(x, w, dtype=ttnn.bfloat8_b, compute_kernel_config=ttnn.MathFidelity.HiFi2)
+    return dev, dev.get_graph()
+
+
+class _FakeDev:
+    """Borrows the real Device split methods without constructing a full backend Device."""
+
+    def __init__(self, devname):
+        self.devname = devname
+
+    _is_blackhole = Device._is_blackhole
+    _is_wormhole = Device._is_wormhole
+    _lm_head_core_grid_num_cores = staticmethod(Device._lm_head_core_grid_num_cores)
+    _lm_head_chunk_widths = Device._lm_head_chunk_widths
+    _split_column_ops = Device._split_column_ops
+    _split_one_matmul_columns = Device._split_one_matmul_columns
+
+
+_SPEC = WL2ArchColumnSplit.from_list(
+    [{'op_type': 'MatMul', 'match_output_x': _VOCAB, 'kind': 'lm_head_vocab'}]
+)
+
+
+def _matmuls(g):
+    return [op for op in g._ops.values() if op.optype == 'MatMul']
+
+
+def _concats(g):
+    return [op for op in g._ops.values() if op.optype == 'Concat']
+
+
+def _sts(g):
+    return [op for op in g._ops.values() if op.optype == 'ShardedToInterleaved']
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('devname,n,width', [('Blackhole', 8, 16032), ('Wormhole', 3, 42752)])
+def test_lm_head_column_split(devname, n, width):
+    dev, g = _build_lm_head_graph()
+    try:
+        assert len(_matmuls(g)) == 1, 'precondition: exactly one lm_head matmul'
+        _FakeDev(devname)._split_column_ops(g, _SPEC)
+
+        mms = _matmuls(g)
+        assert len(mms) == n, f'{devname}: expected {n} chunk matmuls, got {len(mms)}'
+        # every chunk weight (input_1) carries the arch tile width, and preserves the
+        # bf8 dtype + TILE layout of the original weight (clone fidelity).
+        for op in mms:
+            w_t = g._tensors[op.inList[1]]
+            assert int(w_t.shape[-1]) == width, f'chunk weight width {w_t.shape[-1]} != {width}'
+            assert w_t.get_layout() == ttnn.TILE_LAYOUT
+            assert w_t._ttnn_dtype == ttnn.bfloat8_b
+            assert op.attrs.get('math_fidelity') == 'HiFi2'  # attr carried to each chunk
+
+        # full HW region: N chunk matmuls -> N ShardedToInterleaved -> Concat
+        sts = _sts(g)
+        assert len(sts) == n, f'expected {n} ShardedToInterleaved, got {len(sts)}'
+        for op in sts:
+            in_t = g._tensors[op.inList[0]]
+            assert int(in_t.shape[-1]) == width, 'STS input is a chunk output'
+            assert in_t._ttnn_dtype == ttnn.bfloat8_b, 'STS input keeps lm_head bf8 dtype'
+
+        concats = _concats(g)
+        assert len(concats) == 1, 'exactly one Concat reunifying the tiles'
+        y_t = g._tensors[concats[0].outList[0]]
+        assert int(y_t.shape[-1]) == _VOCAB, 'concat output restores full vocab'
+        assert len(concats[0].inList) == n, 'concat consumes all N tiles (via STS)'
+        # concat consumes the STS outputs, not the matmul outputs directly
+        sts_out = {op.outList[0] for op in sts}
+        assert set(concats[0].inList) == sts_out, 'concat inputs are the STS outputs'
+
+        # idempotent: after split no op has output_x == vocab, so a re-run is a no-op.
+        _FakeDev(devname)._split_column_ops(g, _SPEC)
+        assert len(_matmuls(g)) == n
+        assert len(_concats(g)) == 1
+    finally:
+        close_device(dev)
+
+
+@pytest.mark.unit
+def test_empty_split_spec_is_noop():
+    dev, g = _build_lm_head_graph()
+    try:
+        _FakeDev('Blackhole')._split_column_ops(g, WL2ArchColumnSplit.from_list(None))
+        assert len(_matmuls(g)) == 1
+        assert len(_concats(g)) == 0
+    finally:
+        close_device(dev)
+
+
+@pytest.mark.unit
+def test_clone_preserves_layout_memory_dtype():
+    """Regression for the shim Tensor.clone() fidelity fix (layout/memory/dtype preserved)."""
+    dev = open_device()
+    set_default_device(dev)
+    try:
+        w = ttnn.zeros([_DIM, _VOCAB], dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=dev)
+        c = w.clone()
+        assert c.get_layout() == w.get_layout() == ttnn.TILE_LAYOUT
+        assert c._ttnn_dtype == w._ttnn_dtype == ttnn.bfloat8_b
+        assert c._memory_config == w._memory_config
+        assert list(c.shape) == list(w.shape)
+    finally:
+        close_device(dev)

--- a/ttsim/back/device.py
+++ b/ttsim/back/device.py
@@ -176,6 +176,12 @@ class Device:
         return
 
     def execute_graph(self, wlgraph, wlmapspec, *, disable_fusion: bool = False):
+        # 0) ARCH-AWARE COLUMN SPLIT: expand a matched matmul (e.g. lm_head) into arch-
+        # appropriate column tiles + concat.  Runs BEFORE get_ordered_nodes so precision /
+        # resources / execute_op (LUT lookup) all see the expanded graph.  Keeps the front-end
+        # graph device-independent (the arch is only known here at the backend).  See #477.
+        self._split_column_ops(wlgraph, getattr(wlmapspec, 'split_spec', None))
+
         graph_ordered_nodes = wlgraph.get_ordered_nodes()
 
         # 1) SET PRECISION FOR ALL OPS
@@ -309,6 +315,195 @@ class Device:
     def _profiler_pct_to_exec_fraction(v: float) -> float:
         """Convert validated LUT utilization from percentage (0–100) to exec_stats fraction (0–1)."""
         return float(v) / 100.0
+
+    def _is_blackhole(self) -> bool:
+        """True when this device is a Blackhole package (arch package name 'Blackhole').
+
+        Mirrors tt-metal is_blackhole(); used to pick arch-specific realizations at the
+        backend (the front-end graph is device-independent)."""
+        return str(getattr(self, 'devname', '') or '').lower() == 'blackhole'
+
+    def _is_wormhole(self) -> bool:
+        """True when this device is a Wormhole package. Mirrors _is_blackhole() (devname is
+        the arch package name, e.g. 'Wormhole'/'Blackhole'/'Grendel')."""
+        return str(getattr(self, 'devname', '') or '').lower() == 'wormhole'
+
+    @staticmethod
+    def _lm_head_core_grid_num_cores(dim: int) -> int:
+        """Number of cores in tt-metal's lm_head core grid for a given model dim.
+
+        Replicates tt-metal models/tt_transformers/tt/model_config.py (~lines 699-715):
+        start lm_head_num_rows=8, cores_per_row=8; shrink until dim % (TILE*rows*cols)==0.
+        For dim=4096 -> 8x8 = 64 cores (=> WH max_columns 668*64 = 42752)."""
+        tile, rows, cols = 32, 8, 8
+        while dim % (tile * rows * cols) != 0:
+            rows -= 1
+            if rows == 0:
+                cols -= 1
+                if cols == 0:
+                    raise ValueError(f"lm_head core grid: no rows/cols with dim({dim}) % (32*rows*cols)==0")
+                rows = 8
+        return rows * cols
+
+    def _lm_head_chunk_widths(self, vocab: int, dim: int) -> list:
+        """Arch-specific lm_head vocab column-tile widths (single-chip, prefetcher off).
+
+        Mirrors tt-metal ModelArgs.get_lm_head_max_columns_per_device + LMHead dram_sharded
+        split (models/tt_transformers/tt/{model_config,lm_head}.py):
+          - BH single-chip: max_columns = size_per_device // 8 -> 8 x 16032 for vocab=128256
+          - WH:             max_columns = 668 * num_cores       -> 3 x 42752 for dim=4096
+        size_per_device = padded_vocab (num_devices=1). BH max_columns is derived from the
+        PADDED size (not the raw vocab) and rounded up to a tile, so a non-tile-aligned vocab
+        still yields <=8 tile-aligned chunks; the 128256 llama3 vocab is already tile-aligned,
+        so this is 8 x 16032 either way. The vocab column-split is a WH/BH L1-sizing
+        optimization with no analogue on other packages, so a non-WH/BH device returns a single
+        full-width chunk (no split) rather than borrowing the Wormhole formula."""
+        tile = 32
+        size_per_device = math.ceil(vocab / tile) * tile
+        if self._is_blackhole():
+            # tt-metal NUM_LM_HEAD_COLUMNS=8 (num_devices not 4/8 branch); split the PADDED
+            # size into 8 tile-aligned columns.
+            max_cols = math.ceil(size_per_device / 8 / tile) * tile
+        elif self._is_wormhole():
+            max_cols = 668 * self._lm_head_core_grid_num_cores(dim)
+        else:
+            # Non-WH/BH package (e.g. Grendel): no arch-specific column-tiling — skip the split
+            # (single full-width chunk) instead of applying the Wormhole formula to an arch it
+            # wasn't derived for. _split_one_matmul_columns treats len==1 as "leave the op as-is".
+            return [size_per_device]
+        n = math.ceil(size_per_device / max_cols)
+        widths = [min(size_per_device, max_cols)] * (n - 1)
+        widths.append(size_per_device - sum(widths))
+        return widths
+
+    def _split_column_ops(self, wlgraph: Any, split_spec: Any) -> None:
+        """Expand matched matmuls into arch-appropriate column tiles + Concat (config-driven,
+        wl2archmap op_split_spec). The arch is this device's. For each rule, finds MatMuls
+        whose output-0 last-dim == match_output_x (optionally input-0 last-dim ==
+        match_input_x), computes per-arch tile widths, and rewrites the op into N chunk
+        matmuls (each cloning the weight/output tensor at the tile width) whose outputs
+        Concat back into the original output tensor. Idempotent: after the split no MatMul
+        still matches the rule — the inserted Concat re-emits the full vocab-width output,
+        but it is not a MatMul, so a re-run finds no targets. See #477."""
+        if split_spec is None or getattr(split_spec, 'is_empty', lambda: True)():
+            return
+        total_split = 0
+        for rule in split_spec.rules:
+            targets = []
+            for opname in list(wlgraph._ops.keys()):  # snapshot; we mutate _ops in the loop
+                op = wlgraph._ops[opname]
+                if getattr(op, 'removed_in_optimization', False):
+                    continue
+                # Exactly 2 inputs (x, w) and 1 output (y): _split_one_matmul_columns rewrites
+                # inList[0]/inList[1] -> outList[0], so a matmul/linear with a bias (3rd input)
+                # or extra outputs would have those silently dropped — skip it rather than mangle.
+                if str(op.optype).upper() != str(rule.op_type).upper() \
+                        or len(op.inList) != 2 or len(op.outList) != 1:
+                    continue
+                out_t = wlgraph._tensors.get(op.outList[0])
+                in0_t = wlgraph._tensors.get(op.inList[0])
+                if out_t is None or in0_t is None or out_t.shape is None:
+                    continue
+                if int(out_t.shape[-1]) != int(rule.match_output_x):
+                    continue
+                if rule.match_input_x is not None and (
+                    in0_t.shape is None or int(in0_t.shape[-1]) != int(rule.match_input_x)):
+                    continue
+                targets.append(opname)
+            for opname in targets:
+                if self._split_one_matmul_columns(wlgraph, opname, rule):
+                    total_split += 1
+        if total_split:
+            wlgraph.rebuild_graph()
+            logger.debug("Column-split {} matmul(s) into arch tiles ({})", total_split,
+                         'blackhole' if self._is_blackhole() else 'wormhole')
+
+    def _split_one_matmul_columns(self, wlgraph: Any, opname: str, rule: Any) -> bool:
+        from ttsim.front.ttnn.buffer import BufferType, TensorMemoryLayout
+        from ttsim.front.ttnn.memory import MemoryConfig
+        from ttsim.ops import SimOp
+        op = wlgraph._ops[opname]
+        x_name, w_name = op.inList[0], op.inList[1]
+        y_name = op.outList[0]
+        x = wlgraph._tensors[x_name]
+        w = wlgraph._tensors[w_name]
+        y = wlgraph._tensors[y_name]
+        if w.shape is None or len(w.shape) < 2:
+            return False
+        dim, vocab = int(w.shape[0]), int(w.shape[-1])
+        if rule.kind == 'lm_head_vocab':
+            widths = self._lm_head_chunk_widths(vocab, dim)
+        else:
+            raise ValueError(f"unknown column-split kind: {rule.kind}")
+        if len(widths) <= 1:
+            return False  # single tile — leave the op as-is
+        if opname in x.op_in:
+            x.op_in.remove(opname)
+        # Scrub the split op from the weight's consumer list too — otherwise w.op_in keeps
+        # the (soon-deleted) opname, leaving a dangling reference and defeating the
+        # `not w.op_in` cleanup below (the original weight tensor would never be freed).
+        if opname in w.op_in:
+            w.op_in.remove(opname)
+        chunk_out_names = []
+        for i, wi in enumerate(widths):
+            m_i_name = f"{opname}.split{i}"
+            w_i = w.clone()
+            w_i.rename(f"{w_name}.split{i}")
+            w_i.set_shape([dim, int(wi)])
+            w_i.op_in = [m_i_name]
+            w_i.op_out = []
+            wlgraph._tensors[w_i.name] = w_i
+            y_i = y.clone()
+            y_i.rename(f"{y_name}.split{i}")
+            y_i.set_shape(list(y.shape)[:-1] + [int(wi)])
+            y_i.op_in = []
+            y_i.op_out = [m_i_name]
+            wlgraph._tensors[y_i.name] = y_i
+            m_i = SimOp({'name': m_i_name, 'optype': op.optype,
+                         'inList': [x_name, w_i.name], 'outList': [y_i.name],
+                         'attrs': dict(op.attrs)})
+            x.op_in.append(m_i_name)
+            m_i.get_perf_counts([x, w_i], [y_i])
+            m_i.update_tensor_counts([x, w_i], [y_i])
+            wlgraph.add_op(m_i)
+            # HW: each chunk matmul output is L1 width-sharded and a ShardedToInterleaved
+            # stages it to L1 interleaved before the Concat (capture STS: in0
+            # TILE/BFLOAT8_B/L1_WIDTH_SHARDED -> out L1_INTERLEAVED). Restore the lm_head
+            # output dtype (matmul shape-inf may reset it) so the STS key carries bf8.
+            y_i._ttnn_dtype = y._ttnn_dtype
+            y_i.dtype = y.dtype
+            y_i._memory_config = MemoryConfig(TensorMemoryLayout.WIDTH_SHARDED, BufferType.L1)
+            sts_name = f"{m_i_name}.sti"
+            y_i.op_in = [sts_name]
+            y_sti = y_i.clone()
+            y_sti.rename(f"{y_name}.split{i}.sti")
+            y_sti._memory_config = MemoryConfig(TensorMemoryLayout.INTERLEAVED, BufferType.L1)
+            y_sti.op_in = []
+            y_sti.op_out = [sts_name]
+            wlgraph._tensors[y_sti.name] = y_sti
+            sts = SimOp({'name': sts_name, 'optype': 'ShardedToInterleaved',
+                         'inList': [y_i.name], 'outList': [y_sti.name], 'attrs': {}})
+            sts.get_perf_counts([y_i], [y_sti])
+            sts.update_tensor_counts([y_i], [y_sti])
+            wlgraph.add_op(sts)
+            chunk_out_names.append(y_sti.name)
+        concat_name = f"{opname}.concat"
+        concat_inputs = []
+        for cn in chunk_out_names:
+            ct = wlgraph._tensors[cn]
+            ct.op_in.append(concat_name)
+            concat_inputs.append(ct)
+        y.op_out = [concat_name]
+        concat = SimOp({'name': concat_name, 'optype': 'Concat',
+                        'inList': list(chunk_out_names), 'outList': [y_name],
+                        'attrs': {'axis': -1}})
+        concat.get_perf_counts(concat_inputs, [y])
+        concat.update_tensor_counts(concat_inputs, [y])
+        wlgraph.add_op(concat)
+        del wlgraph._ops[opname]
+        if w_name in wlgraph._tensors and not w.op_in:
+            del wlgraph._tensors[w_name]
+        return True
 
     def _annotate_conv_x_pad_logical(self, wlgraph: Any) -> None:
         """Tag conv2d/conv_transpose2d input tensors (+ upstream passthrough chain) with HW-padded channels.

--- a/ttsim/config/wl2archmap.py
+++ b/ttsim/config/wl2archmap.py
@@ -144,6 +144,40 @@ class WL2ArchLayer2ComputePipe(BaseModel):
         return WL2ArchLayer2ComputePipe(wl_map=op2rsrc)
 
 
+class WL2ArchColumnSplitRule(BaseModel):
+    """One column-split rule: match a MatMul and expand it into arch-appropriate column
+    tiles at the backend (see ttsim.back.device.Device._split_column_ops), where the arch
+    is known. Keeps the front-end graph device-independent.
+
+    ``kind`` selects the tiling formula. ``lm_head_vocab`` mirrors tt-metal
+    ``ModelArgs.get_lm_head_max_columns_per_device`` + the LMHead dram_sharded column split
+    (single-chip: BH vocab//8 -> 8 tiles; WH 668*lm_head_core_grid_cores(dim) -> 3 tiles for
+    dim=4096). The op is identified by output-0 last-dim == ``match_output_x`` (the vocab;
+    only the lm_head produces a vocab-wide matmul), optionally narrowed by input-0 last-dim
+    == ``match_input_x`` (the model dim)."""
+    op_type: str = Field(..., description="SimOp optype to match (e.g. MatMul)")
+    match_output_x: int = Field(..., description="Match ops whose output-0 last-dim equals this (vocab)")
+    match_input_x: Optional[int] = Field(default=None, description="Optional: also require input-0 last-dim == this (model dim)")
+    kind: str = Field(default="lm_head_vocab", description="Column-split formula selector")
+
+
+class WL2ArchColumnSplit(BaseModel):
+    """Column-split specifications: a list of rules (empty when op_split_spec is absent)."""
+    rules: List[WL2ArchColumnSplitRule] = Field(default_factory=list, description="Column-split rules")
+
+    @staticmethod
+    def from_list(spec: Optional[List[Dict[str, Any]]]) -> 'WL2ArchColumnSplit':
+        if not spec:
+            return WL2ArchColumnSplit(rules=[])
+        return WL2ArchColumnSplit(rules=[WL2ArchColumnSplitRule(**r) for r in spec])
+
+    def is_empty(self) -> bool:
+        return not self.rules
+
+    def __str__(self):
+        return f"Column Splits: {self.rules}"
+
+
 class WL2ArchMap(BaseModel):
     """
     Represents the workload to architecture mapping.
@@ -152,6 +186,8 @@ class WL2ArchMap(BaseModel):
     removal_spec: WL2ArchRemovalLayers = Field(..., description="Null layers specifications")
     fusion_spec: WL2ArchFusedLayers = Field(..., description="Fused layers specifications")
     rsrc_spec: WL2ArchLayer2ComputePipe = Field(..., description="Resource specifications for operations")
+    split_spec: WL2ArchColumnSplit = Field(default_factory=WL2ArchColumnSplit,
+                                           description="Column-split specifications (optional)")
 
     def layer_2_datatype(self, layer_name: LayerName) -> TypeName:
         """
@@ -165,7 +201,8 @@ class WL2ArchMap(BaseModel):
                 f"Data Types: {self.data_type_spec}\n"
                 f"Null Layers: {self.removal_spec}\n"
                 f"Fused Layers: {self.fusion_spec}\n"
-                f"Resource Specs: {self.rsrc_spec}")
+                f"Resource Specs: {self.rsrc_spec}\n"
+                f"Column Splits: {self.split_spec}")
 
     @staticmethod
     def from_yaml(cfg_yaml_file: str) -> 'WL2ArchMap':
@@ -181,12 +218,15 @@ class WL2ArchMap(BaseModel):
         removal_spec = WL2ArchRemovalLayers.from_list(cfg_dict['op_removal_spec'])
         fusion_spec = WL2ArchFusedLayers.from_list(cfg_dict['op_fusion_spec'])
         rsrc_spec = WL2ArchLayer2ComputePipe.from_dict(cfg_dict['op_rsrc_spec'])
+        # op_split_spec is optional (backward-compatible with existing mapping files).
+        split_spec = WL2ArchColumnSplit.from_list(cfg_dict.get('op_split_spec'))
 
         return WL2ArchMap(
             data_type_spec=data_type_spec,
             removal_spec=removal_spec,
             fusion_spec=fusion_spec,
-            rsrc_spec=rsrc_spec
+            rsrc_spec=rsrc_spec,
+            split_spec=split_spec
         )
 
 

--- a/ttsim/front/ttnn/tensor.py
+++ b/ttsim/front/ttnn/tensor.py
@@ -495,13 +495,36 @@ class Tensor(SimTensor):
         )
 
     def clone(self, clone_num=0):
-        """Create a clone of the tensor with the same shape, dtype, and device."""
-        cloned_tensor = Tensor(
+        """Faithful metadata clone: same shape, dtype, layout, memory_config, and device.
+        Metadata only — SimTensors carry no data, so this is not a torch-style data copy.
+
+        Real ttnn clone preserves the tensor's layout and memory_config — so the previous
+        copy (shape+dtype+device only) was an unfaithful mimic that silently dropped
+        ``layout`` and ``_memory_config``. Both are LUT-key fields, so a lossy clone would
+        make any op built from the copy miss the LUT. Preserve the true ttnn dtype via
+        ``_ttnn_dtype`` (bfloat8_b/bfloat4_b are indistinguishable once mapped to numpy
+        float32). No active caller depended on the lossy behavior."""
+        dtype = self._ttnn_dtype if self._ttnn_dtype is not None else DataType.from_numpy(self.dtype.name)
+        return Tensor(
             shape=self.shape,
-            dtype=DataType.from_numpy(self.dtype.name),
+            dtype=dtype,
+            layout=self.layout,
+            memory_config=self._memory_config,
             device=self.device,
         )
-        return cloned_tensor
+
+    def rename(self, new_name):
+        """Rename this tensor, keeping the front-end device registry consistent.
+
+        ``Tensor.__init__`` registered this tensor in ``device.tensors`` under its original
+        (often auto-generated) name; a bare ``self.name = x`` would leave a stale
+        ``old_name -> tensor`` entry and never register the new name. Used by backend graph
+        surgery (e.g. the lm_head column-split) that clones tensors and then renames them."""
+        if self.device is not None:
+            self.device.tensors.pop(self.name, None)
+        self.name = new_name
+        if self.device is not None:
+            self.device.add_tensor(self)
 
     def new_zeros(self, shape):
         return Tensor(

--- a/ttsim/graph/wl_graph.py
+++ b/ttsim/graph/wl_graph.py
@@ -142,6 +142,38 @@ class WorkloadGraph():
 
         return
 
+    def rebuild_graph(self):
+        """Rebuild the NetworkX graph + summary structures from the current _ops/_tensors.
+
+        Use after in-place op-graph surgery that adds/removes SimOps (e.g. the backend
+        arch-aware column-split transform), so get_ordered_nodes()/get_successors() and the
+        input/output node/tensor sets reflect the mutated graph. Ops flagged
+        removed_in_optimization and dangling consumer references are skipped. Idempotent.
+        """
+        self._graph = nx.MultiDiGraph()
+        self._optype_hist = defaultdict(int)
+        for op_name, op_info in self._ops.items():
+            if getattr(op_info, 'removed_in_optimization', False):
+                continue
+            self._graph.add_node(op_name)
+            self._optype_hist[op_info.optype] += 1
+            for o in op_info.outList:
+                if o not in self._tensors:
+                    continue
+                for inode in self._tensors[o].op_in:
+                    if inode in self._ops and not getattr(self._ops[inode], 'removed_in_optimization', False):
+                        self._graph.add_edge(op_name, inode, name=o)
+        self._input_tensors  = list(set([tname for tname, tval in self._tensors.items() if tval.op_out == []]))
+        self._output_tensors = list(set([tname for tname, tval in self._tensors.items() if tval.op_in == []]))
+        # Filter dangling consumer/producer references (ops removed or flagged
+        # removed_in_optimization) so the node sets honour this method's contract and never
+        # surface op names absent from _ops after in-place graph surgery.
+        def _op_live(name: str) -> bool:
+            return name in self._ops and not getattr(self._ops[name], 'removed_in_optimization', False)
+        self._input_nodes    = list(set([o for t in self._input_tensors for o in self._tensors[t].op_in if _op_live(o)]))
+        self._output_nodes   = list(set([o for t in self._output_tensors for o in self._tensors[t].op_out if _op_live(o)]))
+        return
+
     def __str__(self):
         indent = 4
         ostr = ""

--- a/workloads/ttnn/tt_transformers_dualmode/lm_head.py
+++ b/workloads/ttnn/tt_transformers_dualmode/lm_head.py
@@ -51,25 +51,45 @@ class LMHead:
         self.mesh_device = mesh_device
         self.dtype = dtype
         self.vocab_size = args.vocab_size
-        # Column-split the vocab into chunks (the max_columns_per_device split): the capture
-        # splits 128256 -> 3 x 42752 as 3 DRAM-sharded matmuls + 3 ShardedToInterleaved + Concat
-        # (rows 53-59). Per-chunk dummy output weights (dim, vocab/num_splits).
-        self.num_splits = 3 if args.vocab_size % 3 == 0 else 1
-        split_size = args.vocab_size // self.num_splits
-        self.output_weights = [
-            _dummy_weight((args.dim, split_size), mesh_device, args.WEIGHTS_DTYPE)
-            for _ in range(self.num_splits)
-        ]
+        # Column-split the vocab into chunks (the max_columns_per_device split).
+        # The HW column-tiles the vocab (L1 sizing): num_splits and chunk width are
+        # arch-dependent (tt-metal get_lm_head_max_columns_per_device: BH single-chip
+        # 128256//8=16032 -> 8 chunks; WH 668*num_cores=42752 -> 3 chunks), each a
+        # DRAM-sharded matmul + ShardedToInterleaved, then Concat back to full vocab.
+        #
+        # DUAL-MODE split of responsibility:
+        #  - POLARIS path: emit ONE canonical GEMM (dim x vocab). The arch-specific
+        #    column split is realized in the backend (wl2archmap op_split_spec, issue
+        #    #477) where the arch is known, keeping this front-end graph device-independent.
+        #  - HW path: must do the real column split here — a single dim x vocab GEMM would
+        #    L1-OOM on silicon. (num_splits=3 is WH-correct; BH-HW needs the formula-based
+        #    split — tracked follow-up for the HW-validation runs, not exercised here.)
+        if IS_POLARIS:
+            self.output_weight = _dummy_weight((args.dim, args.vocab_size), mesh_device, args.WEIGHTS_DTYPE)
+        else:
+            self.num_splits = 3 if args.vocab_size % 3 == 0 else 1
+            split_size = args.vocab_size // self.num_splits
+            self.output_weights = [
+                _dummy_weight((args.dim, split_size), mesh_device, args.WEIGHTS_DTYPE)
+                for _ in range(self.num_splits)
+            ]
 
     def forward(self, x):
+        # lm_head matmul explicitly downcasts its output to bfp8 (tt-metal lm_head.py:
+        # dtype=lm_head_dtype, default bfloat8_b) so the downstream ShardedToInterleaved
+        # sees a bf8 activation in the capture — pass it rather than inheriting bf16.
+        lm_head_dtype = getattr(self.args, 'lm_head_dtype', ttnn.bfloat8_b)
+        if IS_POLARIS:
+            # Single logical GEMM (dim x vocab); the backend column-split transform
+            # expands it to N matmuls + N ShardedToInterleaved + Concat per arch.
+            output = ttnn.linear(x, self.output_weight,
+                                 compute_kernel_config=self.args.compute_kernel_config_hifi2,
+                                 program_config=None, memory_config=None, dtype=lm_head_dtype)
+            return tt_all_reduce(output)  # identity (single-chip)
         outputs = []
         for w in self.output_weights:
-            # lm_head matmul explicitly downcasts its output to bfp8 (tt-metal lm_head.py:
-            # dtype=lm_head_dtype, default bfloat8_b), so the following ShardedToInterleaved
-            # sees a bf8 activation in the capture — pass it rather than inheriting bf16.
             o = ttnn.linear(x, w, compute_kernel_config=self.args.compute_kernel_config_hifi2,
-                            program_config=None, memory_config=None,
-                            dtype=getattr(self.args, 'lm_head_dtype', ttnn.bfloat8_b))
+                            program_config=None, memory_config=None, dtype=lm_head_dtype)
             o = ttnn.sharded_to_interleaved(o, memory_config=None)  # capture STS rows 54/56/58
             outputs.append(o)
         # combine the column chunks back to full vocab (capture Concat row 59)


### PR DESCRIPTION
## What
The llama3 lm_head output projection is one logical GEMM (`dim × vocab`) that hardware column-tiles for L1 sizing into an **arch-dependent** number of DRAM-sharded matmuls + reshards + concat (BH single-chip: `128256//8` → 8 × 16032; WH: `668×cores(dim)` → 3 × 42752). The workload previously hardcoded `num_splits=3` (WH-only, capture-fit) in the **device-independent front end**, so BH emitted 3×42752 and missed the LUT on its lm_head matmuls — the largest BH unmatched chunk.

Realize the arch-specific split at the **backend** (where arch is known), keeping the front-end graph device-independent:

- **lm_head.py (Polaris path):** emit ONE canonical GEMM; the backend expands it. The HW path keeps the real split (a single GEMM would L1-OOM on silicon).
- **wl2archmap:** new optional `op_split_spec` (config declares intent; arch-agnostic, backward-compatible).
- **`Device._split_column_ops`** (execute_graph step 0, before the LUT-lookup loop): computes per-arch tile widths via the tt-metal formula (`get_lm_head_max_columns_per_device` + LMHead dram_sharded split) and rewrites the matmul into **N chunk-matmuls + N ShardedToInterleaved + Concat**. Idempotent.
- `WorkloadGraph.rebuild_graph()` primitive; shim `Tensor.clone()` now preserves layout/memory/dtype (real ttnn / torch semantics — the prior lossy copy dropped LUT-key fields; no active caller depended on it).

## Verified
BH decode MatMul 5/8 → **13/13** (8 lm_head chunks hit 16032) + ShardedToInterleaved 9/9; WH decode MatMul **8/8** preserved (3 chunks hit 42752) — no regression. Unit tests cover both arches + idempotency + clone fidelity + the full region. Full fast unit suite green.

Stacked on `466-llama3-dualmode-port` (#471). Draft pending auto-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)