### PR TITLE
feat(481): enforce dependency pinning in conda env files

### DIFF
--- a/checkin_tests.py
+++ b/checkin_tests.py
@@ -34,6 +34,7 @@ def prepare_commands_static(condaenvprefix: OptionalString) -> list[str]:
     # pyproject.toml. These knobs are NOT replicated here, to avoid inconsistency
     commands = [
         f'{condaenvprefix} mypy ./',
+        f'{condaenvprefix} python tools/check_pinned_deps.py',
     ]
     return commands
 

--- a/tests/test_tools/test_check_pinned_deps.py
+++ b/tests/test_tools/test_check_pinned_deps.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from tools.check_pinned_deps import _is_pinned, find_unpinned
+
+
+@pytest.mark.parametrize("spec,expected", [
+    # exact conda pins
+    ("numpy=2.2.3", True),
+    ("python=3.13.2", True),
+    ("numpy=2.2.3=py313_0", True),        # exact pin with build string
+    # exact pip pins
+    ("pytest==8.3.4", True),
+    ("types-requests==2.33.0.20260518", True),
+    ("pkg==1!2.0", True),                 # PEP 440 epoch: '!' is not the '!=' range op
+    # URL / VCS / PEP 508 direct references carry no exact version specifier and
+    # are not expected in the env files -> flagged as unpinned for human review
+    ("mypkg @ https://example.com/mypkg-1.0.whl", False),
+    ("git+ssh://git@github.com/org/repo.git", False),
+    # exact pip pin carrying an environment marker: the marker's '<' constrains
+    # the environment, not the package version, so this stays pinned
+    ('pkg==1.2.3; python_version<"3.12"', True),
+    # unpinned — no version at all
+    ("gitpython", False),
+    ("ruff", False),
+    # range / inequality operators still allow drift -> not an exact pin
+    ("ruff>=0.15", False),
+    ("numpy<3", False),
+    ("pkg!=1.0", False),
+    ("pkg~=1.2", False),
+    # wildcard conda pin still allows patch drift -> not an exact pin
+    ("pkg=1.2.*", False),
+    # malformed pins with no version part (typos) -> not pinned
+    ("pkg=", False),
+    ("pkg==", False),
+])
+def test_is_pinned_accepts_only_exact_pins(spec, expected):
+    assert _is_pinned(spec) is expected
+
+
+def _write(tmp_path, text):
+    p = tmp_path / "env.yaml"
+    p.write_text(text, encoding="utf-8")
+    return str(p)
+
+
+def test_find_unpinned_flags_conda_and_pip_entries(tmp_path):
+    env = _write(tmp_path, """
+name: sample
+channels:
+  - conda-forge
+dependencies:
+  - numpy=2.2.3
+  - gitpython
+  - ruff>=0.15
+  - pip:
+    - pytest==8.3.4
+    - types-requests
+""")
+    # channels are ignored; unpinned conda ('gitpython'), a range spec ('ruff>=0.15'),
+    # and unpinned pip ('types-requests') are all flagged.
+    assert find_unpinned(env) == ["gitpython", "ruff>=0.15", "pip: types-requests"]
+
+
+def test_find_unpinned_empty_on_fully_pinned(tmp_path):
+    env = _write(tmp_path, """
+dependencies:
+  - numpy=2.2.3
+  - pip:
+    - pytest==8.3.4
+""")
+    assert find_unpinned(env) == []
+
+
+def test_find_unpinned_handles_empty_yaml(tmp_path):
+    # yaml.safe_load returns None for an empty document; must not raise.
+    env = _write(tmp_path, "")
+    assert find_unpinned(env) == []
+
+
+def test_find_unpinned_handles_empty_pip_block(tmp_path):
+    # '- pip:' with no items yields {'pip': None}; must not raise a TypeError.
+    env = _write(tmp_path, """
+dependencies:
+  - numpy=2.2.3
+  - pip:
+""")
+    assert find_unpinned(env) == []

