### PR TITLE
Add TitansMAC (Memory-as-Context Transformer) workload

### DIFF
--- a/config/ip_workloads.yaml
+++ b/config/ip_workloads.yaml
@@ -32,6 +32,38 @@ workloads:
       rn50_b1_hd : { img_height: 1024, img_width: 1024 }
       rn50_b1_uhd: { img_height: 2828, img_width: 2828 }
 
+  - api: TTSIM
+    name: TitansMAC
+    basedir: workloads/Titans
+    module : TitansMAC@mac_transformer.py
+    params :
+      vocab_sz                  : 256
+      ff_mult                   : 4
+      segment_len               : 32
+      num_persist_mem_tokens    : 4
+      num_longterm_mem_tokens   : 0
+      mem_depth                 : 2
+      mem_expansion_factor      : 2.0
+      mem_heads                 : 4
+      mem_dim_head              : 64
+      max_chunks_unroll         : 16
+      attention_mode            : segmented
+      bs                        : 1
+    instances:
+      # mem_chunk_size chosen so nW / mem_chunk_size <= 16 (unroll limit);
+      titans_mac_nano  : { nL: 2,  nH: 4,  dE: 128, dim_head: 32, nW: 64,   mem_chunk_size: 8,
+                           neural_memory_layers: [2] }
+      titans_mac_micro : { nL: 4,  nH: 4,  dE: 256, dim_head: 64, nW: 128, mem_chunk_size: 8,
+                          neural_memory_layers: [2, 4] }
+      titans_mac_small : { nL: 8,  nH: 8,  dE: 384, dim_head: 48, nW: 512, mem_chunk_size: 32,
+                          neural_memory_layers: [2, 4, 6, 8] }
+      titans_mac_base  : { nL: 12, nH: 12, dE: 768, dim_head: 64, nW: 1024, mem_chunk_size: 64,
+                          neural_memory_layers: [2, 4, 6, 8, 10, 12] }
+      titans_mac_large : { nL: 24, nH: 16, dE: 1024, dim_head: 64, nW: 2048, mem_chunk_size: 128,
+                           neural_memory_layers: [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24] }
+      titans_mac_xlarge : { nL: 24, nH: 16, dE: 1536, dim_head: 96, nW: 2048, mem_chunk_size: 128,
+                           neural_memory_layers: [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24] }
+
   # generate resnet50.onnx using code in workloads/onnx/examples/:
   - api: ONNX
     name: RESNET50
@@ -331,7 +363,7 @@ workloads:
         stage_res: [56, 28, 14, 7], dims: [80, 224, 384, 1024], blocks: [3, 4, 8, 3],
         stem_out: 48, head_in: 1024, head_widths: [6144, 6400], activation: gelu,
         global_pool: avg, compute_pipe: matrix, model_size: large }
-  
+
   - api: TTSIM
     name: EfficientViT_SEG
     basedir: workloads/EfficientViT
@@ -459,7 +491,7 @@ workloads:
     instances:
       dd_base  : { camera_height: 256, camera_width: 1024, lidar_h: 256, lidar_w: 256 }
       dd_small : { camera_height: 256, camera_width: 256, lidar_h: 256, lidar_w: 256 }
-  
+
   - api: TTSIM
     name: FusionAD
     basedir: workloads/FusionAD/projects/mmdet_plugin/fusionad/detectors
@@ -481,7 +513,7 @@ workloads:
       fusionad_tiny  : { bev_h: 25,  bev_w: 25,  img_height: 256,  img_width: 256  }
       fusionad_small : { bev_h: 50,  bev_w: 50,  img_height: 512,  img_width: 512  }
       # fusionad_base  : { bev_h: 200, bev_w: 200, img_height: 900,  img_width: 1600 }
-  
+
 
   - api: TTSIM
     name: DiffusionDrive_Validation

