### PR TITLE
feat: MLIR frontend for Polaris (api: MLIR ingestion)

### DIFF
--- a/config/mlir_workloads.yaml
+++ b/config/mlir_workloads.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+workloads:
+  - api: MLIR
+    name: TOY_MLIR
+    basedir: workloads/mlir/examples
+    instances:
+      toy_mm_add:  { path: toy_mm_add.mlir,  bs: 1 }
+      matmul_only: { path: matmul_only.mlir, bs: 1 }
+      mlp_block:   { path: mlp_block.mlir,   bs: 1 }
+      mlp_forge_real: { path: mlp_forge_real.mlir, bs: 1 }

--- a/polaris.py
+++ b/polaris.py
@@ -13,7 +13,8 @@ from pathlib import Path
 from typing import Any, Set, Optional
 
 from ttsim.config import TTSimHLRunSummary, get_arspec_from_yaml, get_wlmapspec_from_yaml, get_wlspec_from_yaml
-from ttsim.front.onnx.onnx2nx import onnx2graph  # NOTE: import from ttsim.front had potential cyclic dependency
+from ttsim.front.onnx.onnx2nx import onnx2graph
+from ttsim.front.mlir import mlir2graph  # NOTE: import from ttsim.front had potential cyclic dependency
 from ttsim.front.ttnn import open_device, close_device
 from ttsim.utils.common import get_ttsim_functional_instance, get_ttnn_functional_instance, print_csv, str_to_bool, setup_logger
 from ttsim.utils.types import validate_datatype, get_valid_sim_dtypes
@@ -127,6 +128,15 @@ def get_wlgraph(TBL, wlg, wln, wli, gcfg, wpath, enable_memalloc):
                         0)
             finally:
                 close_device(ttnn_device)
+        elif wlg == 'MLIR':
+            logger.info(">>mlir-wl = {}.{}.{}.b{} = {}", wlg, wln, wli, wlb, wpath)
+            mlir_graph = mlir2graph(wli, wpath)
+            TBL[(wlg,wln,wli,wlb)] = (None, mlir_graph)
+            for _,op in mlir_graph._ops.items():
+                itensors = [mlir_graph._tensors[x] for x in op.inList]
+                otensors = [mlir_graph._tensors[x] for x in op.outList]
+                op.get_perf_counts(itensors, otensors)
+                op.update_tensor_counts(itensors,otensors)
         elif wlg == 'ONNX':
             logger.info(">>onnx-wl = {}.{}.{}.b{} = {}", wlg, wln, wli, wlb, wpath)
             dim_overrides: dict = {}

