### PR TITLE
Add Whisper base workload ONNX Support and SkipLayerNormalization support

### DIFF
--- a/config/ip_workloads.yaml
+++ b/config/ip_workloads.yaml
@@ -79,6 +79,17 @@ workloads:
       bert_base : { path: 'onnx/bert-fixed-128.onnx', seq_len: 128, bs: 1 }
 
   - api: ONNX
+    name: WHISPER-BASE
+    basedir: workloads/onnx
+    module: whisper-base-fixed.onnx
+    instances:
+      default: { path: whisper-base-fixed.onnx,
+                 bs: 1,
+                 audio_seq_len: 3000,
+                 decoder_seq_len: 16,
+                 feature_dim: 80 }
+
+  - api: ONNX
     name: VIT-BASE
     basedir: workloads/onnx
     module: vit-base-fixed-224.onnx

--- a/config/wl2archmapping.yaml
+++ b/config/wl2archmapping.yaml
@@ -60,7 +60,7 @@ op_rsrc_spec:
              Pad, Permute, Pow,
              QuantizeLinear,
              Reciprocal, ReduceMax, ReduceMean, ReduceMin, ReduceProd, ReduceSum, Relu, Reshard, Reshape, Resize,
-             ScatterND, ScatterElements, Shape, ShardedToInterleaved, Sigmoid, Sin, Slice, Softmax, SoftmaxCrossEntropyLoss, Softplus, Split, Sqrt, Squeeze, Sub, Sum,
+             ScatterND, ScatterElements, Shape, ShardedToInterleaved, Sigmoid, Sin, SkipLayerNormalization, Slice, Softmax, SoftmaxCrossEntropyLoss, Softplus, Split, Sqrt, Squeeze, Sub, Sum,
              Tanh, Tile, Tilize, TilizeWithValPadding, TopK, TorchGather, Transpose, Trilu,
              Unsqueeze, Untilize, UntilizeWithUnpadding, Upsample,
              VoxelPooling,

--- a/ttsim/ops/desc/nn.py
+++ b/ttsim/ops/desc/nn.py
@@ -764,6 +764,77 @@ def ln_sinf(iTList, oTList, op, **kwargs):
     return
 
 
+def skip_ln_sinf(iTList, oTList, op, **kwargs):
+    X = iTList[0]
+    skip = iTList[1]
+    gamma = iTList[2]
+    beta = iTList[3] if len(iTList) > 3 else None
+    bias = iTList[4] if len(iTList) > 4 else None
+    assert X.check_shape(), f"Illegal Shape for {X}"
+
+    input_count = X.nelems()
+    reduction_count = prod_ints(X.shape[:-1]) if X.rank() > 0 else 1
+
+    instr_count = {
+        "add": 0,
+        "sub": 0,
+        "mul": 0,
+        "div": 0,
+        "mac": 0,
+        "rsqrt": 0,
+    }
+    # value = input + skip (+ bias)
+    instr_count["add"] += input_count           # + skip
+    if bias is not None:
+        instr_count["add"] += input_count       # + bias
+    # LayerNorm over last dim
+    instr_count["add"] += input_count           # sum for mean
+    instr_count["div"] += reduction_count       # mean
+    instr_count["sub"] += input_count           # x - mean
+    instr_count["mul"] += input_count           # squared diff
+    instr_count["add"] += input_count           # sum for variance
+    instr_count["div"] += reduction_count       # variance
+    instr_count["add"] += reduction_count       # variance + epsilon
+    instr_count["rsqrt"] += reduction_count     # 1/sqrt(var + eps)
+    instr_count["mul"] += input_count           # normalize
+    instr_count["mac"] += input_count           # scale (*gamma) (+beta)
+
+    oTList[0].shape = X.shape
+    oTList[0].dtype = X.dtype
+
+    reduction_shape = X.shape[:-1] + [1]
+    if len(oTList) >= 2:
+        oTList[1].shape = reduction_shape
+        oTList[1].dtype = X.dtype
+    if len(oTList) >= 3:
+        oTList[2].shape = reduction_shape
+        oTList[2].dtype = X.dtype
+    if len(oTList) >= 4:
+        oTList[3].shape = X.shape
+        oTList[3].dtype = X.dtype
+
+    biasElems = 0 if bias is None else bias.nelems()
+    betaElems = 0 if beta is None else beta.nelems()
+    biasBytes = 0 if bias is None else bias.nbytes(op.precision)
+    betaBytes = 0 if beta is None else beta.nbytes(op.precision)
+    outElems = sum(t.nelems() for t in oTList)
+    outBytes = sum(t.nbytes(op.precision) for t in oTList)
+    op.perf_stats = {
+        "inElems": X.nelems() + skip.nelems() + gamma.nelems() + betaElems + biasElems,
+        "outElems": outElems,
+        "inBytes": X.nbytes(op.precision)
+        + skip.nbytes(op.precision)
+        + gamma.nbytes(op.precision)
+        + betaBytes
+        + biasBytes,
+        "outBytes": outBytes,
+        "instrs": instr_count,
+    }
+
+    oTList[0].data = None
+    return
+
+
 def groupnorm_sinf(iTList, oTList, op, **kwargs):
     # For GroupNormalization, the shape inference is similar to LayerNormalization
     # The output shape is the same as input shape