--- a/tools/check_pinned_deps.py
+++ b/tools/check_pinned_deps.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+"""
+Guard against unpinned dependencies in the conda environment definition files.
+
+An unpinned dependency (one with no version specifier) lets a fresh `conda env
+create` solve to whatever is newest at the time. That silently drifts the
+toolchain and can redden CI on unchanged code — e.g. a newer Pillow tightening
+`Image.fromarray`'s inline type stubs, or a newer type-stub / ruff release
+introducing rules the code has never seen. See issue #475.
+
+This checker parses each environment YAML's `dependencies:` list (both conda
+entries and the nested `pip:` block) and fails if any entry lacks a version
+pin. Channels, comments, and the `pip:` key itself are ignored.
+"""
+# SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import sys
+
+import yaml
+from loguru import logger
+
+# A dependency counts as pinned only with an EXACT version specifier: conda
+# 'name=ver' (optionally a '=build' suffix) or pip 'name==ver'. Range/inequality
+# operators (>=, <=, >, <, !=, ~=) still let the toolchain drift, so they do NOT
+# count — defeating them is the whole point of the guard (issue #475).
+#
+# Note: the env files are not expected to use '@' / URL / VCS (PEP 508 direct)
+# references — they carry no exact version specifier, so they are deliberately
+# flagged as unpinned; if one is ever added it surfaces for explicit human
+# review rather than being silently accepted.
+# Matched as whole operators (not bare characters) so a PEP 440 epoch pin like
+# 'pkg==1!2.0' is not mistaken for the '!=' range operator.
+_RANGE_OPERATORS = ('>=', '<=', '!=', '~=', '<', '>')
+
+DEFAULT_ENV_FILES = ['environment.yaml', 'envdev.yaml']
+
+
+def _is_pinned(spec: str) -> bool:
+    """True only for an exact pin (conda '=', pip '=='). Range/inequality
+    specifiers and wildcard pins are treated as unpinned, since they still
+    permit the resolved version to drift."""
+    # Drop any PEP 508 environment marker (everything after ';'): its operators
+    # (e.g. python_version<'3.12') constrain the environment, not the package
+    # version, so they must not be mistaken for a range spec on the package.
+    spec = spec.split(';', 1)[0].strip()
+    if '*' in spec:  # wildcard pin, e.g. 'pkg=1.2.*' — still allows patch drift
+        return False
+    if any(op in spec for op in _RANGE_OPERATORS):
+        return False
+    if '=' not in spec:
+        return False
+    # reject a bare operator with no version part, e.g. 'pkg=' / 'pkg=='
+    return spec.rsplit('=', 1)[1].strip() != ''
+
+
+def find_unpinned(env_file: str) -> list[str]:
+    """Return the list of unpinned dependency specs in one environment YAML."""
+    with open(env_file, encoding='utf-8') as f:
+        doc = yaml.safe_load(f) or {}
+
+    unpinned: list[str] = []
+    for dep in doc.get('dependencies', []):
+        if isinstance(dep, str):
+            # conda dependency, e.g. 'numpy=2.2.3' or (unpinned) 'gitpython'
+            if not _is_pinned(dep):
+                unpinned.append(dep)
+        elif isinstance(dep, dict):
+            # the nested pip block: {'pip': ['pytest==8.3.4', 'types-requests', ...]}
+            # an empty block ('- pip:' with no items) yields {'pip': None} -> treat as []
+            for pip_spec in (dep.get('pip') or []):
+                if isinstance(pip_spec, str) and not _is_pinned(pip_spec):
+                    unpinned.append(f'pip: {pip_spec}')
+    return unpinned
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        'env_files',
+        nargs='*',
+        default=DEFAULT_ENV_FILES,
+        help=f'environment YAML files to check (default: {" ".join(DEFAULT_ENV_FILES)})',
+    )
+    args = parser.parse_args()
+
+    logger.remove()
+    logger.add(sys.stderr, format='<level>{level: <8}</level> | <level>{message}</level>')
+
+    total = 0
+    for env_file in args.env_files:
+        unpinned = find_unpinned(env_file)
+        if unpinned:
+            total += len(unpinned)
+            logger.error(f'{env_file}: {len(unpinned)} unpinned dependency(ies):')
+            for spec in unpinned:
+                logger.error(f'    - {spec}')
+        else:
+            logger.info(f'{env_file}: all dependencies pinned')
+
+    if total:
+        logger.error(
+            f'{total} unpinned dependency(ies) found. Pin each to its current '
+            'installed version (see issue #475) to prevent CI-breaking env drift.'
+        )
+        return 1
+    logger.success('all environment dependencies are pinned')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Fixes #481. Follow-up to #475.

## Motivation

#475 pinned every floating dependency after unpinned **Pillow** drifted to 11.1.0 and reddened mypy across many PRs. That fixed the incident, but nothing *stops the class of drift from recurring* — a future PR can add an unpinned dep and silently reintroduce the same hazard (a newer type-stub / ruff / library release breaking CI on unchanged code).

## Changes

- **`tools/check_pinned_deps.py`** — parses each env YAML's `dependencies:` list (conda entries + the nested `pip:` block) and exits non-zero if any entry lacks a version specifier (`name=ver` / `name==ver`). Channels, comments, and the `pip:` key are ignored.
- **`checkin_tests.py`** — adds the checker to the `static` suite (alongside `mypy ./`), so it runs both in CI and as the pre-commit "static checker" hook — no separate hook needed.

## Verification

- `checkin_tests.py static` → both `mypy ./` and `check_pinned_deps.py` PASS on current `main`.
- Checker returns exit 1 and names offenders on a deliberately-unpinned fixture (conda + pip); exit 0 on the fully-pinned env files.
- pre-commit (SPDX / static / unit) passed on commit.

The matching Copilot / human review-guideline rules land separately (Copilot-instructions bundle + team review doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)