--- a/tests/test_mlir2graph.py
+++ b/tests/test_mlir2graph.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the MLIR -> Polaris frontend (ttsim/front/mlir/mlir2nx.py)."""
+import pytest
+from ttsim.front.mlir.mlir2nx import parse_mlir, mlir2graph
+
+EXAMPLES = "workloads/mlir/examples"
+
+
+@pytest.mark.unit
+def test_parse_toy_matmul_add():
+    """Toy MLIR (MatMul + Add) parses to the expected ops and shapes."""
+    fg = parse_mlir(f"{EXAMPLES}/toy_mm_add.mlir")
+    assert [op.optype for op in fg.ops] == ["MatMul", "Add"]
+    shapes = {t.name: t.shape for t in fg.tensors.values()}
+    assert shapes["X"] == [4, 8]
+    assert shapes["W"] == [8, 16]
+    assert shapes["Y"] == [4, 16]
+
+
+@pytest.mark.unit
+def test_mlir2graph_builds_workloadgraph():
+    """mlir2graph produces a WorkloadGraph with the right node count."""
+    gg = mlir2graph("toy", f"{EXAMPLES}/toy_mm_add.mlir")
+    assert gg is not None
+    assert gg.get_node_count() == 2   # MatMul + Add
+
+
+@pytest.mark.unit
+def test_real_forge_ttir_folds_to_clean_mlp():
+    """Real Forge TTIR (dot_general/maximum + broadcast/reshape/constant plumbing)
+    folds into a clean MatMul -> Add -> Relu -> MatMul -> Add graph."""
+    fg = parse_mlir(f"{EXAMPLES}/mlp_forge_real.mlir")
+    assert [op.optype for op in fg.ops] == ["MatMul", "Add", "Relu", "MatMul", "Add"]
+
+
+@pytest.mark.unit
+def test_shape_inference_runs_on_real_ttir():
+    """Shape inference runs on the real-TTIR graph and resolves output shapes."""
+    gg = mlir2graph("mlp", f"{EXAMPLES}/mlp_forge_real.mlir")
+    for _, op in gg._ops.items():
+        it = [gg._tensors[x] for x in op.inList]
+        ot = [gg._tensors[x] for x in op.outList]
+        op.get_perf_counts(it, ot)
+        for t in ot:
+            assert t.shape is not None

--- a/tests/test_polaris_mlir.py
+++ b/tests/test_polaris_mlir.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end simulation test: real Forge TTIR runs through the full Polaris flow."""
+import pytest
+from tests.common import reset_typespec
+import polaris
+
+
+@pytest.mark.unit
+def test_polaris_mlir_forge_ttir(reset_typespec):
+    """Real Forge TTIR (mlp_forge_real.mlir) simulates end-to-end via polaris.main."""
+    rc = polaris.main([
+        '--odir', '__dummy', '--study', 'mlir_test',
+        '--wlspec', 'config/mlir_workloads.yaml',
+        '--archspec', 'config/all_archs.yaml',
+        '--wlmapspec', 'config/wl2archmapping.yaml',
+        '--filterwli', 'mlp_forge_real',
+        '--datatype', 'fp32',
+    ])
+    assert rc == 0, "Polaris should simulate the MLIR (Forge TTIR) workload successfully"

--- a/ttsim/config/simconfig.py
+++ b/ttsim/config/simconfig.py
@@ -246,12 +246,36 @@ class WorkloadONNX(WorkloadCfgBlk):
         return result
 
 
-TypeWorkloadClass = Type[WorkloadTTSIM] | Type[WorkloadONNX] | Type[WorkloadTTNN]
-TypeWorkload = WorkloadTTSIM | WorkloadONNX | WorkloadTTNN
+class WorkloadMLIR(WorkloadCfgBlk):
+    instances: dict
+    params: dict
+    basedir: str
+    required_fields = ['basedir', 'instances']
+    optional_fields: dict[str, Any] = {'params': {}}
+
+    def __init__(self, wlname, **kwargs):
+        super().__init__(wlname, **kwargs)
+        self.api = 'MLIR'
+
+    def get_instances(self):
+        result = {}
+        for iname, icfg in self.instances.items():
+            xcfg = {}
+            if self.params:
+                xcfg.update(self.params)
+            for xx, xv in icfg.items():
+                xcfg[xx] = xv
+            result[iname] = {'group': self.name, 'cfg': xcfg}
+            result[iname]['path'] = os.path.join(self.basedir, xcfg['path'])
+        return result
+
+
+TypeWorkloadClass = Type[WorkloadTTSIM] | Type[WorkloadONNX] | Type[WorkloadTTNN] | Type[WorkloadMLIR]
+TypeWorkload = WorkloadTTSIM | WorkloadONNX | WorkloadTTNN | WorkloadMLIR
 
 
 class AWorkload:
-    WLCLS_TBL: dict[str, TypeWorkloadClass] = {'TTSIM': WorkloadTTSIM, 'ONNX': WorkloadONNX, 'TTNN': WorkloadTTNN}
+    WLCLS_TBL: dict[str, TypeWorkloadClass] = {'TTSIM': WorkloadTTSIM, 'ONNX': WorkloadONNX, 'TTNN': WorkloadTTNN, 'MLIR': WorkloadMLIR}
 
     @staticmethod
     def create_workload(apiname: str, **kwargs) -> TypeWorkload:
@@ -263,7 +287,7 @@ class WorkloadGroup(WorkloadCfgBlk):
     # Type hints for instance attributes
     workloads: dict[str, WorkloadCfgBlk]
     # Class attributes
-    WLCLS_TBL = {'TTSIM': WorkloadTTSIM, 'ONNX': WorkloadONNX, 'TTNN': WorkloadTTNN}
+    WLCLS_TBL = {'TTSIM': WorkloadTTSIM, 'ONNX': WorkloadONNX, 'TTNN': WorkloadTTNN, 'MLIR': WorkloadMLIR}
 
     def __init__(self, apiname, **kwargs):
         WLCLS = self.WLCLS_TBL[apiname]

--- a/ttsim/config/validators.py
+++ b/ttsim/config/validators.py
@@ -99,6 +99,25 @@ class PYDWorkloadONNXModelValidator(PYDWorkloadBaseModel):
             result[iname]['path'] = os.path.join(self.basedir, xcfg['path'])
         return result
 
+class PYDWorkloadMLIRModelValidator(PYDWorkloadBaseModel):
+    api: Literal['MLIR']
+    name: str
+    basedir: str
+    instances: dict
+    params: Optional[dict] = {}
+
+    def get_instances(self):
+        result = {}
+        for iname, icfg in self.instances.items():
+            xcfg = {}
+            if self.params:
+                xcfg.update(self.params)
+            for xx, xv in icfg.items():
+                xcfg[xx] = xv
+            result[iname] = {'group': self.name, 'cfg': xcfg}
+            result[iname]['path'] = os.path.join(self.basedir, xcfg['path'])
+        return result
+
 class PYDWorkloadTTNNModelValidator(PYDWorkloadBaseModel):
     api: Literal['TTNN']
     name: str
@@ -108,7 +127,7 @@ class PYDWorkloadTTNNModelValidator(PYDWorkloadBaseModel):
     params: Optional[dict] = {}
 
 
-AnyWorkload = Annotated[PYDWorkloadTTSIMModelValidator | PYDWorkloadONNXModelValidator | PYDWorkloadTTNNModelValidator  , Field(discriminator='api')]
+AnyWorkload = Annotated[PYDWorkloadTTSIMModelValidator | PYDWorkloadONNXModelValidator | PYDWorkloadTTNNModelValidator | PYDWorkloadMLIRModelValidator , Field(discriminator='api')]
 
 
 class PYDWorkloadListValidator(BaseModel):

--- a/ttsim/front/mlir/__init__.py
+++ b/ttsim/front/mlir/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+from .mlir2nx import mlir2graph, parse_mlir