@@ -1099,6 +1170,24 @@ def register_nn_ops():
             3,
             1,
             ln_sinf,
+            True,
+            True,
+            True,
+            True,
+            True,
+        ],
+        [
+            "SkipLayerNormalization",
+            "ARITY_VARIADIC[3-5]->VARIADIC[1-4]",
+            "com.microsoft",
+            "COMMON",
+            1,
+            1,
+            5,
+            3,
+            4,
+            1,
+            skip_ln_sinf,
             True,
             True,
             True,

--- a/workloads/onnx/examples/whisper-onnx-dump.py
+++ b/workloads/onnx/examples/whisper-onnx-dump.py
@@ -1,0 +1,76 @@
+# #!/usr/bin/env python
+# # SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# # SPDX-License-Identifier: Apache-2.0
+
+# import os
+# os.environ['KMP_DUPLICATE_LIB_OK'] = 'True'
+
+# import torch
+# import onnx
+# import onnxruntime as ort
+# from transformers import WhisperForConditionalGeneration
+
+# model_name = "openai/whisper-base"
+# raw_onnx_path = "whisper-base-fixed-raw.onnx"
+# final_onnx_path = "workloads/onnx/whisper-base-fixed.onnx"
+
+# # Load model
+# model = WhisperForConditionalGeneration.from_pretrained(
+#     model_name,
+#     attn_implementation="eager"
+# )
+# model.config.use_cache = False
+# model.eval()
+
+# BATCH_SIZE = 1
+# FEATURE_DIM = 80
+# AUDIO_SEQ_LEN = 3000
+# DECODER_SEQ_LEN = 16
+
+# input_features = torch.randn(BATCH_SIZE, FEATURE_DIM, AUDIO_SEQ_LEN, dtype=torch.float32)
+# decoder_input_ids = torch.zeros((BATCH_SIZE, DECODER_SEQ_LEN), dtype=torch.long)
+# decoder_attention_mask = torch.ones((BATCH_SIZE, DECODER_SEQ_LEN), dtype=torch.long)
+
+
+# class WhisperWrapper(torch.nn.Module):
+#     def __init__(self, model):
+#         super().__init__()
+#         self.model = model
+
+#     def forward(self, input_features, decoder_input_ids, decoder_attention_mask):
+#         return self.model(
+#             input_features=input_features, 
+#             decoder_input_ids=decoder_input_ids,
+#             decoder_attention_mask=decoder_attention_mask,
+#             return_dict=False
+#         )[0]
+
+
+# wrapped_model = WhisperWrapper(model)
+
+# print("Exporting initial ONNX graph...")
+# torch.onnx.export(
+#     wrapped_model,
+#     (input_features, decoder_input_ids, decoder_attention_mask),
+#     raw_onnx_path,
+#     input_names=["input_features", "decoder_input_ids", "decoder_attention_mask"],
+#     output_names=["logits"],
+#     opset_version=17,
+#     dynamic_axes=None,
+#     do_constant_folding=True,
+#     export_params=True,
+#     dynamo=False
+# )
+
+# print("Folding shape constants via ONNX Runtime graph optimization...")
+# os.makedirs(os.path.dirname(final_onnx_path), exist_ok=True)
+
+# opt_options = ort.SessionOptions()
+# opt_options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
+# opt_options.optimized_model_filepath = final_onnx_path
+# _ = ort.InferenceSession(raw_onnx_path, opt_options)
+
+# if os.path.exists(raw_onnx_path):
+#     os.remove(raw_onnx_path)
+
+# print(f"Saved optimized, fully static ONNX: {final_onnx_path}")


### PR DESCRIPTION
### Summary
This PR introduces support for the Whisper-base model into the Polaris simulator and adds registry support for the `SkipLayerNormalization` fused operator to handle aggressively optimized ONNX graphs.

### Key Changes
* **Workload Configuration:** Added `WHISPER-BASE` to `config/ip_workloads.yaml`.
* **Operator Registry Update:** Registered `SkipLayerNormalization` in `ttsim/ops/desc/nn.py` (aliasing the standard `LayerNormalization` shape inference and cycle counts) so Polaris can natively process fused normalization nodes.
* **Architecture Mapping:** Updated `config/wl2archmapping.yaml` to ensure the new workload and fused operators map correctly across the simulation architectures.