### PR TITLE
Add deeepseek-coder workload ONNX Support

### DIFF
--- a/config/ip_workloads.yaml
+++ b/config/ip_workloads.yaml
@@ -88,6 +88,14 @@ workloads:
                  img_height: 224,
                  img_width: 224 }
 
+  # generate deepseek-coder-1.3b-fixed.onnx using code in workloads/onnx/examples/:
+  - api: ONNX
+    name: DEEPSEEK-CODER-1.3B
+    basedir: workloads/onnx
+    module : deepseek_coder_onnx_dump.py
+    instances:
+        default : { path: 'deepseek-coder-1.3b-fixed.onnx', seq_len: 128, bs: 1 }
+
   - api: ONNX
     name: PI0FAST_BASE
     basedir: workloads/onnx

--- a/workloads/onnx/examples/deepseek_coder_onnx_dump.py
+++ b/workloads/onnx/examples/deepseek_coder_onnx_dump.py
@@ -1,0 +1,57 @@
+# #!/usr/bin/env python
+# # SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# # SPDX-License-Identifier: Apache-2.0
+
+# import os
+# os.environ["KMP_DUPLICATE_LIB_OK"] = "True"
+
+# import torch
+# from transformers import AutoModelForCausalLM
+
+# class DeepSeekExportWrapper(torch.nn.Module):
+#     """
+#     Wraps the causal language model to cleanly extract the logits tensor,
+#     avoiding Hugging Face dataclass tracing errors during ONNX export.
+#     """
+#     def __init__(self, model):
+#         super().__init__()
+#         self.model = model
+
+#     def forward(self, input_ids, attention_mask):
+#         return self.model(
+#             input_ids=input_ids, 
+#             attention_mask=attention_mask
+#         ).logits
+
+# model_name = "deepseek-ai/deepseek-coder-1.3b-base"
+
+# # Load model
+# print(f"Loading {model_name}...")
+# model = AutoModelForCausalLM.from_pretrained(model_name)
+# model.config.use_cache = False
+# model.eval()
+
+# wrapped_model = DeepSeekExportWrapper(model)
+
+# BATCH_SIZE = 1
+# SEQ_LEN = 128
+
+# input_ids = torch.randint(0, model.config.vocab_size, (BATCH_SIZE, SEQ_LEN), dtype=torch.long)
+# attention_mask = torch.ones((BATCH_SIZE, SEQ_LEN), dtype=torch.long)
+
+# script_dir = os.path.dirname(os.path.abspath(__file__))
+# onnx_dir = os.path.abspath(os.path.join(script_dir, ".."))
+# output_path = os.path.join(onnx_dir, "deepseek-coder-1.3b-fixed.onnx")
+
+# print("Exporting to ONNX...")
+# torch.onnx.export(
+#     wrapped_model,
+#     (input_ids, attention_mask),
+#     output_path,
+#     input_names=["input_ids", "attention_mask"],
+#     output_names=["logits"],
+#     opset_version=17,
+#     dynamic_axes=None
+# )
+
+# print(f"Saved fixed-shape ONNX to: {output_path}")


### PR DESCRIPTION
### Summary

This PR introduces support for the DeepSeek Coder 1.3B Base model into the Polaris simulator by adding a dedicated ONNX export script and workload configuration for performance projection.

### Key Changes

* **Workload Configuration:** Added `DEEPSEEK-CODER-1.3B` to `config/ip_workloads.yaml` 
* **ONNX Export Script:** Created `workloads/onnx/examples/deepseek_coder_onnx_dump.py` to trace and export `deepseek-ai/deepseek-coder-1.3b-base` with fixed input dimensions (`seq_len: 128`, `bs: 1`).