--- a/tests/test_workloads/test_titans_mac.py
+++ b/tests/test_workloads/test_titans_mac.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""
+Smoke tests for the Titans MAC TTSim port.
+Validates: (1) forward graph builds, (2) param-count math is consistent,
+(3) ONNX export round-trips, (4) NeuralMemory store/retrieve shapes are sane.
+"""
+import os
+import sys
+import pytest
+import ttsim.front.functional.op as F
+from workloads.Titans.mac_transformer import TitansMAC
+from workloads.Titans.neural_memory  import NeuralMemory
+from workloads.Titans.memory_models  import MemoryMLP
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+@pytest.mark.unit
+def test_memory_mlp_shapes():
+    m = MemoryMLP('mm', dim=32, depth=2, expansion_factor=2.0)
+    x = F._from_shape('x', shape=[4, 8, 32])
+    y = m(x)
+    assert y.shape == [4, 8, 32]
+    assert m.analytical_param_count() == 32 * 64 + 64 * 32
+
+@pytest.mark.unit
+def test_neural_memory_forward_graph():
+    nm = NeuralMemory('nm', dim=64, chunk_size=4, dim_head=32, heads=2, depth=2)
+    seq = F._from_shape('seq', shape=[1, 16, 64])
+    out, state = nm(seq)
+    assert out.shape == [1, 16, 64]
+
+@pytest.mark.unit
+def test_neural_memory_chunk_state_propagation():
+    """
+    D1 verification:
+      - seq_len=16, chunk_size=4 -> num_ch=4 chunks
+      - max_chunks_unroll=8, depth=2 -> 16 per-chunk handles per op type total
+    Confirms per-chunk handles are allocated AND the constructor wires them
+    correctly. Everything below the returned-state block is constructor-time
+    state and holds without a forward call.
+
+    Note: no caller in the repo threads state between invocations (MACBlock
+    passes mem_state=None), so cross-call propagation is not exercised here
+    or anywhere else; this pins the shape of the state that store_memories
+    hands back.
+    """
+    nm = NeuralMemory('nm_state', dim=32, chunk_size=4, dim_head=16, heads=2,
+                      depth=2, max_chunks_unroll=8)
+    seq = F._from_shape('seq_state', shape=[1, 16, 32])
+    out, state = nm(seq)
+    assert out.shape == [1, 16, 32], f'bad out shape {out.shape}'
+
+    # returned state: seq_index advances by the full sequence, and the port
+    # asserts N % chunk_size == 0, so there is never a cached remainder
+    assert state.seq_index == 16, f'seq_index: want 16, got {state.seq_index}'
+    assert state.cache_store_segment is None, 'port emits no remainder segment'
+    assert sorted(state.weights) == ['W0', 'W1']
+    assert sorted(state.updates) == ['W0', 'W1']
+    assert len(state.states) == 2, 'states should be (last_update, last_momentum)'
+    assert state.weights['W0'].shape == [2, 16, 32], \
+        f'W0 update: want [B*H, 16, 32], got {state.weights["W0"].shape}'
+
+
+    # Each per-chunk op list = depth * max_chunks_unroll = 2 * 8 = 16 handles
+    expected = 2 * 8
+    assert len(nm.mom_mul)   == expected, f'mom_mul:   want {expected}, got {len(nm.mom_mul)}'
+    assert len(nm.mom_add)   == expected, f'mom_add:   want {expected}, got {len(nm.mom_add)}'
+    assert len(nm.decay_mul) == expected, f'decay_mul: want {expected}, got {len(nm.decay_mul)}'
+    assert len(nm.weight_add)== expected, f'weight_add: want {expected}, got {len(nm.weight_add)}'
+    assert len(nm.weight_sub)== expected, f'weight_sub: want {expected}, got {len(nm.weight_sub)}'
+
+    # Index helper is correct
+    assert nm._mc(0, 0) == 0
+    assert nm._mc(0, 7) == 7
+    assert nm._mc(1, 0) == 8
+    assert nm._mc(1, 7) == 15
+
+    # Variant Splits cover all num_ch values from 1 to max_chunks_unroll
+    assert len(nm._grads_splits) == 2, 'grads_splits should be per-layer (depth=2)'
+    assert len(nm._grads_splits[0]) == 8, 'grads_splits[0] should have max_chunks_unroll variants'
+    assert len(nm._momentum_coef_splits) == 8
+    assert len(nm._decay_factor_splits) == 8
+    assert nm._decay_factor_splits[3].count == 4, 'Split variant for num_ch=4 should have count=4'
+
+
+@pytest.mark.integration
+def test_titans_mac_forward_graph_and_onnx(tmp_path):
+    cfg = dict(
+        nL=2, nH=4, dE=128, dim_head=32, nW=32, vocab_sz=256, bs=1,
+        segment_len=8, num_persist_mem_tokens=4, num_longterm_mem_tokens=4,
+        neural_memory_layers=[2],
+        mem_depth=2, mem_expansion_factor=2.0, mem_heads=2, mem_dim_head=32,
+        mem_chunk_size=4,
+    )
+    m = TitansMAC('titans_mac', cfg)
+    m.create_input_tensors()
+    gg = m.get_forward_graph()
+    onnx_path = os.path.join(str(tmp_path), 'titans_mac.onnx')
+    gg.graph2onnx(onnx_path, do_model_check=False)
+    assert os.path.exists(onnx_path), 'ONNX not written'

--- a/workloads/Titans/mac_transformer.py
+++ b/workloads/Titans/mac_transformer.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""
+TTSim port of titans_pytorch.mac_transformer -- a forward-only cost model.
+
+Classes:
+- FeedForward                 : dim -> ff_mult*dim -> dim MLP
+- SegmentedAttention          : segment-local causal attention + persistent
+                                memory K/V ("full" mode also available)
+- MACBlock                    : attention + optional NeuralMemory + FeedForward
+- MemoryAsContextTransformer  : embeddings, transformer body, output projection
+- TitansMAC                   : Polaris workload entry point
+
+The body is NOT nL physical layers. It is two proxy blocks - one with a
+neural memory (t_mem) and one without (t_nomem) - whose op stats are scaled
+by repeat counts derived from neural_memory_layers. Repeated layers are
+cost-identical, so this is exact for cost projection while keeping the graph
+O(1) in nL: nL=24 builds ~500 ops, not 24 layers' worth. Both cycles and
+analytical_param_count() apply the same repeat counts.
+"""
+import math
+from typing import Any
+
+import numpy as np
+import ttsim.front.functional.op as F
+import ttsim.front.functional.tensor_op as T
+import ttsim.front.functional.sim_nn as SimNN
+from ttsim.ops.tensor import SimTensor
+
+from workloads.Titans.neural_memory import NeuralMemory, _RMSNorm
+
+class FeedForward(SimNN.Module):
+    def __init__(self, name, dim, mult=4):
+        super().__init__()
+        self.name = name
+        dim_inner = int(dim * mult * 2 / 3)
+        self.norm  = _RMSNorm(f'{name}.norm', dim)
+        self.proj_in  = SimNN.Linear(f'{name}.proj_in', dim, dim_inner * 2)
+        self.split    = F.SplitOpHandle(f'{name}.split', count=2, axis=2)
+        self.silu     = F.Sigmoid(f'{name}.silu_sig')   # we use sigmoid * x as silu
+        self.mul_silu = F.Mul(f'{name}.mul_silu')
+        self.mul_gate = F.Mul(f'{name}.mul_gate')
+        self.proj_out = SimNN.Linear(f'{name}.proj_out', dim_inner, dim)
+        self.dim = dim
+        self.dim_inner = dim_inner
+        super().link_op2module()
+
+    def __call__(self, x):
+        x = self.norm(x)
+        h = self.proj_in(x)
+        a, gate = self.split(h)
+        gate_silu = self.mul_silu(gate, self.silu(gate))
+        h = self.mul_gate(a, gate_silu)
+        return self.proj_out(h)
+
+    def analytical_param_count(self, lvl=0):
+        pc  = self.proj_in.analytical_param_count(lvl + 1)
+        pc += self.proj_out.analytical_param_count(lvl + 1)
+        pc += self.norm.analytical_param_count(lvl + 1)
+        return pc
+
+class SegmentedAttention(SimNN.Module):
+    def __init__(self, name, dim, segment_len,
+                 num_persist_mem_tokens=0, num_longterm_mem_tokens=0,
+                 dim_head=64, heads=8, attention_mode="segmented"):   # default mode:segmented
+        super().__init__()
+        self.name = name
+        self.dim  = dim
+        self.dim_head = dim_head
+        self.heads    = heads
+        self.attention_mode = attention_mode
+        assert attention_mode in ("segmented", "full")  #Default "segmented" so nothing changes unless explicitly set to "full".
+        self.dim_inner= dim_head * heads
+        self.segment_len             = segment_len
+        self.num_persist_mem_tokens  = num_persist_mem_tokens
+        self.num_longterm_mem_tokens = num_longterm_mem_tokens
+        self.total_segment_len       = segment_len + num_longterm_mem_tokens
+
+        self.norm   = _RMSNorm(f'{name}.norm', dim)
+        self.to_qkv = SimNN.Linear(f'{name}.to_qkv', dim, self.dim_inner * 3)
+        self.split  = F.SplitOpHandle(f'{name}.qkv_split', count=3, axis=2)
+        self.softmax= F.Softmax(f'{name}.softmax')
+        self.to_out = SimNN.Linear(f'{name}.to_out', self.dim_inner, dim)
+        self.attn_scale = F._from_data(f'{name}.attn_scale',
+                                       data=np.float32(1.0 / math.sqrt(dim_head)))
+        self.qk_mm = F.MatMul(f'{name}.qk_mm')
+        self.av_mm = F.MatMul(f'{name}.av_mm')
+        self.persistent_k: SimTensor | None = None
+        self.persistent_v: SimTensor | None = None
+
+        if num_persist_mem_tokens > 0:
+            self.persistent_k = F._from_shape(f'{name}.persistent_k',
+                                              shape=[1, heads, num_persist_mem_tokens, dim_head],
+                                              is_param=True)
+            self.persistent_v = F._from_shape(f'{name}.persistent_v',
+                                              shape=[1, heads, num_persist_mem_tokens, dim_head],
+                                              is_param=True)
+            self.persistent_k.set_module(self); self._tensors[self.persistent_k.name] = self.persistent_k
+            self.persistent_v.set_module(self); self._tensors[self.persistent_v.name] = self.persistent_v
+            # persistent-attention op handles (broadcast-term softmax, no .repeat)
+            self.qk_mm_persist = F.MatMul(f'{name}.qk_mm_persist')
+            self.av_mm_persist = F.MatMul(f'{name}.av_mm_persist')
+            self.exp_seg   = F.Exp(f'{name}.exp_seg')
+            self.exp_per   = F.Exp(f'{name}.exp_per')
+            self.sum_seg   = F.ReduceSum(f'{name}.sum_seg', axis=-1)
+            self.sum_per   = F.ReduceSum(f'{name}.sum_per', axis=-1)
+            self.add_denom = F.Add(f'{name}.add_denom')
+            self.div_seg   = F.Div(f'{name}.div_seg')
+            self.div_per   = F.Div(f'{name}.div_per')
+            self.add_out   = F.Add(f'{name}.add_out')
+        else:
+            self.persistent_k = None
+            self.persistent_v = None
+        super().link_op2module()
+
+    # ---- fold/unfold: verified numerically exact vs reference (0.0 diff) ----
+    def _to_heads(self, t, B, N, H, Dh):
+        return t.reshape(B, N, H, Dh).transpose(1, 2)              # [B,H,N,Dh]
+
+    def _segment(self, t, B, H, W, S, Dh):
+        # [B,H,N,Dh] -> [B*W,H,S,Dh]   ref: 'b h (w n) d -> (b w) h n d'
+        return t.reshape(B, H, W, S, Dh).transpose(1, 2).reshape(B * W, H, S, Dh)
+
+    def _unsegment(self, t, B, H, W, S, Dh):
+        # [B*W,H,S,Dh] -> [B,H,N,Dh]   (inverse)
+        return t.reshape(B, W, H, S, Dh).transpose(1, 2).reshape(B, H, W * S, Dh)
+
+    def _local_attention(self, Q, K, V):
+        """
+        Segment-local attention. Persistent K/V attended via broadcasting matmuls
+        with a shared softmax denominator no .repeat, so no replicated-parameter
+        write traffic (avoids the memory-bandwidth validator failure that physical
+        per-segment replication triggers on the larger instances).
+        Q, K, V: [B*W, H, S, Dh] returns [B*W, H, S, Dh]
+        """
+        scores_seg = self.qk_mm(Q, K.transpose(-1, -2)) * self.attn_scale   # [BW,H,S,S]
+
+        if self.persistent_k is None:
+            return self.av_mm(self.softmax(scores_seg), V)
+
+        # persistent scores via broadcast: Q[BW,H,S,Dh] x pk^T[1,H,Dh,P] -> [BW,H,S,P]
+        # transpose is patched onto SimTensor at import time
+        # (ttsim/front/functional/tensor_op.py), so mypy cannot see it. The
+        # ignore is required here and not on K/V above because persistent_k is
+        # annotated SimTensor | None, while Q/K/V are unannotated params (Any).
+        pk_t = self.persistent_k.transpose(-1, -2)   # type: ignore[attr-defined] # [1,H,Dh,P]
+        scores_per = self.qk_mm_persist(Q, pk_t) * self.attn_scale          # [BW,H,S,P]
+
+        # joint softmax over (S + P) keys, via shared denominator (no concat/split):
+        e_seg = self.exp_seg(scores_seg)                                    # [BW,H,S,S]
+        e_per = self.exp_per(scores_per)                                    # [BW,H,S,P]
+        denom = self.add_denom(self.sum_seg(e_seg), self.sum_per(e_per))    # [BW,H,S,1]
+        attn_seg = self.div_seg(e_seg, denom)                               # [BW,H,S,S]
+        attn_per = self.div_per(e_per, denom)                               # [BW,H,S,P]
+
+        # value terms: segment normal, persistent broadcast (pv [1,H,P,Dh])
+        out_seg = self.av_mm(attn_seg, V)                                   # [BW,H,S,Dh]
+        out_per = self.av_mm_persist(attn_per, self.persistent_v)           # [BW,H,S,Dh]
+        return self.add_out(out_seg, out_per)                               # [BW,H,S,Dh]
+
+    def _full_attention(self, Q, K, V):
+        """Full O(N^2) attention baseline. Reuses _local_attention on the
+        un-segmented sequence (batch=B, seq=N) -- every token attends every
+        token plus persistent memory (same broadcast-term handling)."""
+        return self._local_attention(Q, K, V)
+
+    def __call__(self, x):
+        B, N, D = x.shape
+        H, Dh   = self.heads, self.dim_head
+        x = self.norm(x)
+        Q, K, V = self.split(self.to_qkv(x))
+        Q = self._to_heads(Q, B, N, H, Dh)
+        K = self._to_heads(K, B, N, H, Dh)
+        V = self._to_heads(V, B, N, H, Dh)
+        if self.attention_mode == "full":
+            out = self._full_attention(Q, K, V)          # [B,H,N,Dh]
+        else:
+            S = self.total_segment_len
+            assert N % S == 0, \
+                f"N={N} must be divisible by total_segment_len={S} " \
+                f"(segment_len={self.segment_len} + num_longterm_mem_tokens={self.num_longterm_mem_tokens})"
+            W = N // S
+            Q = self._segment(Q, B, H, W, S, Dh)
+            K = self._segment(K, B, H, W, S, Dh)
+            V = self._segment(V, B, H, W, S, Dh)
+
+            out = self._local_attention(Q, K, V)           # [B*W,H,S,Dh]
+            out = self._unsegment(out, B, H, W, S, Dh)     # [B,H,N,Dh]
+        out = out.transpose(1, 2).reshape(B, N, H * Dh)
+        return self.to_out(out)
+
+    def analytical_param_count(self, lvl=0):
+        pc  = self.to_qkv.analytical_param_count(lvl + 1)
+        pc += self.to_out.analytical_param_count(lvl + 1)
+        pc += self.norm.analytical_param_count(lvl + 1)
+        if self.persistent_k is not None:
+            pc += 2 * self.heads * self.num_persist_mem_tokens * self.dim_head
+        return pc
+
+class MACBlock(SimNN.Module):
+    def __init__(self, name, dim, segment_len, dim_head, heads, ff_mult,
+                 num_persist_mem_tokens, num_longterm_mem_tokens,
+                 use_neural_memory,
+                 mem_depth, mem_expansion_factor, mem_heads, mem_dim_head,
+                 mem_chunk_size,
+                 max_chunks_unroll = 16,attention_mode = "segmented"):
+        super().__init__()
+        self.name = name
+        self.mem: NeuralMemory | None = None
+        if use_neural_memory:
+            self.mem = NeuralMemory(
+                name       = f'{name}.mem',
+                dim        = dim,
+                chunk_size = mem_chunk_size,
+                dim_head   = mem_dim_head,
+                heads      = mem_heads,
+                depth      = mem_depth,
+                expansion_factor = mem_expansion_factor,
+                max_chunks_unroll = max_chunks_unroll,
+            )
+            self.add_mem = F.Add(f'{name}.add_mem')
+
+        self.attn    = SegmentedAttention(
+            name=f'{name}.attn', dim=dim, segment_len=segment_len,
+            num_persist_mem_tokens=num_persist_mem_tokens,
+            num_longterm_mem_tokens=num_longterm_mem_tokens,
+            dim_head=dim_head, heads=heads,attention_mode=attention_mode)
+        self.add_attn= F.Add(f'{name}.add_attn')
+        self.ff      = FeedForward(f'{name}.ff', dim, mult=ff_mult)
+        self.add_ff  = F.Add(f'{name}.add_ff')
+        super().link_op2module()
+
+    def __call__(self, x, mem_state=None):
+        if self.mem is not None:
+            retrieved, mem_state = self.mem(x, state=mem_state)
+            x = self.add_mem(x, retrieved)
+        x = self.add_attn(x, self.attn(x))
+        x = self.add_ff  (x, self.ff(x))
+        return x, mem_state
+
+    def analytical_param_count(self, lvl=0):
+        pc = 0
+        if self.mem is not None:
+            pc += self.mem.analytical_param_count(lvl + 1)
+        pc += self.attn.analytical_param_count(lvl + 1)
+        pc += self.ff.analytical_param_count(lvl + 1)
+        return pc
+
+class MemoryAsContextTransformer(SimNN.Module):
+    def __init__(self, name, cfg):
+        super().__init__()
+        self.name = name
+        self.cfg  = cfg
+        self.vocab_sz = cfg['vocab_sz']
+        self.dim      = cfg['dE']
+        self.nL       = cfg['nL']
+        self.nH       = cfg['nH']
+        self.dim_head = cfg.get('dim_head', self.dim // self.nH)
+        self.nW       = cfg['nW']                       # seq_len
+        self.bs       = cfg['bs']
+        self.ff_mult  = cfg.get('ff_mult', 4)
+        self.segment_len            = cfg['segment_len']
+        self.num_persist_mem_tokens = cfg.get('num_persist_mem_tokens', 0)
+        self.num_longterm_mem_tokens= cfg.get('num_longterm_mem_tokens', 0)
+        self.neural_memory_layers   = set(cfg.get('neural_memory_layers',
+                                                   list(range(1, self.nL + 1))))
+        self.mem_depth        = cfg.get('mem_depth', 2)
+        self.mem_expansion    = cfg.get('mem_expansion_factor', 2.0)
+        self.mem_heads        = cfg.get('mem_heads', 4)
+        self.mem_dim_head     = cfg.get('mem_dim_head', 64)
+        # mem_chunk_size is upstream's neural_memory_segment_len (the NeuralMemory
+        # chunk size); the default matches upstream's segment_len +
+        # num_longterm_mem_tokens. Bounded here by max_chunks_unroll: the
+        # recurrence is unrolled per chunk, so nW / mem_chunk_size must be
+        # <= max_chunks_unroll
+        self.mem_chunk_size   = cfg.get('mem_chunk_size',
+                                        self.segment_len + self.num_longterm_mem_tokens)
+        self.max_chunks_unroll = cfg.get('max_chunks_unroll', 16)
+        self.attention_mode = cfg.get('attention_mode', 'segmented')
+
+        self.wte = F.Embedding('wte', self.vocab_sz, self.dim)
+        self.wpe = F.Embedding('wpe', self.nW, self.dim)
+        self.add_emb = F.Add('add_emb')
+
+        # longterm memory tokens (learnable)
+        self.longterm_mems: SimTensor | None = None
+        if self.num_longterm_mem_tokens > 0:
+            self.longterm_mems = F._from_shape(
+                'longterm_mems',
+                shape=[1, self.num_longterm_mem_tokens, self.dim], is_param=True)
+
+        mem_layer_set = set(self.neural_memory_layers)
+        all_layers    = set(range(1, self.nL + 1))
+        self._n_mem_layers   = len(mem_layer_set & all_layers)
+        self._n_nomem_layers = self.nL - self._n_mem_layers
+
+        self.blocks = SimNN.ModuleList([
+            MACBlock(
+                name='t_mem',
+                dim=self.dim, segment_len=self.segment_len,
+                dim_head=self.dim_head, heads=self.nH, ff_mult=self.ff_mult,
+                num_persist_mem_tokens=self.num_persist_mem_tokens,
+                num_longterm_mem_tokens=self.num_longterm_mem_tokens,
+                use_neural_memory=True,
+                mem_depth=self.mem_depth,
+                mem_expansion_factor=self.mem_expansion,
+                mem_heads=self.mem_heads,
+                mem_dim_head=self.mem_dim_head,
+                mem_chunk_size=self.mem_chunk_size,
+                max_chunks_unroll=self.max_chunks_unroll,
+                attention_mode=self.attention_mode,
+            ),
+            MACBlock(
+                name='t_nomem',
+                dim=self.dim, segment_len=self.segment_len,
+                dim_head=self.dim_head, heads=self.nH, ff_mult=self.ff_mult,
+                num_persist_mem_tokens=self.num_persist_mem_tokens,
+                num_longterm_mem_tokens=self.num_longterm_mem_tokens,
+                use_neural_memory=False,
+                mem_depth=self.mem_depth,
+                mem_expansion_factor=self.mem_expansion,
+                mem_heads=self.mem_heads,
+                mem_dim_head=self.mem_dim_head,
+                mem_chunk_size=self.mem_chunk_size,
+                max_chunks_unroll=self.max_chunks_unroll,
+                attention_mode=self.attention_mode,
+            ),
+        ])
+        self._block_repeat_counts = [self._n_mem_layers, self._n_nomem_layers]
+
+        self.final_norm = _RMSNorm('final_norm', self.dim)
+        self.to_logits  = SimNN.Linear('to_logits', self.dim, self.vocab_sz, bias=False)
+
+        self.input_tensors = {}
+        super().link_op2module()
+
+    def set_batch_size(self, new_bs):
+        self.bs = new_bs
+
+    def create_input_tensors(self):
+        self.input_tensors = {
+            'tokens': F._from_shape('tokens', [self.bs, self.nW], is_param=False, np_dtype=np.int64),
+            'pos'  : F._from_shape('pos',   [self.bs, self.nW], is_param=False, np_dtype=np.int64),
+        }
+
+    def get_forward_graph(self):
+        return super()._get_forward_graph(self.input_tensors)
+
+    def __call__(self):
+        assert len(self.input_tensors) == 2, "call create_input_tensors() first"
+        tok = self.input_tensors['tokens']
+        pos = self.input_tensors['pos'] # pos = position indices [0 to N-1]:positional-embedding lookup (wpe)
+        x = self.add_emb(self.wte(tok), self.wpe(pos)) # token_emb + pos_emb
+
+        if self.longterm_mems is not None:
+            x = T.cat([self.longterm_mems, x], dim=1)
+
+        # Each proxy block stands in for rc physical layers. rc == 0 means the
+        # config has no layers of that type, and such a block must not be built
+        # into the graph at all - see PROXY-BLOCK COST ACCOUNTING below for why
+        # emitting its ops would make cycles and params disagree.
+        # Skipping is safe for the residual stream: a block maps [B, N, dim] to
+        # [B, N, dim], so x keeps the same shape whether or not it runs.
+        for blk, rc in zip(self.blocks, self._block_repeat_counts):
+            if rc == 0:
+                continue
+            x, _ = blk(x, mem_state=None)
+
+        # PROXY-BLOCK COST ACCOUNTING
+        # The model is built as two proxy blocks (t_mem: memory-bearing, t_nomem:
+        # plain) rather than nL physical layers. Here we set each op's repeat_count
+        # to the number of layers of that block type (_block_repeat_counts), so
+        # Polaris costs a stack of "rc" identical layers as per_layer_cost * rc,
+        # WITHOUT materializing rc copies in the graph.
+        #
+        # This multiplies projected CYCLES to reflect nL layers; it does NOT create
+        # nL physical layers. It is exact for cost projection because repeated
+        # layers are cost-identical. Parameter counting (analytical_param_count)
+        # applies the SAME _block_repeat_counts (per-block param count * rc), so
+        # cycles and params are scaled consistently.
+        # The rc == 0 case is load-bearing for that consistency. repeat_count
+        # defaults to 1 (SimOp.__init__, ttsim/ops/op.py), so an op left
+        # unassigned is billed as one full layer. Params would report the block
+        # as absent while cycles reported it running once. The invariant is
+        # therefore maintained upstream: a block with rc == 0 is never called,
+        # so it contributes no ops here and nothing is left at the default.
+        # Every op reached by this loop belongs to a block with rc >= 1.
+
+        for blk, rc in zip(self.blocks, self._block_repeat_counts):
+            if rc == 0:
+                continue # not in the graph: nothing to scale
+            repeated_ops: dict[str, Any] = {}
+            blk.get_ops(repeated_ops)
+            for _, op_obj in repeated_ops.items():
+                op_obj.repeat_count = rc
+
+        x = self.final_norm(x)
+        return self.to_logits(x)
+
+    def analytical_param_count(self, lvl=0):
+        # Params scaled by _block_repeat_counts (same counts used for cycle
+        # accounting in __call__), so a proxy block counts for all rc layers.
+        pc = 0
+        pc += self.vocab_sz * self.dim
+        pc += self.nW * self.dim
+        if self.longterm_mems is not None:
+            pc += self.num_longterm_mem_tokens * self.dim
+        pc += sum(
+            # ModuleList.__iter__ is typed -> Iterator[Module], and base Module does
+            # not declare analytical_param_count (every subclass implements it as an
+            # informal protocol), so mypy erases the concrete MACBlock type here.
+            # Hence the ignore; the same calls on self.attn / self.mem need none,
+            # because those attributes keep their concrete types.
+            blk.analytical_param_count(lvl + 1) * rc  # type: ignore[attr-defined]
+            for blk, rc in zip(self.blocks, self._block_repeat_counts)
+        )
+        pc += self.dim
+        pc += self.dim * self.vocab_sz
+        return pc
+
+
+class TitansMAC(MemoryAsContextTransformer):
+    """Polaris workload class.
+       __init__(name, cfg) / set_batch_size / create_input_tensors /
+       get_forward_graph / __call__ / analytical_param_count.
+    """
+    pass

--- a/workloads/Titans/memory_models.py
+++ b/workloads/Titans/memory_models.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""
+TTSim port of titans_pytorch/memory_models.py @ Ported from lucidrains/titans-pytorch v0.3.9 (0aaf130, 2025-01-29)
+https://github.com/lucidrains/titans-pytorch
+- MemoryMLP : the small 2-layer MLP whose weights ARE the neural memory
+- ResidualNorm : LayerNorm(model(x)) + x wrapper (TTT-paper convention)
+Only MemoryMLP is wired into NeuralMemory by default.
+Other variants (GatedResidualMemoryMLP, FactorizedMemoryMLP, MemorySwiGluMLP,
+MemoryAttention) can be added later with the same SimNN.Module pattern.
+"""
+import ttsim.front.functional.op as F
+import ttsim.front.functional.sim_nn as SimNN
+
+class ResidualNorm(SimNN.Module):
+    """LayerNorm(model(x)) + x.  Used by NeuralMemory when mem_model_norm_add_residual=True."""
+    def __init__(self, name, dim, model):
+        super().__init__()
+        self.name  = name
+        self.dim   = dim
+        self.model = model
+        self.norm  = F.LayerNorm(f'{name}.ln', dim)
+        self.add   = F.Add(f'{name}.add_res')
+        super().link_op2module()
+
+    def __call__(self, x):
+        out = self.model(x)
+        return self.add(self.norm(out), x)
+
+    def analytical_param_count(self, lvl=0):
+        return 2 * self.dim + self.model.analytical_param_count(lvl + 1)
+
+class MemoryMLP(SimNN.Module):
+    """
+    Reference: titans_pytorch.memory_models.MemoryMLP
+
+    depth-layer MLP, GELU between layers, no bias.
+    Input/output dim == dim (i.e. dim_head of NeuralMemory).
+    """
+    def __init__(self, name, dim, depth, expansion_factor=2.0):
+        super().__init__()
+        self.name  = name
+        self.dim   = dim
+        self.depth = depth
+        dim_hidden = int(dim * expansion_factor)
+        dims       = [dim] + [dim_hidden] * (depth - 1) + [dim]
+        self.dims  = dims
+
+        self.matmuls = []
+        self.gelus   = []
+        for i in range(depth):
+            mm = F.MatMul(f'{name}.W{i}')
+            w  = F._from_shape(f'{name}.W{i}.param', shape=[dims[i], dims[i + 1]], is_param=True)
+            setattr(self, f'_W{i}', w)
+            setattr(self, f'mm{i}', mm)
+            self.matmuls.append((mm, w))
+            if i < depth - 1:
+                g = F.Gelu(f'{name}.gelu{i}')
+                setattr(self, f'gelu{i}', g)
+                self.gelus.append(g)
+        super().link_op2module()
+
+    def __call__(self, x):
+        out = x
+        for i, (mm, w) in enumerate(self.matmuls):
+            if i > 0:
+                out = self.gelus[i - 1](out)
+            out = mm(out, w)
+        return out
+
+    def analytical_param_count(self, lvl=0):
+        return sum(self.dims[i] * self.dims[i + 1] for i in range(self.depth))

--- a/workloads/Titans/neural_memory.py
+++ b/workloads/Titans/neural_memory.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""
+TTSim port of titans_pytorch/neural_memory.NeuralMemory
+  - Memory IS the weights of a small MLP (MemoryMLP).
+  - store_memories chunk-by-chunk:
+       (a) project seq -> keys, values, adaptive_lr, decay_factor
+       (b) per-chunk: forward MemoryMLP on keys, compute (pred - v)^2 loss,
+           derive grads dL/dW for each W in MemoryMLP via explicit chain-rule
+           matmuls (cheap to emit, correct shapes/FLOPs for perf projection).
+       (c) momentum accumulation:  M_t = a * M_{t-1} + grad_t       (one step per chunk)
+       (d) decay-based weight update: W_t = (1-decay) * W_{t-1} + M_t
+  - retrieve_memories:
+       q = Linear(norm(seq)); out = MemoryMLP(q | W_current); merge_heads.
+
+Forward-only. State (NeuralMemState) is a 5-tuple of SimTensors per the
+namedtuple in the reference.  Backprop engineer wires gradient producers
+to the op handles in store_memories / retrieve_memories.
+
+"""
+from collections import namedtuple
+
+import numpy as np
+import ttsim.front.functional.op as F
+import ttsim.front.functional.sim_nn as SimNN
+from workloads.Titans.memory_models import MemoryMLP, ResidualNorm
+
+NeuralMemState = namedtuple('NeuralMemState', [
+    'seq_index',
+    'weights',
+    'cache_store_segment',
+    'states',
+    'updates',
+])
+
+class _MultiheadRMSNorm(SimNN.Module):
+    """RMSNorm(dim) * (gamma_per_head + 1) — same as titans MultiheadRMSNorm."""
+    def __init__(self, name, dim, heads):
+        super().__init__()
+        self.name = name
+        self.dim  = dim
+        self.heads = heads
+        self.mulx2  = F.Mul(f'{name}.mulx2')
+        self.meanop = F.Mean(f'{name}.mean', dim=-1)
+        self.sqrt   = F.Sqrt(f'{name}.sqrt')
+        self.recip  = F.Reciprocal(f'{name}.recip')
+        self.mulnorm= F.Mul(f'{name}.mulnorm')
+        self.mulgamma=F.Mul(f'{name}.mulgamma')
+        self.addone = F.Add(f'{name}.addone')
+        self.gamma  = F._from_shape(f'{name}.gamma', shape=[heads, 1, dim], is_param=True)
+        self.one    = F._from_data(f'{name}.one', np.float32(1.0))
+        self.one.set_module(self); self._tensors[self.one.name] = self.one
+        super().link_op2module()
+
+    def __call__(self, x):
+        eps = F._from_shape(f'{self.name}.eps', shape=[1])
+        eps.set_module(self); self._tensors[eps.name] = eps
+        x2  = self.mulx2(x, x)
+        mu  = self.meanop(x2).unsqueeze(-1)
+        rms = self.recip(self.sqrt(mu + eps))
+        normed = self.mulnorm(x, rms)
+        return self.mulgamma(normed, self.addone(self.gamma, self.one))
+
+    def analytical_param_count(self, lvl=0):
+        return self.heads * self.dim
+
+class _RMSNorm(SimNN.Module):
+    """Standard RMSNorm (no learnable gamma if elementwise_affine=False)."""
+    def __init__(self, name, dim, elementwise_affine=True):
+        super().__init__()
+        self.name = name
+        self.dim  = dim
+        self.eaff = elementwise_affine
+        self.mulx2  = F.Mul(f'{name}.mulx2')
+        self.meanop = F.Mean(f'{name}.mean', dim=-1)
+        self.sqrt   = F.Sqrt(f'{name}.sqrt')
+        self.recip  = F.Reciprocal(f'{name}.recip')
+        self.mulnorm= F.Mul(f'{name}.mulnorm')
+        if elementwise_affine:
+            self.weight = F._from_shape(f'{name}.weight', shape=[dim], is_param=True)
+            self.mulw   = F.Mul(f'{name}.mulw')
+        super().link_op2module()
+
+    def __call__(self, x):
+        eps = F._from_shape(f'{self.name}.eps', shape=[1])
+        eps.set_module(self); self._tensors[eps.name] = eps
+        x2  = self.mulx2(x, x)
+        mu  = self.meanop(x2).unsqueeze(-1)
+        normed = self.mulnorm(x, self.recip(self.sqrt(mu + eps)))
+        if self.eaff:
+            return self.mulw(normed, self.weight)
+        return normed
+
+    def analytical_param_count(self, lvl=0):
+        return self.dim if self.eaff else 0
+
+class NeuralMemory(SimNN.Module):
+    """
+    TTSim port of titans_pytorch.neural_memory.NeuralMemory.
+
+    Constructor mirrors the reference for the supported subset.
+    Per-chunk
+    representations are always mean-pooled; the reference's attn_pool_chunks
+    (AttentionPool) path is not modeled, so that knob is absent here rather
+    than accepted and ignored.
+    """
+    def __init__(
+        self,
+        name,
+        dim,
+        chunk_size = 1,
+        dim_head   = None,
+        heads      = 1,
+        depth      = 2,
+        expansion_factor = 2.0,
+        mem_model_norm_add_residual = True,
+        pre_rmsnorm  = True,
+        post_rmsnorm = False,
+        qk_rmsnorm   = False,
+        max_chunks_unroll = 16,
+    ):
+        super().__init__()
+        self.name = name
+        self.max_chunks_unroll = max_chunks_unroll
+        dim_head = dim_head if dim_head is not None else dim
+        assert not (heads == 1 and dim_head != dim)
+
+        self.dim       = dim
+        self.dim_head  = dim_head
+        self.heads     = heads
+        self.dim_inner = dim_head * heads
+        self.chunk_size = chunk_size
+        self.store_chunk_size    = chunk_size
+        self.retrieve_chunk_size = chunk_size
+
+        # ----- norms -----
+        self.retrieve_norm = _RMSNorm(f'{name}.retrieve_norm', dim) if pre_rmsnorm else F.Identity(f'{name}.id_rn')
+        self.store_norm    = _RMSNorm(f'{name}.store_norm',    dim) if pre_rmsnorm else F.Identity(f'{name}.id_sn')
+        self.multihead_rmsnorm = _MultiheadRMSNorm(f'{name}.mh_rmsnorm', dim_head, heads) if post_rmsnorm else F.Identity(f'{name}.id_mh')
+        self.q_norm = _MultiheadRMSNorm(f'{name}.q_norm', dim_head, heads) if qk_rmsnorm else F.Identity(f'{name}.id_q')
+        self.k_norm = _MultiheadRMSNorm(f'{name}.k_norm', dim_head, heads) if qk_rmsnorm else F.Identity(f'{name}.id_k')
+
+        # ----- projections -----
+        self.to_queries = SimNN.Linear(f'{name}.to_queries', dim, self.dim_inner)
+        self.to_keys    = SimNN.Linear(f'{name}.to_keys',    dim, self.dim_inner)
+        self.to_values  = SimNN.Linear(f'{name}.to_values',  dim, self.dim_inner)
+
+        # ----- per-chunk learned hparams -----
+        self.to_adaptive_step = SimNN.Linear(f'{name}.to_adaptive_step', dim, heads)
+        self.to_decay_factor  = SimNN.Linear(f'{name}.to_decay_factor',  dim, heads)
+        self.to_momentum      = SimNN.Linear(f'{name}.to_momentum',      dim, heads)
+        self.adaptive_step_sig= F.Sigmoid(f'{name}.adaptive_step_sig')
+        self.decay_sig        = F.Sigmoid(f'{name}.decay_sig')
+        self.momentum_sig     = F.Sigmoid(f'{name}.momentum_sig')
+
+        # ----- multi-head retrieve gate -----
+        self.to_retrieve_gate: SimNN.Linear | None = None
+        if heads > 1:
+            self.to_retrieve_gate = SimNN.Linear(f'{name}.to_retrieve_gate', dim, heads)
+            self.retrieve_gate_sig= F.Sigmoid(f'{name}.retrieve_gate_sig')
+            self.combine_heads    = SimNN.Linear(f'{name}.combine_heads', self.dim_inner, dim)
+        else:
+            self.combine_heads    = F.Identity(f'{name}.id_combine')
+
+        # ----- the memory model (its weights are the memory) -----
+        inner_model = MemoryMLP(f'{name}.mem_mlp', dim_head, depth, expansion_factor)
+        self.memory_model: ResidualNorm | MemoryMLP
+        if mem_model_norm_add_residual:
+            self.memory_model = ResidualNorm(f'{name}.mem_resnorm', dim_head, inner_model)
+        else:
+            self.memory_model = inner_model
+
+        self._mem_param_names = [f'W{i}' for i in range(depth)]
+        self._mem_param_dims  = inner_model.dims  # length depth+1
+        self._mem_inner       = inner_model
+        self._mem_depth       = depth
+
+        self.store_mm_fwd     = F.SimOpHandleList([F.MatMul(f'{name}.store_fwd_W{i}')          for i in range(depth)])
+        self.store_gelu_fwd   = F.SimOpHandleList([F.Gelu  (f'{name}.store_fwd_gelu{i}')       for i in range(depth - 1)])
+        self.sub_err          = F.Sub(f'{name}.sub_err')
+        self.mul_scale        = F.Mul(f'{name}.mul_lr_scale')
+        self.store_mm_bwd_dW  = F.SimOpHandleList([F.MatMul(f'{name}.store_bwd_dW{i}')         for i in range(depth)])
+        self.store_mm_bwd_dh  = F.SimOpHandleList([F.MatMul(f'{name}.store_bwd_dh{i}')         for i in range(depth - 1)])
+        self.gelu_grad        = F.SimOpHandleList([F.Mul   (f'{name}.store_bwd_geluprime{i}')  for i in range(depth - 1)])
+
+        self.mom_mul   = F.SimOpHandleList([
+            F.Mul(f'{name}.mom_mul_W{i}_c{c}')
+            for i in range(depth) for c in range(self.max_chunks_unroll)
+        ])
+        self.mom_add   = F.SimOpHandleList([
+            F.Add(f'{name}.mom_add_W{i}_c{c}')
+            for i in range(depth) for c in range(self.max_chunks_unroll)
+        ])
+        self.decay_mul = F.SimOpHandleList([
+            F.Mul(f'{name}.decay_mul_W{i}_c{c}')
+            for i in range(depth) for c in range(self.max_chunks_unroll)
+        ])
+        self.weight_add = F.SimOpHandleList([
+            F.Add(f'{name}.weight_add_W{i}_c{c}')
+            for i in range(depth) for c in range(self.max_chunks_unroll)
+        ])
+        self.weight_sub = F.SimOpHandleList([
+            F.Sub(f'{name}.weight_sub_W{i}_c{c}')
+            for i in range(depth) for c in range(self.max_chunks_unroll)
+        ])
+
+        self._grads_splits = []
+        for i in range(depth):
+            row = []
+            for k in range(1, self.max_chunks_unroll + 1):
+                op = F.SplitOpHandle(f'{name}.grads_split_W{i}_n{k}', count=k, axis=1)
+                setattr(self, f'grads_split_W{i}_n{k}', op)
+                row.append(op)
+            self._grads_splits.append(row)
+
+        self._momentum_coef_splits = []
+        self._decay_factor_splits  = []
+        for k in range(1, self.max_chunks_unroll + 1):
+            mop = F.SplitOpHandle(f'{name}.momentum_coef_split_n{k}', count=k, axis=1)
+            dop = F.SplitOpHandle(f'{name}.decay_factor_split_n{k}',  count=k, axis=1)
+            setattr(self, f'momentum_coef_split_n{k}', mop)
+            setattr(self, f'decay_factor_split_n{k}',  dop)
+            self._momentum_coef_splits.append(mop)
+            self._decay_factor_splits.append(dop)
+
+        self.chunk_mean = F.Mean(f'{name}.chunk_mean', dim=-2)
+        self.decay_chunk_mean    = F.Mean(f'{name}.decay_chunk_mean',    dim=1)
+        self.momentum_chunk_mean = F.Mean(f'{name}.momentum_chunk_mean', dim=1)
+
+        self.cat_cache = F.Concat(f'{name}.cat_cache', axis=1)
+
+        super().link_op2module()
+
+
+    def _mc(self, i, c):
+        """D1: flat-index helper for per-chunk recurrence ops.
+        Maps (layer_idx i, chunk_idx c) -> position in the flat SimOpHandleList."""
+        return i * self.max_chunks_unroll + c
+
+
+    def init_weights(self, batch):
+        """Returns dict[name -> SimTensor] mirroring lucidrains init_weights.
+        Shape per param: [batch*heads, dim_in, dim_out]."""
+        bh = batch * self.heads
+        d  = self._mem_inner.dims
+        out = {}
+        for i in range(self._mem_depth):
+            t = F._from_shape(
+                f'{self.name}.init_W{i}',
+                shape=[bh, d[i], d[i + 1]], is_param=True)
+            t.set_module(self)
+            self._tensors[t.name] = t
+            out[f'W{i}'] = t
+        return out
+
+    def init_momentum(self, batch):
+        bh = batch * self.heads
+        d  = self._mem_inner.dims
+        out = {}
+        for i in range(self._mem_depth):
+            t = F._from_shape(
+                f'{self.name}.init_M{i}',
+                shape=[bh, d[i], d[i + 1]], is_param=False)
+            t.set_module(self)
+            self._tensors[t.name] = t
+            out[f'W{i}'] = t
+        return out
+
+    def retrieve_memories(self, seq, weights):
+        """
+        seq      : SimTensor [B, N, D]
+        weights  : dict 'Wi' -> SimTensor [B*H, dim_in, dim_out]   (current memory)
+        returns  : SimTensor [B, N, D]
+        """
+        B, N, D = seq.shape
+        H, Dh   = self.heads, self.dim_head
+
+        x = self.retrieve_norm(seq)
+        q = self.to_queries(x)
+        q = q.reshape(B, N, H, Dh).transpose(1, 2)
+        q = self.q_norm(q)
+
+        h = q.reshape(B * H, N, Dh)
+        for i in range(self._mem_depth):
+            if i > 0:
+                h = self._mem_inner.gelus[i - 1](h)
+            mm = self._mem_inner.matmuls[i][0]
+            h  = mm(h, weights[f'W{i}'])
+        out = h
+        if isinstance(self.memory_model, ResidualNorm):
+            out = self.memory_model.add(self.memory_model.norm(h), q.reshape(B * H, N, Dh))
+
+        out = out.reshape(B, H, N, Dh)
+        out = self.multihead_rmsnorm(out)
+
+        if self.to_retrieve_gate is not None:
+            gate = self.retrieve_gate_sig(self.to_retrieve_gate(x))
+            gate = gate.reshape(B, N, H, 1).transpose(1, 2)
+            out  = out * gate
+
+        out = out.transpose(1, 2).reshape(B, N, H * Dh)
+        out = self.combine_heads(out)
+        return out
+
+    def store_memories(self, seq, weights, past_state, seq_index):
+        """
+        Emits the per-chunk store-update graph.
+
+        seq        : SimTensor [B, N, D]
+        weights    : dict 'Wi' -> SimTensor [B*H, di, dj]
+        past_state : tuple(last_update, last_momentum), both dicts as above
+        seq_index  : python int (host-side bookkeeping only)
+
+        returns: (updates_dict, NeuralMemState)
+
+        UNROLL CONSTRAINT: the per-chunk momentum/decay recurrence is unrolled
+        into explicit ops (one set per chunk) rather than a runtime loop, so the
+        chunk count (N / chunk_size) must not exceed max_chunks_unroll. This bounds
+        the graph size for long sequences. The assert below enforces it; configs
+        keep N / mem_chunk_size <= max_chunks_unroll (see ip_workloads.yaml).
+
+        """
+        B, N, D = seq.shape
+        H, Dh   = self.heads, self.dim_head
+        C       = self.store_chunk_size
+
+        assert N % C == 0, f"N={N} must be divisible by chunk_size={C} (mem_chunk_size)"
+        num_ch   = N // C
+
+        x = self.store_norm(seq)
+
+        chunked = self.chunk_mean(x.reshape(B, num_ch, C, D))
+        adaptive_lr  = self.adaptive_step_sig(self.to_adaptive_step(x)).transpose(1,2)
+        decay_factor = self.decay_sig       (self.to_decay_factor (chunked)).transpose(1,2)
+        momentum_coef= self.momentum_sig    (self.to_momentum     (chunked)).transpose(1,2)
+
+        K = self.to_keys  (x).reshape(B, N, H, Dh).transpose(1, 2)
+        V = self.to_values(x).reshape(B, N, H, Dh).transpose(1, 2)
+        K = self.k_norm(K)
+
+        acts = [K.reshape(B * H, N, Dh)]
+        for i in range(self._mem_depth):
+            h = acts[-1]
+            if i > 0:
+                h = self.store_gelu_fwd[i - 1](h)
+            h = self.store_mm_fwd[i](h, weights[f'W{i}'])
+            acts.append(h)
+        pred = acts[-1]
+
+        err = self.sub_err(pred, V.reshape(B * H, N, Dh))
+        d_pred = self.mul_scale(err, adaptive_lr.reshape(B * H, N, 1))
+
+        grads = {}
+        d_h = d_pred
+        for i in reversed(range(self._mem_depth)):
+            a_in = acts[i]
+
+            di_i = a_in.shape[-1]
+            dj_i = d_h.shape[-1]
+            a_in_chunked = a_in.reshape(B * H, num_ch, C, di_i)
+            d_h_chunked  = d_h.reshape(B * H, num_ch, C, dj_i)
+
+            grads[f'W{i}'] = self.store_mm_bwd_dW[i](
+                a_in_chunked.transpose(-1, -2), d_h_chunked)
+
+            if i > 0:
+                d_h = self.store_mm_bwd_dh[i - 1](d_h, weights[f'W{i}'].transpose(-1, -2))
+                d_h = self.gelu_grad[i - 1](d_h, a_in)
+
+        assert num_ch <= self.max_chunks_unroll, \
+            f"num_chunks={num_ch} exceeds max_chunks_unroll={self.max_chunks_unroll}. " \
+            f"Either raise max_chunks_unroll or bump mem_chunk_size in the YAML."
+
+        prev_update, prev_momentum = past_state
+        new_update, new_momentum = {}, {}
+
+        decay_factor_r  = decay_factor.reshape(B * H, num_ch, 1, 1)
+        momentum_coef_r = momentum_coef.reshape(B * H, num_ch, 1, 1)
+
+        decay_chunks    = self._decay_factor_splits[num_ch - 1](decay_factor_r)
+        momentum_chunks = self._momentum_coef_splits[num_ch - 1](momentum_coef_r)
+
+
+        for i in range(self._mem_depth):
+            one_const = F._from_data(f'{self.name}.one_W{i}', np.float32(1.0))
+            one_const.set_module(self); self._tensors[one_const.name] = one_const
+
+            g_chunks = self._grads_splits[i][num_ch - 1](grads[f'W{i}'])
+
+            m_prev = prev_momentum[f'W{i}']
+            w_prev = prev_update[f'W{i}']
+
+            for c in range(num_ch):
+                g_c     = g_chunks[c].squeeze(1)
+                eta_c   = momentum_chunks[c].squeeze(1)
+                alpha_c = decay_chunks[c].squeeze(1)
+
+                m_scaled = self.mom_mul[self._mc(i, c)](m_prev, eta_c)
+                m_new    = self.mom_add[self._mc(i, c)](m_scaled, g_c)
+
+                one_minus_alpha = self.weight_sub[self._mc(i, c)](one_const, alpha_c)
+                w_decayed       = self.decay_mul[self._mc(i, c)](w_prev, one_minus_alpha)
+                w_new           = self.weight_add[self._mc(i, c)](w_decayed, m_new)
+
+                m_prev = m_new
+                w_prev = w_new
+
+            new_momentum[f'W{i}'] = m_prev
+            new_update[f'W{i}']   = w_prev
+
+        next_state = (new_update, new_momentum)
+        next_mem_state = NeuralMemState(
+            seq_index = seq_index + N,
+            weights   = new_update,
+            cache_store_segment = None,
+            states    = next_state,
+            updates   = new_update,
+        )
+        return new_update, next_mem_state
+
+    def __call__(self, seq, state=None, store_seq=None):
+        B = seq.shape[0]
+        store_seq = store_seq if store_seq is not None else seq
+
+        if state is None:
+            weights    = self.init_weights(B)
+            past_state = (weights, self.init_momentum(B))
+            seq_index  = 0
+            cache_seg  = None
+        else:
+            seq_index  = state.seq_index
+            weights    = state.weights
+            past_state = state.states
+            cache_seg  = state.cache_store_segment
+
+        if cache_seg is not None:
+            store_seq = self.cat_cache(cache_seg, store_seq)
+
+        store_seq_len = store_seq.shape[-2]
+
+        updates, next_mem_state = self.store_memories(
+            store_seq, weights, past_state, seq_index)
+        weights    = next_mem_state.weights
+        past_state = next_mem_state.states
+
+        new_cache_seg = None
+
+        next_state_final = NeuralMemState(
+            seq_index           = seq_index + store_seq_len,
+            weights             = weights,
+            cache_store_segment = new_cache_seg,
+            states              = past_state,
+            updates             = updates,
+        )
+
+        retrieved = self.retrieve_memories(seq, weights)
+        return retrieved, next_state_final
+
+    def analytical_param_count(self, lvl=0):
+        pc = 0
+        pc += self.to_queries.analytical_param_count(lvl + 1)
+        pc += self.to_keys.analytical_param_count(lvl + 1)
+        pc += self.to_values.analytical_param_count(lvl + 1)
+        pc += self.to_adaptive_step.analytical_param_count(lvl + 1)
+        pc += self.to_decay_factor.analytical_param_count(lvl + 1)
+        pc += self.to_momentum.analytical_param_count(lvl + 1)
+        if self.to_retrieve_gate is not None:
+            pc += self.to_retrieve_gate.analytical_param_count(lvl + 1)
+            pc += self.combine_heads.analytical_param_count(lvl + 1)
+        pc += self.memory_model.analytical_param_count(lvl + 1)
+        # norms
+        for n in ['retrieve_norm','store_norm','multihead_rmsnorm','q_norm','k_norm']:
+            mod = getattr(self, n)
+            if hasattr(mod, 'analytical_param_count'):
+                pc += mod.analytical_param_count(lvl + 1)
+        return pc


### PR DESCRIPTION
Adds support for profiling the Titans architecture (Memory-as-Context Transformer variant) in Polaris.

1. New workload under workloads/Titans/ — MemoryAsContextTransformer built on the SimNN op API, with NeuralMemory (test-time-training long-term memory) and segmented attention.
2. Registered in config/ip_workloads.yaml as TitansMAC, with size instances (nano → xlarge).
3. Includes a smoke test (test_titans_mac.py) covering memory-module shapes, forward pass, chunk-state propagation, and ONNX export.

Verified: profiles end-to-end on Wormhole n150 and n300