--- a/ttsim/front/mlir/mlir2nx.py
+++ b/ttsim/front/mlir/mlir2nx.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""MLIR -> Polaris WorkloadGraph frontend (v3: real Forge TTIR + toy syntax)."""
+import re
+from dataclasses import dataclass, field
+import numpy as np
+
+from ttsim.graph import WorkloadGraph
+from ttsim.ops import SimOp, SimTensor
+
+OP_MAP = {
+    "matmul": "MatMul", "dot_general": "MatMul", "dot": "MatMul",
+    "add": "Add", "mul": "Mul", "multiply": "Mul", "subtract": "Sub", "sub": "Sub",
+    "maximum": "Relu", "relu": "Relu",
+    "transpose": "Transpose", "reshape": "Reshape",
+}
+TRANSPARENT = {"broadcast", "broadcast_in_dim", "convert", "typecast"}
+CONST_OPS = {"constant", "empty", "iota"}
+DT_MAP = {
+    "f64": np.float64, "f32": np.float32, "f16": np.float16, "bf16": np.float16,
+    "i64": np.int64, "i32": np.int32, "i8": np.int8, "i1": np.bool_,
+}
+_TRANSPARENT_ALL = TRANSPARENT | {"reshape"}
+
+
+@dataclass
+class FTensor:
+    name: str; shape: list; dtype: str
+    data: object = None; is_param: bool = False; is_const: bool = False
+    op_in: list = field(default_factory=list)
+    op_out: list = field(default_factory=list)
+
+
+@dataclass
+class FOp:
+    name: str; optype: str; inList: list; outList: list
+    attrs: dict = field(default_factory=dict); domain: str = "ai.onnx"
+
+
+@dataclass
+class FGraph:
+    name: str
+    ops: list = field(default_factory=list)
+    tensors: dict = field(default_factory=dict)
+    hdr: dict = field(default_factory=dict)
+
+
+_TENSOR_RE = re.compile(r"tensor<([^>]*)>")
+
+
+def _parse_tensor_type(t):
+    m = _TENSOR_RE.search(t)
+    if not m:
+        return None, None
+    body = m.group(1).split(",")[0]
+    parts = body.split("x")
+    dims = parts[:-1]
+    if not all(d.strip().isdigit() for d in dims):
+        return None, parts[-1]
+    return [int(d) for d in dims], parts[-1]
+
+
+def parse_mlir(path, wlname=None):
+    src = open(path).read()
+    fg = FGraph(name=wlname or "mlir_wl", hdr={"name": wlname or "mlir_wl", "framework_type": "MLIR"})
+
+    sig = re.search(r"func\.func\s+(?:public\s+|private\s+)?@(\w+)\s*\((.*?)\)\s*->", src, re.S)
+    assert sig, "no func.func signature found"
+    fg.name = sig.group(1); fg.hdr["name"] = sig.group(1)
+    for arg in [a.strip() for a in sig.group(2).split(",") if a.strip()]:
+        am = re.match(r"%([\w.]+)\s*:\s*(tensor<[^>]*>)", arg)
+        if not am:
+            continue
+        shp, dt = _parse_tensor_type(am.group(2))
+        fg.tensors[am.group(1)] = FTensor(name=am.group(1), shape=shp, dtype=dt)
+
+    op_re = re.compile(
+        r'%([\w.]+)\s*=\s*"?(?:(\w+)\.)?(\w+)"?\s*\(([^)]*)\)\s*'
+        r'(<\{.*?\}>)?\s*(\{.*?\})?\s*:\s*\(([^)]*)\)\s*->\s*(tensor<[^>]*>)')
+
+    alias = {}
+    const_results = set()
+    raw = []
+    for m in op_re.finditer(src):
+        res, _dialect, opname, operands, aattr, battr, intypes, restype = m.groups()
+        inames = [o.strip().lstrip("%") for o in operands.split(",") if o.strip()]
+        if opname in CONST_OPS:
+            const_results.add(res)
+            continue
+        if opname in _TRANSPARENT_ALL:
+            alias[res] = inames[0] if inames else None
+            continue
+        raw.append((res, opname, inames, (aattr or "") + (battr or ""), restype))
+
+    def resolve(t):
+        seen = set()
+        while t in alias and t not in seen:
+            seen.add(t)
+            t = alias[t]
+        return t
+
+    for i, (res, opname, inames, attrblk, restype) in enumerate(raw):
+        assert opname in OP_MAP, f"unsupported MLIR op '{opname}' (supported: {sorted(set(OP_MAP))})"
+        resolved = []
+        for nm in inames:
+            r = resolve(nm)
+            if r in const_results:
+                continue
+            resolved.append(r)
+        optype = OP_MAP[opname]
+        if opname == "maximum" and len(resolved) == 1:
+            optype = "Relu"
+        attrs = {}
+        pm = re.search(r"perm\s*=\s*\[([\d,\s]*)\]", attrblk)
+        if pm:
+            attrs["perm"] = [int(x) for x in pm.group(1).split(",") if x.strip()]
+        rshp, rdt = _parse_tensor_type(restype)
+        fg.tensors[res] = FTensor(name=res, shape=rshp, dtype=rdt)
+        fg.ops.append(FOp(name=f"{opname}_{i}", optype=optype, inList=resolved, outList=[res], attrs=attrs))
+
+    for op in fg.ops:
+        for t in op.inList:
+            if t in fg.tensors:
+                fg.tensors[t].op_in.append(op.name)
+        for t in op.outList:
+            fg.tensors[t].op_out.append(op.name)
+    return fg
+
+
+def fgraph_to_polaris(fg):
+    gg = WorkloadGraph(fg.name)
+    gg.add_hdr_info(fg.hdr)
+    for t in fg.tensors.values():
+        gg.add_tensor(SimTensor({
+            "name": t.name, "shape": [int(d) for d in t.shape], "dtype": np.dtype(DT_MAP[t.dtype]),
+            "data": t.data, "resolve": "M", "op_in": t.op_in, "op_out": t.op_out,
+            "is_param": t.is_param, "is_const": t.is_const,
+        }))
+    for op in fg.ops:
+        gg.add_op(SimOp({
+            "name": op.name, "optype": op.optype, "domain": op.domain,
+            "inList": op.inList, "outList": op.outList, "attrs": op.attrs,
+        }))
+    gg.construct_graph()
+    return gg
+
+
+def mlir2graph(wlname, wlpath, **kwargs):
+    return fgraph_to_polaris(parse_mlir(wlpath, wlname))

--- a/workloads/mlir/examples/matmul_only.mlir
+++ b/workloads/mlir/examples/matmul_only.mlir
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+func.func @matmul_only(%A: tensor<32x64xf32>, %B: tensor<64x128xf32>) -> tensor<32x128xf32> {
+  %C = matmul(%A, %B) : (tensor<32x64xf32>, tensor<64x128xf32>) -> tensor<32x128xf32>
+  return %C : tensor<32x128xf32>
+}

--- a/workloads/mlir/examples/mlp_block.mlir
+++ b/workloads/mlir/examples/mlp_block.mlir
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+// matmul -> add -> transpose -> matmul -> add
+func.func @mlp_block(%X: tensor<4x8xf32>, %W1: tensor<8x16xf32>, %B1: tensor<16xf32>, %W2: tensor<4x16xf32>, %B2: tensor<16x16xf32>) -> tensor<16x16xf32> {
+  %H1 = matmul(%X, %W1) : (tensor<4x8xf32>, tensor<8x16xf32>) -> tensor<4x16xf32>
+  %H2 = add(%H1, %B1) : (tensor<4x16xf32>, tensor<16xf32>) -> tensor<4x16xf32>
+  %H3 = transpose(%H2) {perm = [1, 0]} : (tensor<4x16xf32>) -> tensor<16x4xf32>
+  %H4 = matmul(%H3, %W2) : (tensor<16x4xf32>, tensor<4x16xf32>) -> tensor<16x16xf32>
+  %Y = add(%H4, %B2) : (tensor<16x16xf32>, tensor<16x16xf32>) -> tensor<16x16xf32>
+  return %Y : tensor<16x16xf32>
+}

--- a/workloads/mlir/examples/mlp_forge_real.mlir
+++ b/workloads/mlir/examples/mlp_forge_real.mlir
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+module @jit_mlp attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
+  ttcore.device_module {
+    builtin.module @jit_mlp attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
+      func.func public @main(%arg0: tensor<4x8xf32>, %arg1: tensor<8x16xf32>, %arg2: tensor<16xf32>, %arg3: tensor<16x16xf32>, %arg4: tensor<16xf32>) -> (tensor<4x16xf32> {jax.result_info = "result"}) {
+        %0 = "ttir.constant"() <{value = dense<0.000000e+00> : tensor<f32>}> : () -> tensor<f32>
+        %1 = "ttir.dot_general"(%arg0, %arg1) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 1>, contract_dims_rhs = array<i64: 0>}> : (tensor<4x8xf32>, tensor<8x16xf32>) -> tensor<4x16xf32>
+        %2 = "ttir.reshape"(%arg2) <{shape = [1 : i32, 16 : i32]}> : (tensor<16xf32>) -> tensor<1x16xf32>
+        %3 = "ttir.broadcast"(%2) <{broadcast_dimensions = array<i64: 1, 1>}> : (tensor<1x16xf32>) -> tensor<1x16xf32>
+        %4 = "ttir.broadcast"(%3) <{broadcast_dimensions = array<i64: 4, 1>}> : (tensor<1x16xf32>) -> tensor<4x16xf32>
+        %5 = "ttir.add"(%1, %4) : (tensor<4x16xf32>, tensor<4x16xf32>) -> tensor<4x16xf32>
+        %6 = "ttir.reshape"(%0) <{shape = [1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1xf32>
+        %7 = "ttir.broadcast"(%6) <{broadcast_dimensions = array<i64: 4, 16>}> : (tensor<1x1xf32>) -> tensor<4x16xf32>
+        %8 = "ttir.maximum"(%5, %7) : (tensor<4x16xf32>, tensor<4x16xf32>) -> tensor<4x16xf32>
+        %9 = "ttir.dot_general"(%8, %arg3) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 1>, contract_dims_rhs = array<i64: 0>}> : (tensor<4x16xf32>, tensor<16x16xf32>) -> tensor<4x16xf32>
+        %10 = "ttir.reshape"(%arg4) <{shape = [1 : i32, 16 : i32]}> : (tensor<16xf32>) -> tensor<1x16xf32>
+        %11 = "ttir.broadcast"(%10) <{broadcast_dimensions = array<i64: 1, 1>}> : (tensor<1x16xf32>) -> tensor<1x16xf32>
+        %12 = "ttir.broadcast"(%11) <{broadcast_dimensions = array<i64: 4, 1>}> : (tensor<1x16xf32>) -> tensor<4x16xf32>
+        %13 = "ttir.add"(%9, %12) : (tensor<4x16xf32>, tensor<4x16xf32>) -> tensor<4x16xf32>
+        return %13 : tensor<4x16xf32>
+      }
+    }
+  }
+}

--- a/workloads/mlir/examples/toy_mm_add.mlir
+++ b/workloads/mlir/examples/toy_mm_add.mlir
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+// Y = (X @ W) + B  — MatMul + Add
+func.func @toy_mm_add(%X: tensor<4x8xf32>, %W: tensor<8x16xf32>, %B: tensor<16xf32>) -> tensor<4x16xf32> {
+  %H = matmul(%X, %W) : (tensor<4x8xf32>, tensor<8x16xf32>) -> tensor<4x16xf32>
+  %Y = add(%H, %B) : (tensor<4x16xf32>, tensor<16xf32>) -> tensor<4x16xf32>
+  return %Y : tensor<4x16xf32>
+}


### PR DESCRIPTION
## Summary
Adds an MLIR frontend for Polaris — a compiler-driven ingestion path that parses
compiler-generated MLIR (TT-Forge / TT-MLIR TTIR) and lowers it into a Polaris
WorkloadGraph, mirroring the existing ONNX frontend (onnx2nx.py).

## What's included
- `ttsim/front/mlir/mlir2nx.py` — parse MLIR -> normalized IR -> Polaris graph
- New `api: MLIR` path: polaris.py dispatch + config validators + simconfig + wlspec
- Toy MLIR examples + `config/mlir_workloads.yaml`
- Op support (v1): MatMul (matmul/dot_general), Add, Mul, Sub, Relu (maximum),
  Reshape, Transpose; folds broadcast/reshape/constant plumbing

## Validated
- Toy MLIR (MatMul, MatMul+Add, MLP) — matches equivalent ONNX flow
- Real Forge TTIR (toy MLP via tt-xla -> StableHLO -> ttmlir-opt) runs end-to-end;
  per-op cycle stats on Grendel (fp32) and Wormhole n150/n300 (bf16)
