### PR TITLE
fix(507): pass --check-exit-code to tracy so failed captures fail loudly

### DIFF
--- a/tools/si_profiling_helpers/run-ttnn-profiler.py
+++ b/tools/si_profiling_helpers/run-ttnn-profiler.py
@@ -528,7 +528,12 @@ def run_profiler(
     """
     # Use the current interpreter (sys.executable) so tracy runs under the same
     # venv/python as this wrapper, rather than relying on whatever 'python3' is on PATH.
-    argv = [sys.executable, '-m', 'tracy', '-p', '-r', '-v',
+    # --check-exit-code makes tracy propagate the wrapped command's non-zero exit
+    # (tt-metal tools/tracy/__main__.py); without it tracy still generates its report and
+    # exits 0 even when the pytest failed/timed out, so anyfails() below would see a false
+    # success and run the remaining passes + merge on a truncated capture (the failure only
+    # surfacing later as a confusing merge row-count mismatch).
+    argv = [sys.executable, '-m', 'tracy', '-p', '-r', '-v', '--check-exit-code',
             f'--op-support-count={op_support_count}', '-o', output_dir]
     if collect_noc_traces:
         argv.append('--collect-noc-traces')


### PR DESCRIPTION
## Problem

The SI-profiling capture wrapper (`tools/si_profiling_helpers/run-ttnn-profiler.py`) invokes
`python -m tracy … -m pytest …` **without `--check-exit-code`**. Tracy only propagates the wrapped
test's non-zero exit when that flag is set (`tt-metal tools/tracy/__main__.py:412`); otherwise it
generates its report and **exits 0 even when the pytest failed or timed out**.

The wrapper's `anyfails()` gate keys on the subprocess `returncode`, so it sees a false success,
runs the remaining passes, and the failure surfaces later — confusingly — as a **merge** error.

## Repro (observed)

A ResNet50 BH p100a capture: the `raw` and `trace` passes hit the pytest 300s timeout (305.8s /
327.2s) at the final `ttnn.linear`; `perf` passed at 295.3s. Because tracy exited 0 on the
timed-out passes, the wrapper proceeded through all passes to the merge, which then failed with a
row-count mismatch (`noctrace=114 fpu=115 vanilla=114`) — the killed passes had written incomplete
CSVs (missing the final op + `stop` signpost). The real failure (capture timeout) was invisible
until the merge.

## Fix

Add `--check-exit-code` to the tracy invocation in `run_profiler()`. The wrapper *already* has
stop-on-failure gating (`anyfails()` + per-pass gates); it was just defeated by the false `rc=0`.
With the flag, a failed/timed-out capture returns non-zero → the existing gate trips → subsequent
passes and the merge are skipped and the run exits non-zero **at the point of failure**.

## Not in scope (follow-on)

With `--check-exit-code`, the first tracy pass becomes a de-facto fail gate, making the no-tracy
`failcheck` pre-flight's fail-fast role largely redundant (in the repro the failcheck *passed* at
278s under the limit while the profiled passes timed out). Whether to demote the failcheck is a
separate behavior decision (non-identical failure coverage: plain baseline vs profiled truth),
tracked for a follow-on. The 300s timeout itself is a capture-config matter handled on the HW-run
side — this PR only makes such failures **surface loudly** instead of masking them.

## Verification

- `py_compile`, `ruff check`, SPDX, `checkin_tests.py static` (mypy `./` + pin guard) — all clean.
- 1 file, +6/−1.

Closes #507