### PR TITLE
fix(500): drop Tracy signpost rows in ops_perf_three_csv_merge

### DIFF
--- a/doc/SPEC_ops_perf_three_csv_merge.md
+++ b/doc/SPEC_ops_perf_three_csv_merge.md
@@ -26,6 +26,10 @@ Merge **exactly three** TT-Metal-style ops perf CSV files found under a root dir
 - Empty, `-`, or non-numeric: **skip** the range check for that cell.
 - Strip whitespace; whitespace-only is blank. **Zero** means parses to **0.0** after strip.
 
+## Input row filtering (signpost markers)
+
+Immediately after reading each CSV (before validation, classification, iteration detection, and join-key parsing), rows whose `OP TYPE` is **`signpost`** (case-insensitive) are dropped. These are Tracy signpost markers (e.g. the `start`/`stop` pair a perf test wraps around its profiled region), emitted by TT-Metal's ops-log post-processor with an empty `GLOBAL CALL COUNT`; `signpost` is the only non-op `OP TYPE` it writes. They carry no device-op data, so removing them keeps every downstream step operating on real ops only (and prevents the empty `GLOBAL CALL COUNT` from failing join-key parsing). A **`loguru` `info`** line records the count dropped per file. The same filter rule is applied to all three inputs; agreement of the three files after filtering is still enforced separately by the existing row-count-equality and identical-join-key-set checks (see *Join keys and sorting*), not by this step.
+
 ## Iteration filtering
 
 TT-Metal device-perf harnesses (e.g. `run_device_perf(num_iterations=N)`) may concatenate multiple iterations of the same model in one CSV. This script reduces the input to a single iteration so downstream tools (e.g. `tt_perf_mapper`) consume one row per op.

--- a/doc/SPEC_ops_perf_trace_replay_merge.md
+++ b/doc/SPEC_ops_perf_trace_replay_merge.md
@@ -58,3 +58,5 @@ If a future capture is trace+replay **and** iterative (a replay session that its
 ## Shared behavior (unchanged from the iterative tool)
 
 Classification (noctrace / fpu / vanilla), header subsequence/omission rules, join keys and sorting, per-row and aggregate duration checks, MemTraffic derivation, and the full output column order are exactly as specified in [`SPEC_ops_perf_three_csv_merge.md`](SPEC_ops_perf_three_csv_merge.md). The reduction runs **after** classification/header validation and **before** the join, so the join always receives one unique-keyed row set per variant.
+
+**Signpost-row filtering** (see the iterative spec's *Input row filtering* section) is likewise inherited: `signpost` marker rows are dropped in the shared `run_merge` immediately after each CSV is read — **before** classification and the replay-session reduction — so a trace+replay capture whose passes are wrapped in Tracy `start`/`stop` signposts is handled identically to an iterative one.

--- a/tests/test_tools/test_ops_perf_three_csv_merge.py
+++ b/tests/test_tools/test_ops_perf_three_csv_merge.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import csv
+from pathlib import Path
 
 import pytest
 
@@ -12,6 +13,7 @@ from tools.si_profiling_helpers.ops_perf_three_csv_merge import (
     classify_file,
     detect_by_op_code_period,
     detect_iteration_boundaries,
+    drop_signpost_rows,
     iteration_summary,
     pick_median_iteration,
     run_merge,
@@ -284,6 +286,36 @@ def test_pick_measured_indices_override():
 
 
 # ---------------------------------------------------------------------------
+# drop_signpost_rows
+# ---------------------------------------------------------------------------
+
+def _signpost_row(op_code):
+    # TT-Metal emits signpost markers with OP TYPE 'signpost' and no GLOBAL CALL COUNT.
+    return {'OP CODE': op_code, 'OP TYPE': 'signpost', 'GLOBAL CALL COUNT': ''}
+
+
+@pytest.mark.unit
+def test_drop_signpost_rows_removes_markers():
+    rows = [_signpost_row('start'), *_rows(['conv', 'relu']), _signpost_row('stop')]
+    kept = drop_signpost_rows(rows, Path('x.csv'))
+    assert [r['OP CODE'] for r in kept] == ['conv', 'relu']
+    assert all(r['OP TYPE'] != 'signpost' for r in kept)
+
+
+@pytest.mark.unit
+def test_drop_signpost_rows_case_insensitive():
+    rows = [{'OP CODE': 'start', 'OP TYPE': 'SignPost', 'GLOBAL CALL COUNT': ''}, *_rows(['conv'])]
+    assert len(drop_signpost_rows(rows, Path('x.csv'))) == 1
+
+
+@pytest.mark.unit
+def test_drop_signpost_rows_noop_when_absent():
+    rows = _rows(['conv', 'relu'])
+    kept = drop_signpost_rows(rows, Path('x.csv'))
+    assert kept == rows
+
+
+# ---------------------------------------------------------------------------
 # classify_file
 # ---------------------------------------------------------------------------
 
@@ -389,6 +421,41 @@ def test_merge_appends_overhead_ratio_columns(tmp_path):
     # Row B: raw=0 -> blank (no division), not '0' or 'inf'.
     assert rows['Add'][COL_FPU_UTIL_RAW] == ''
     assert rows['Add'][COL_MEM_UTIL_RAW] == ''
+
+
+def _e2e_signpost(op_code):
+    # Signpost marker row as tt-metal writes it: OP TYPE 'signpost', empty GLOBAL CALL COUNT.
+    r = {c: '' for c in _E2E_COLS}
+    r['OP CODE'] = op_code
+    r['OP TYPE'] = 'signpost'
+    return r
+
+
+@pytest.mark.unit
+def test_merge_skips_signpost_rows(tmp_path):
+    # ResNet50/WH capture pathology: each pass wraps its ops in start/stop Tracy
+    # signposts, emitted as rows with an empty GLOBAL CALL COUNT. Pre-fix these
+    # crashed join-key parsing ("Empty 'GLOBAL CALL COUNT'"); they must now be
+    # dropped so the merge succeeds and they never reach the output.
+    keys = [(1024, 'Matmul'), (2048, 'Add')]
+
+    def with_signposts(op_rows):
+        return [_e2e_signpost('start'), *op_rows, _e2e_signpost('stop')]
+
+    _write_csv(tmp_path / 'noctrace.csv',
+               with_signposts([_e2e_row(g, op, 1200, dram='45.2') for g, op in keys]))
+    _write_csv(tmp_path / 'fpuutil.csv',
+               with_signposts([_e2e_row(g, op, 1100, fpu='62.1') for g, op in keys]))
+    _write_csv(tmp_path / 'vanilla.csv',
+               with_signposts([_e2e_row(g, op, 1000) for g, op in keys]))
+
+    out = tmp_path / 'merged_ops.csv'
+    run_merge(tmp_path, out, dram_peak_bw_gbps=288.0, duration_rel_tol=1e9, encoding='utf-8')
+
+    with out.open(newline='') as fh:
+        rows = list(csv.DictReader(fh))
+    assert {r['OP CODE'] for r in rows} == {'Matmul', 'Add'}
+    assert all(r['OP TYPE'] != 'signpost' for r in rows)
 
 
 # fpu-only analysis columns (extras the fpu pass carries beyond the noctrace schema)

--- a/tests/test_tools/test_ops_perf_trace_replay_merge.py
+++ b/tests/test_tools/test_ops_perf_trace_replay_merge.py
@@ -187,6 +187,42 @@ def test_main_merges_trace_replay_capture(tmp_path):
     assert {r['DEVICE KERNEL DURATION [ns]'] for r in rows} == {'100'}
 
 
+def _tr_signpost(name):
+    # Tracy signpost marker as TT-Metal emits it: OP TYPE 'signpost', empty GLOBAL CALL
+    # COUNT and no replay session.
+    r = {c: '' for c in _TR_COLS}
+    r['OP CODE'] = name
+    r['OP TYPE'] = 'signpost'
+    return r
+
+
+@pytest.mark.unit
+def test_main_drops_signpost_rows_in_trace_replay(tmp_path):
+    # A trace+replay capture whose passes are wrapped in start/stop Tracy signposts
+    # (empty GLOBAL CALL COUNT). The signpost drop lives in the shared run_merge, so it
+    # must cover the trace+replay variant too: the merge must succeed and the marker
+    # rows must never reach the output. (Same root cause as the ResNet50 3-CSV failure.)
+    def wrapped(**kw):
+        capture = _capture_rows({'': 999, '1': 100, '2': 200}, **kw)
+        return [_tr_signpost('start'), *capture, _tr_signpost('stop')]
+
+    _write_csv(tmp_path / 'trace.csv', wrapped(dram='45.2'))
+    _write_csv(tmp_path / 'perf.csv', wrapped(fpu='62.1'))
+    _write_csv(tmp_path / 'raw.csv', wrapped())
+
+    out = tmp_path / 'merged_ops.csv'
+    rc = main([
+        '--input-dir', str(tmp_path), '--dram-peak-bw-gbps', '288.0',
+        '--output', str(out), '--duration-rel-tol', '1e9',
+    ])
+    assert rc == 0
+
+    with out.open(newline='') as fh:
+        rows = list(csv.DictReader(fh))
+    assert {r['OP CODE'] for r in rows} == {'Matmul', 'Add'}
+    assert all(r['OP TYPE'] != 'signpost' for r in rows)
+
+
 @pytest.mark.unit
 def test_main_errors_on_non_trace_replay_capture(tmp_path):
     # No populated replay-session id -> not a trace+replay capture -> exit 1.

--- a/tools/si_profiling_helpers/ops_perf_three_csv_merge.py
+++ b/tools/si_profiling_helpers/ops_perf_three_csv_merge.py
@@ -37,6 +37,14 @@ COL_MC_NOC_UTIL = "MULTICAST NOC UTIL (%)"
 COL_ETH_BW_UTIL = "ETH BW UTIL (%)"
 COL_NPE_CONG = "NPE CONG IMPACT (%)"
 
+# Tracy signpost markers (tracy.signpost("...")) are emitted as CSV rows by TT-Metal's
+# ops-log post-processor with OP TYPE == "signpost" and no GLOBAL CALL COUNT. It is the
+# only non-op OP TYPE the processor ever writes (the sole literal OP TYPE assignment in
+# tt-metal tools/tracy/process_ops_logs.py). These rows are host-side navigation markers,
+# not device ops, so they are dropped before validation / iteration detection / join-key
+# parsing. Matched case-insensitively for robustness.
+OP_TYPE_SIGNPOST = "signpost"
+
 JOIN_KEYS: Tuple[str, ...] = (COL_GLOBAL_CALL_COUNT, COL_OP_CODE, COL_OP_TYPE)
 
 UTILIZATION_COLUMNS: Tuple[str, ...] = (
@@ -189,6 +197,22 @@ def read_csv(path: Path, encoding: str) -> Tuple[Tuple[str, ...], List[Dict[str,
                 raise MergeError(f"CSV row has more fields than header: {path}")
             rows.append(row)
         return header, rows
+
+
+def drop_signpost_rows(rows: List[Dict[str, str]], path: Path) -> List[Dict[str, str]]:
+    """Drop Tracy signpost marker rows (OP TYPE == "signpost").
+
+    Signposts are host-side timeline markers (e.g. the ``start``/``stop`` pair a perf test
+    wraps around the profiled region); TT-Metal writes them as rows with an empty
+    GLOBAL CALL COUNT, which would otherwise break join-key parsing. They carry no device-op
+    data, so removing them here keeps every downstream step (validation, iteration detection,
+    join) operating on real ops only. See ``OP_TYPE_SIGNPOST``.
+    """
+    kept = [r for r in rows if _strip_cell(r.get(COL_OP_TYPE)).lower() != OP_TYPE_SIGNPOST]
+    dropped = len(rows) - len(kept)
+    if dropped:
+        logger.info("Dropped {} signpost marker row(s) from {}", dropped, path)
+    return kept
 
 
 def require_columns(header: Sequence[str], required: Iterable[str], path: Path) -> None:
@@ -754,6 +778,7 @@ def run_merge(
     path_kind: Dict[Path, str] = {}
     for p in paths:
         header, rows = read_csv(p, encoding)
+        rows = drop_signpost_rows(rows, p)
         loaded.append((p, header, rows))
 
     # Classify


### PR DESCRIPTION
## Problem

Merging a ResNet50 WH n150 capture with the SI-profiling merge tool fails:

```
MergeError: Empty 'GLOBAL CALL COUNT' in <csv> row 1
```

The device run itself succeeds — the merge is the only failure. ResNet50's perf test wraps its
profiled region in `tracy.signpost("start"/"stop")` markers, which TT-Metal's ops-log
post-processor emits as CSV rows with `OP TYPE = "signpost"` and an empty `GLOBAL CALL COUNT`:

```
OP CODE,OP TYPE,GLOBAL CALL COUNT,DEVICE ID,...
start,signpost,,,...        <- empty GLOBAL CALL COUNT
PadDeviceOperation,tt_dnn_device,1024,0,...
...
stop,signpost,,,...
```

`parse_join_key()` requires an integer `GLOBAL CALL COUNT` on every row and raises on the first
signpost row. Prior ViT / VGG / llama3 captures had **0** signpost rows, so ResNet50 is the first
workload to hit this.

## Fix

Drop rows whose `OP TYPE == "signpost"` (case-insensitive) in the shared `run_merge`, immediately
after each CSV is read — **before** classification, row reduction, and join-key parsing. `signpost`
is the only non-op `OP TYPE` TT-Metal writes (the sole literal `OP TYPE` assignment in
`tools/tracy/process_ops_logs.py`) and the only row type lacking a `GLOBAL CALL COUNT`, so this is
exhaustive and drops no real ops. A `loguru` info line records the per-file drop count.

### Covers both merge variants

The two SI-profiling merge tools share the same core: `ops_perf_trace_replay_merge.py` does
`run_merge = ops_perf_three_csv_merge.run_merge` and differs only in the *reducer*
(`reduce_trace_replay` vs `reduce_iterative`). Because the drop lives in `run_merge` — before the
reducer runs — the single fix covers **both** the iterative (no-trace-replay) and the trace-replay
merge paths. A regression test drives each entry point (including a trace+replay capture wrapped in
signposts), and both SPECs document the behavior.

## Changes

- `tools/si_profiling_helpers/ops_perf_three_csv_merge.py` — `OP_TYPE_SIGNPOST` constant +
  `drop_signpost_rows()` helper, wired into the shared `run_merge` right after `read_csv`.
- `tests/test_tools/test_ops_perf_three_csv_merge.py` — 4 regression tests (unit + end-to-end).
- `tests/test_tools/test_ops_perf_trace_replay_merge.py` — end-to-end test proving the trace-replay
  variant drops signposts via the shared core.
- `doc/SPEC_ops_perf_three_csv_merge.md` — new "Input row filtering (signpost markers)" section.
- `doc/SPEC_ops_perf_trace_replay_merge.md` — notes signpost filtering is inherited from `run_merge`.

## Verification

- `pytest tests/test_tools/test_ops_perf_{three_csv,trace_replay}_merge.py` — 46 passed.
- `checkin_tests.py static` (mypy ./ + pin guard), ruff, spdx — all clean.
- End-to-end on the real failing ResNet50 capture: 2 signpost rows dropped per CSV, 108 ops merged,
  0 signpost rows in output.

Closes #500