### PR TITLE
docs(508): Sphinx docs site — Phase 1 (scaffold + code-generated reference tables + config examples)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+doc/_build/
 
 # PyBuilder
 .pybuilder/

--- a/doc/_ext/ttsim_registry.py
+++ b/doc/_ext/ttsim_registry.py
@@ -1,0 +1,303 @@
+# SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Sphinx build-time directives that render Polaris reference tables from the live code.
+
+Three directives are registered:
+
+* ``simops-table``   -- every registered SimOp op-type and its metadata (from the ops
+  descriptor registry).
+* ``ttnn-simop-map`` -- the TTNN shim function -> SimOp op-type mapping (public factory-bound
+  shims extracted statically via ``ast``, private helpers excluded; hand-written
+  wrapper/composite shims are noted rather than fabricated, since their emission is
+  argument-dependent).
+* ``onnx-simop-map`` -- the ONNX op-type -> SimOp mapping (identity): the ``ai.onnx`` op-types
+  with an implemented (callable) shape function, with registered-but-unimplemented stubs
+  called out separately.
+
+Design constraints (see the Sphinx docs plan):
+
+* This module lives under ``doc/_ext`` and is imported ONLY by ``sphinx-build`` -- it is
+  never imported by ``ttsim``/``polaris.py``, so it adds no runtime import cost.
+* For the TTNN map it parses ``op.py`` source with ``ast`` -- it does NOT
+  ``import ttsim.front.ttnn`` (avoids pulling the shim/ttnn import weight).
+* For the SimOp/ONNX tables it imports only the ops descriptor registry, which any
+  Polaris run already initializes.
+
+Tables are built as docutils nodes directly (not by emitting RST/Markdown text), so they
+render as real ``<table>`` elements regardless of the surrounding parser (these pages are
+MyST/Markdown).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+# docutils ships no type stubs and `types-docutils` is not worth a dev dependency for two
+# imports — narrow, rule-specific ignores keep the rest of this file type-checked.
+from docutils import nodes  # type: ignore[import-untyped]
+from docutils.parsers.rst import Directive  # type: ignore[import-untyped]
+
+# doc/_ext/ttsim_registry.py -> repo root is two parents up from this file's dir.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TTNN_OP_PY = _REPO_ROOT / 'ttsim' / 'front' / 'ttnn' / 'op.py'
+_TTNN_INIT_PY = _REPO_ROOT / 'ttsim' / 'front' / 'ttnn' / '__init__.py'
+_DESC_DIR = _REPO_ROOT / 'ttsim' / 'ops' / 'desc'  # source of the SimOp / ONNX registry
+
+
+def _overridden_op_names() -> set:
+    """Names that ``ttsim/front/ttnn/__init__.py`` re-imports AFTER ``from .op import *``.
+    These shadow the star-imported op.py bindings, so for such a name the op.py factory
+    mapping is NOT what the public shim actually emits (e.g. ``permute``/``reshape`` are
+    re-exported from ``ttnn_shim``). They must be excluded from the factory table."""
+    tree = ast.parse(_TTNN_INIT_PY.read_text())
+    overridden: set = set()
+    star_seen = False
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom):
+            if any(a.name == '*' for a in node.names):
+                if (node.module or '').split('.')[-1] == 'op':
+                    star_seen = True
+            elif star_seen:
+                for a in node.names:
+                    overridden.add(a.asname or a.name)
+    return overridden
+
+# Representative public wrapper/composite shims (hand-written `def`s in op.py, NOT factory
+# assignments) whose emitted SimOp(s) depend on their arguments. Non-exhaustive BY DESIGN:
+# op.py is the authoritative set. This list exists only so the factory table below is not
+# mistaken for the whole shim API — it deliberately carries no per-op emission strings
+# (those go stale; e.g. rms_norm now delegates to a single LayerNormalization).
+_TTNN_WRAPPER_EXAMPLES = [
+    'linear', 'conv2d', 'conv_transpose2d', 'max_pool2d', 'rms_norm', 'moe', 'silu',
+    'concat', 'manual_seed', 'sampling',
+]
+
+
+# --- docutils node builders (parser-agnostic) ---------------------------------------
+
+def _cell(content) -> nodes.entry:
+    """One table cell. ``content`` is a str (plain), a ('code', str) tuple (monospace),
+    or a list mixing str and ('code', str) fragments."""
+    entry = nodes.entry()
+    para = nodes.paragraph()
+    frags = content if isinstance(content, list) else [content]
+    for frag in frags:
+        if isinstance(frag, tuple) and frag[0] == 'code':
+            para += nodes.literal(text=frag[1])
+        else:
+            para += nodes.Text(frag if isinstance(frag, str) else str(frag))
+    entry += para
+    return entry
+
+
+def _table(caption: str, headers: list[str], rows: list[list]) -> nodes.table:
+    table = nodes.table()
+    table['classes'].append('colwidths-auto')
+    if caption:
+        table += nodes.title(text=caption)
+    tgroup = nodes.tgroup(cols=len(headers))
+    table += tgroup
+    for _ in headers:
+        tgroup += nodes.colspec(colwidth=1)
+    thead = nodes.thead()
+    tgroup += thead
+    hrow = nodes.row()
+    for h in headers:
+        hrow += _cell(h)
+    thead += hrow
+    tbody = nodes.tbody()
+    tgroup += tbody
+    for row in rows:
+        r = nodes.row()
+        for cell in row:
+            r += _cell(cell)
+        tbody += r
+    return table
+
+
+def _para(text: str) -> nodes.paragraph:
+    p = nodes.paragraph()
+    p += nodes.Text(text)
+    return p
+
+
+class _GeneratedDirective(Directive):
+    """Base: subclasses implement ``_build_nodes`` returning a list of docutils nodes."""
+
+    has_content = False
+
+    def _build_nodes(self) -> list[nodes.Node]:  # pragma: no cover - overridden
+        raise NotImplementedError
+
+    def run(self) -> list[nodes.Node]:
+        try:
+            return self._build_nodes()
+        except Exception as exc:
+            # Fail the build — do NOT emit a silent warning node. A warning admonition does
+            # not raise a Sphinx warning, so `sphinx-build -W` would still pass with the table
+            # missing. Raising self.error() surfaces a docutils error so the gate enforces
+            # that the table actually generated.
+            raise self.error(f'{type(self).__name__}: could not generate table: {exc!r}')
+
+    def _note_deps(self, paths) -> None:
+        # Register the source files read at build time as page dependencies, so an
+        # incremental build regenerates the table when they change (Sphinx cannot otherwise
+        # infer that this .md depends on the registry / op.py). Keeps tables from going stale.
+        env = self.state.document.settings.env
+        for p in paths:
+            env.note_dependency(str(p))
+
+
+def _load_registry() -> dict:
+    from ttsim.ops.desc import initialize_op_desc
+    from ttsim.ops.desc.registry import get_opdesc_registry
+
+    initialize_op_desc()
+    return get_opdesc_registry()._registry
+
+
+def _shape_fn_cell(val: object):
+    if callable(val):
+        # Not every callable carries __name__ — functools.partial, lru_cache wrappers and
+        # callable class instances do not. Every shape fn registered today is a plain
+        # function, but falling back to the type name keeps a future one from crashing the
+        # docs build.
+        return ('code', getattr(val, '__name__', None) or type(val).__name__)
+    if isinstance(val, str):
+        return [('code', val), ' (declared, unimplemented)']
+    return str(val)
+
+
+class SimOpsTableDirective(_GeneratedDirective):
+    """Render all registered SimOp op-types with their metadata."""
+
+    def _build_nodes(self) -> list[nodes.Node]:
+        self._note_deps(sorted(_DESC_DIR.glob('*.py')))
+        reg = _load_registry()
+        headers = ['Op type', 'Group', 'Domain', 'Inputs', 'Outputs', 'Opset', 'Shape fn', 'Attrs']
+        rows = []
+        for name in sorted(reg):
+            d = reg[name]
+            rows.append([
+                ('code', name),
+                d.get('group', ''),
+                d.get('domain', ''),
+                f"{d['min_input']}–{d['max_input']}",
+                f"{d['min_output']}–{d['max_output']}",
+                str(d.get('version', '')),
+                _shape_fn_cell(d.get('shape_inf_func')),
+                'yes' if d.get('has_attr') else 'no',
+            ])
+        intro = _para(f'{len(rows)} registered op-types (generated at build time from the '
+                      'ops descriptor registry).')
+        return [intro, _table('Registered SimOp op-types', headers, rows)]
+
+
+class TTNNSimOpMapDirective(_GeneratedDirective):
+    """Render the TTNN shim -> SimOp op-type mapping."""
+
+    def _build_nodes(self) -> list[nodes.Node]:
+        self._note_deps([_TTNN_OP_PY, _TTNN_INIT_PY])
+        overridden = _overridden_op_names()
+        tree = ast.parse(_TTNN_OP_PY.read_text())
+        raw = []  # (name, optype, kind) for every public factory assignment in op.py
+        for node in tree.body:
+            if isinstance(node, ast.Assign) and isinstance(node.value, ast.Call):
+                fname = getattr(node.value.func, 'id', None)
+                if fname in ('single_output_immediate_op', 'multiple_output_immediate_op') and node.value.args:
+                    a0 = node.value.args[0]
+                    if isinstance(a0, ast.Constant) and isinstance(a0.value, str):
+                        kind = 'single' if fname.startswith('single') else 'multi'
+                        for t in node.targets:
+                            # Public only — skip private helper assignments (e.g. _concat_impl,
+                            # _move, _conv2d_raw) that are not part of the exported shim API.
+                            if isinstance(t, ast.Name) and not t.id.startswith('_'):
+                                raw.append((t.id, a0.value, kind))
+        # Exclude names that __init__.py re-exports (from ttnn_shim) after `from .op import *`
+        # — their op.py factory binding is NOT the public emission, so listing it is wrong.
+        factory = sorted((n, o, k) for (n, o, k) in raw if n not in overridden)
+        shadowed = sorted({n for (n, o, k) in raw if n in overridden})
+        rows = [[('code', shim), ('code', optype), kind] for shim, optype, kind in factory]
+        intro = _para(f'{len(rows)} public factory-bound shims (extracted statically from '
+                      'ttsim/front/ttnn/op.py; private helpers and __init__-overridden names excluded).')
+        table = _table('TTNN shim to SimOp op-type', ['TTNN shim', 'SimOp op-type', 'Outputs'], rows)
+
+        # The factory table omits the shim's hand-written wrapper/composite functions, whose
+        # emitted SimOp(s) are argument-dependent. Name a representative few and point at the
+        # source as authoritative — do NOT fabricate per-op emission strings (they go stale).
+        note = nodes.paragraph()
+        note += nodes.Text('The factory table above does not capture the shim’s hand-written '
+                           'wrapper/composite functions (e.g. ')
+        for i, w in enumerate(_TTNN_WRAPPER_EXAMPLES):
+            if i:
+                note += nodes.Text(', ')
+            note += nodes.literal(text=w)
+        note += nodes.Text('), whose emitted SimOp(s) depend on their arguments. See ')
+        note += nodes.literal(text='ttsim/front/ttnn/op.py')
+        note += nodes.Text(' for the complete, authoritative set.')
+        result = [intro, table, note]
+        if shadowed:
+            snote = nodes.paragraph()
+            snote += nodes.Text('Note: ')
+            snote += nodes.literal(text='ttsim/front/ttnn/__init__.py')
+            snote += nodes.Text(' re-exports ')
+            for i, n in enumerate(shadowed):
+                if i:
+                    snote += nodes.Text(', ')
+                snote += nodes.literal(text=n)
+            snote += nodes.Text(' from ')
+            snote += nodes.literal(text='ttnn_shim')
+            snote += nodes.Text(' after ')
+            snote += nodes.literal(text='from .op import *')
+            snote += nodes.Text(', so the public shim’s emission differs from the op.py factory '
+                                'binding of the same name — these are excluded from the table above.')
+            result.append(snote)
+        return result
+
+
+class ONNXSimOpMapDirective(_GeneratedDirective):
+    """Render the ONNX op-type -> SimOp mapping (identity) and supported ai.onnx op set."""
+
+    def _build_nodes(self) -> list[nodes.Node]:
+        self._note_deps(sorted(_DESC_DIR.glob('*.py')))
+        reg = _load_registry()
+        onnx_ops = sorted(n for n, d in reg.items() if d.get('domain') == 'ai.onnx')
+        # "Registered" != "executable": some ai.onnx entries carry a *string* shape-fn stub,
+        # which SimOp.get_perf_counts would call and raise on. Only callable shape-fns are
+        # genuinely supported; the stubs are listed separately as not-yet-implemented.
+        callable_ops = [n for n in onnx_ops if callable(reg[n].get('shape_inf_func'))]
+        stub_ops = [n for n in onnx_ops if isinstance(reg[n].get('shape_inf_func'), str)]
+        headers = ['ONNX op-type', 'SimOp op-type', 'Inputs', 'Outputs', 'Shape fn']
+        rows = []
+        for name in callable_ops:
+            d = reg[name]
+            rows.append([
+                ('code', name),
+                [('code', name), ' (identity)'],
+                f"{d['min_input']}–{d['max_input']}",
+                f"{d['min_output']}–{d['max_output']}",
+                _shape_fn_cell(d.get('shape_inf_func')),
+            ])
+        intro = _para('ONNX nodes map to SimOps by identity (the node’s op_type is the SimOp op-type), '
+                      'sharing the same shape-inference functions. The table lists the '
+                      f'{len(rows)} ai.onnx op-types with an implemented (callable) shape function.')
+        result = [intro, _table('Supported ONNX op-types', headers, rows)]
+        if stub_ops:
+            note = nodes.paragraph()
+            note += nodes.Text(f'A further {len(stub_ops)} ai.onnx op-types are registered but NOT yet '
+                               'implemented (string shape-fn stub — would raise at runtime if used): ')
+            for i, n in enumerate(stub_ops):
+                if i:
+                    note += nodes.Text(', ')
+                note += nodes.literal(text=n)
+            note += nodes.Text('.')
+            result.append(note)
+        return result
+
+
+def setup(app):
+    app.add_directive('simops-table', SimOpsTableDirective)
+    app.add_directive('ttnn-simop-map', TTNNSimOpMapDirective)
+    app.add_directive('onnx-simop-map', ONNXSimOpMapDirective)
+    return {'parallel_read_safe': True, 'parallel_write_safe': True}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: (C) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Sphinx configuration for the Polaris (ttsim) documentation site.
+
+Phase 1: MyST ingests the existing Markdown in ``doc/`` in place, plus a custom
+build-time extension (``ttsim_registry``) that generates the SimOp / TTNN / ONNX
+reference tables from the live code. API autodoc and publishing come in later phases.
+"""
+
+import os
+import re
+import sys
+from pathlib import Path
+
+_DOC_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _DOC_DIR.parent
+
+# Make the custom extension importable, and the repo importable so the extension can
+# read the ops descriptor registry at build time.
+sys.path.insert(0, str(_DOC_DIR / '_ext'))
+sys.path.insert(0, str(_REPO_ROOT))
+
+project = 'Polaris'
+copyright = '2025, Tenstorrent AI ULC'
+author = 'Tenstorrent AI ULC'
+
+extensions = [
+    'myst_parser',
+    'ttsim_registry',
+]
+
+# MyST: allow the ```{directive}``` fences the reference pages use, plus a few niceties.
+myst_enable_extensions = [
+    'colon_fence',
+    'deflist',
+]
+myst_heading_anchors = 3
+
+source_suffix = {'.md': 'markdown'}
+root_doc = 'index'
+
+# The existing markdown (INTRODUCTION.md, user_guide.md) links to source-code dirs
+# (../ttsim/..., ../config/), the top-level README, and docs excluded from this Phase-1
+# build. Those targets are real but sit outside the Sphinx tree, so MyST cannot resolve
+# them. They are rewritten to GitHub URLs at source-read (_rewrite_repo_links below) so the
+# published links WORK; no warning is emitted and none is suppressed. `-W` therefore still
+# fails on a genuinely broken link, including a typo under those same directories.
+
+# Peripheral docs excluded from the Phase-1 site (avoids orphan warnings under -W).
+# These are wired into the toctree in later phases.
+exclude_patterns = [
+    '_build',
+    'Thumbs.db',
+    '.DS_Store',
+    'README.md',                              # GitHub folder-landing page, not a site page
+    'README_dynamic_badges.md',
+    'README_github_actions_architecture.md',
+    'SPEC_ops_perf_three_csv_merge.md',
+    'SPEC_ops_perf_trace_replay_merge.md',
+    'tools/**',                               # tool/CI READMEs — folded in a later phase
+]
+
+html_theme = 'sphinx_rtd_theme'
+html_title = 'Polaris Documentation'
+
+# Belt-and-suspenders: some CI shells set cwd elsewhere; ensure repo import works.
+os.environ.setdefault('PYTHONPATH', str(_REPO_ROOT))
+
+
+# Blob/tree base for links that point at repository content rather than doc pages.
+# Pin this to a tag when the site is published for a release; `main` tracks HEAD.
+_GITHUB_BLOB = 'https://github.com/tenstorrent/polaris/blob/main'
+_GITHUB_TREE = 'https://github.com/tenstorrent/polaris/tree/main'
+
+# Markdown inline-link targets, e.g. the "../ttsim/ops/op.py" in "[op.py](../ttsim/ops/op.py)".
+# Anchors/queries are excluded so a fragment link to a doc page is never touched.
+_MD_LINK_RE = re.compile(r'\]\((?P<target>[^)\s#?]+)\)')
+
+
+def _rewrite_repo_links(app, docname, source):
+    """Point links at repository content to GitHub, so they RESOLVE instead of being silenced.
+
+    ``INTRODUCTION.md`` and ``user_guide.md`` link to source dirs (``../ttsim/ops/op.py``),
+    the top-level README, and docs excluded from this phase. Those targets are real, but they
+    are outside the Sphinx tree, so MyST cannot resolve them and emits ``myst.xref_missing``.
+    Earlier revisions of this file silenced that warning — first with an allowlist, then with
+    an on-disk existence test. Both left the built HTML carrying
+    ``<a href="#../ttsim/front/ttnn/">``: a same-page fragment link that navigates nowhere.
+    The warning was the messenger; the dead link was the defect.
+
+    Rewriting the target at ``source-read`` (before MyST parses it) makes the published link
+    work, needs no warning filter at all, and drops this file's dependence on the wording of
+    Sphinx log messages.
+
+    The typo gate is preserved *by construction*: only a target that resolves to a real path
+    is rewritten. ``../ttsim/tpyo.py`` resolves to nothing, is left untouched, and still
+    raises ``myst.xref_missing`` — so ``sphinx-build -W`` fails, exactly as before.
+
+    Note the asymmetry: a rewritten link is absolute and therefore tracks ``_GITHUB_BLOB``'s
+    ref, while the on-disk markdown keeps its relative form and stays browsable on GitHub.
+    """
+    doc_dir = (Path(app.srcdir) / docname).parent
+
+    def _repo_path(target):
+        """Absolute path inside the repo for a link target, or None if it isn't one."""
+        if target.startswith(('http://', 'https://', 'mailto:', 'ftp:', '/')):
+            return None
+        candidate = Path(os.path.normpath(str(doc_dir / target)))
+        try:
+            rel = candidate.relative_to(_REPO_ROOT)
+        except ValueError:
+            return None                      # escapes the repo — leave it alone
+        if candidate.exists():
+            return rel, candidate.is_dir()
+        md = Path(f'{candidate}.md')          # pages are linked without their extension
+        return (rel.with_suffix('.md'), False) if md.exists() else None
+
+    def _sub(match):
+        target = match.group('target')
+        resolved = _repo_path(target)
+        if resolved is None:
+            return match.group(0)             # not repo content (or a typo) — untouched
+        rel, is_dir = resolved
+        # A doc page inside the Sphinx tree must keep its relative link so MyST resolves it
+        # internally; only content OUTSIDE the tree needs to go to GitHub.
+        if not is_dir and rel.suffix == '.md' and str(rel).startswith(f'{_DOC_DIR.name}/'):
+            in_tree = Path(app.srcdir) / rel.relative_to(_DOC_DIR.name)
+            if in_tree.exists() and not _is_excluded(rel.relative_to(_DOC_DIR.name)):
+                return match.group(0)
+        base = _GITHUB_TREE if is_dir else _GITHUB_BLOB
+        return f']({base}/{rel})'
+
+    source[0] = _MD_LINK_RE.sub(_sub, source[0])
+
+
+def _is_excluded(rel_to_srcdir):
+    """True if a doc-tree-relative path is kept out of this phase's build."""
+    from fnmatch import fnmatch
+
+    text = str(rel_to_srcdir)
+    return any(fnmatch(text, pattern) for pattern in exclude_patterns)
+
+
+def setup(app):
+    app.connect('source-read', _rewrite_repo_links)

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,0 +1,36 @@
+# Polaris Documentation
+
+**Polaris** (`ttsim`) is a high-level, roofline performance simulator for AI workloads
+on Tenstorrent hardware. Start with the [Introduction](INTRODUCTION.md) for the guided
+tour, then dive into the guides and reference below.
+
+```{toctree}
+:maxdepth: 2
+:caption: Guides
+
+INTRODUCTION
+user_guide
+overview
+torch2ttsim
+```
+
+```{toctree}
+:maxdepth: 2
+:caption: Frontends & authoring
+
+functional
+ttnn_shims_README
+TTNN_WORKLOAD_FLOW
+shape_inference
+```
+
+```{toctree}
+:maxdepth: 2
+:caption: Reference (generated)
+
+reference/simops
+reference/ttnn-mapping
+reference/onnx-mapping
+reference/config-examples
+YAML_MASTER_FORMAT
+```

--- a/doc/reference/config-examples.md
+++ b/doc/reference/config-examples.md
@@ -1,0 +1,97 @@
+# Configuration file examples
+
+A Polaris run is wired together from four YAML files. This page shows an annotated,
+minimal excerpt of each. (These are *excerpts* — see the files under `config/` for the
+full, current content.)
+
+## Workload registry — `config/all_workloads.yaml`
+
+Declares each workload, its frontend (`api`), the Python module implementing it, shared
+`params`, and named size `instances`.
+
+```yaml
+workloads:
+  - api: TTSIM                 # frontend: TTSIM | TTNN | ONNX
+    name: basic_llm
+    basedir: workloads
+    module: BasicLLM.py        # implements the workload
+    params:
+      vocab_sz: 50257
+      norm_type: layer
+      bs: 1
+    instances:
+      gpt_nano  : { nL:  3, nH:  3, dE:   48, nW:   32}   # tiny — good for smoke runs
+      gpt_micro : { nL:  4, nH:  4, dE:  128, nW:   32}
+      gpt1      : { nL: 12, nH: 12, dE:  768, nW:  512}
+```
+
+Each `instances` entry is a preset (`nL` layers, `nH` heads, `dE` embedding dim, `nW`
+sequence/window). `--filterwli gpt_nano` selects one.
+
+## Architecture spec — `config/tt_bh.yaml` / `config/tt_wh.yaml`
+
+Two top-level keys: `ipblocks` (reusable compute/memory block definitions) and `packages`
+(chip products and their SKU `instances`).
+
+```yaml
+packages:
+  - name: Blackhole
+    instances:
+      - name: p100a
+        operator_lookup_file: lfc://hlm-lut/bh_p100a_lut_v5.yaml   # per-SKU perf LUT
+        compute_grid_size: [12, 10]
+        ipgroups:
+          - ipname: tensix                 # compute block from `ipblocks`
+            iptype: compute
+            num_units: 120                 # 120 Tensix cores
+            ramp_penalty: 100
+            ip_overrides:
+              pipes.matrix.freq_MHz: 1350
+              pipes.vector.freq_MHz: 1350
+          - ipname: gddr6_bh               # memory block
+            iptype: memory
+            num_units: 7
+```
+
+The `operator_lookup_file` is how a per-SKU performance LUT is attached (see
+[YAML_MASTER_FORMAT](../YAML_MASTER_FORMAT.md)). `ipblocks` (not shown) define the
+per-instruction throughput tables the perf model reads.
+
+## Graph-mapping spec — `config/wl2archmapping.yaml`
+
+Post-processing rules applied to the workload graph after it is built, before execution.
+
+```yaml
+op_data_type_spec:                 # dtype assignment
+  global_type: int8
+  override:
+    dropout: int32
+
+op_removal_spec:                   # ops dropped from the graph
+  - Dropout
+  - Identity
+  - Constant
+
+op_fusion_spec:                    # op-sequence patterns fused into one node
+  - [Add, LayerNormalization, Matmul, Add, Matmul, Add, Gelu]
+  - [Conv, BatchNormalization, Relu]
+  - [Matmul, Mul, Softmax]
+
+op_rsrc_spec:                      # compute-pipe assignment (matrix vs vector) — not shown
+op_split_spec:                     # arch-aware op splitting (e.g. lm_head) — not shown
+```
+
+## Run config — `config/runcfg_*.yaml`
+
+Bundles the three files above plus study parameters for a run. Used with `polproj.py`.
+
+```yaml
+title: Run all workloads
+study: runall
+odir: __runall
+wlspec: config/all_workloads.yaml       # → workload registry
+archspec: config/all_archs.yaml         # → architecture spec
+wlmapspec: config/wl2archmapping.yaml   # → graph-mapping spec
+filterwlg: TTSIM                        # workload-group filter
+dump_stats_csv: true                    # emit the per-op stats CSV
+```

--- a/doc/reference/onnx-mapping.md
+++ b/doc/reference/onnx-mapping.md
@@ -1,0 +1,11 @@
+# ONNX → SimOp mapping
+
+The [ONNX frontend](../overview.md) parses an `.onnx` model and turns each node into a
+`SimOp`. The mapping is **identity**: an ONNX node's `op_type` becomes the SimOp op-type
+directly, and shape inference is shared with the SimOp registry. The supported set is the
+`ai.onnx`-domain entries that have an **implemented (callable) shape function**, listed
+below (generated at build time); entries registered with an unimplemented string stub are
+called out separately beneath the table.
+
+```{onnx-simop-map}
+```

--- a/doc/reference/simops.md
+++ b/doc/reference/simops.md
@@ -1,0 +1,13 @@
+# SimOps reference
+
+Every operation in a Polaris workload graph is a `SimOp` of some **op-type**. The table
+below is generated at build time from the ops descriptor registry
+(`ttsim/ops/desc/`), so it always matches the code.
+
+Columns: the op-type name, its group (descriptor module), ONNX/Tenstorrent domain, input
+and output arity bounds, the ONNX opset version, the shape-inference function, and whether
+the op takes attributes. Shape functions marked *declared, unimplemented* are registered
+as string stubs and are not yet callable.
+
+```{simops-table}
+```

--- a/doc/reference/ttnn-mapping.md
+++ b/doc/reference/ttnn-mapping.md
@@ -1,0 +1,13 @@
+# TTNN shim → SimOp mapping
+
+The [TTNN shim](../ttnn_shims_README.md) presents the `ttnn` API but records each call as
+a `SimOp` instead of executing it. The table below lists the **public factory-bound** shims —
+extracted statically from `ttsim/front/ttnn/op.py` — and the SimOp op-type each emits.
+Several shim names deliberately map onto one op-type (e.g. `outer` → `MatMul`).
+
+Beyond these, the shim has hand-written wrapper/composite functions whose emitted SimOp(s)
+depend on their arguments. The note under the table names a **representative, non-exhaustive**
+few and points to `op.py` as the authoritative set — it is not a complete listing.
+
+```{ttnn-simop-map}
+```

--- a/envdev.yaml
+++ b/envdev.yaml
@@ -25,6 +25,7 @@ dependencies:
   - pyyaml=6.0.2
   - scipy=1.17.1 # used by Deformable DETR
   - simpy=4.1.1
+  - myst-parser=4.0.1
   - sphinx=8.2.1
   - sphinx-rtd-theme=3.0.1
   - yaml=0.2.5

--- a/environment.yaml
+++ b/environment.yaml
@@ -25,6 +25,7 @@ dependencies:
   - pyyaml=6.0.2
   - scipy=1.17.1 # used by Deformable DETR
   - simpy=4.1.1
+  - myst-parser=4.0.1
   - sphinx=8.2.1
   - sphinx-rtd-theme=3.0.1
   - yaml=0.2.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ addopts = "--durations=0 --ignore=tests/test_ttnn/reference/"
 [tool.mypy]
 check_untyped_defs = true
 explicit_package_bases = true
-exclude = "^__.*/|^tests/|ttsim/back/tensix_neo|ttsim/front/llk|/reference/|^workloads/si_ttnn|^workloads/diffusers|^workloads/llm/|^workloads/llama2|^workloads/ttnn/llama3|^workloads/ttnn/vit/|^workloads/mamba2/|^workloads/basicresnet.py|^tools/profiling/|^tools/compare_csv\\.py$|^tools/compare_profiler_to_polaris\\.py$"
+exclude = "^__.*/|^tests/|ttsim/back/tensix_neo|ttsim/front/llk|/reference/|^workloads/si_ttnn|^workloads/diffusers|^workloads/llm/|^workloads/llama2|^workloads/ttnn/llama3|^workloads/ttnn/vit/|^workloads/mamba2/|^workloads/basicresnet.py|^tools/profiling/|^tools/compare_csv\\.py$|^tools/compare_profiler_to_polaris\\.py$|^doc/_build/"
 # disallow_untyped_calls = true
 # disallow_untyped_defs = true
 warn_unreachable = true


### PR DESCRIPTION
Addresses #508 (Phase 1). Targets `main` (#488 merged 2026-08-13).

## What

Stands up a Sphinx docs site that reuses the existing `doc/*.md` (via MyST, no RST rewrite) and **auto-generates reference tables from the live code**.

- **Scaffold (T1):** `doc/conf.py` (MyST + rtd theme), `doc/index.md` toctree ingesting the existing markdown in place; `myst-parser` pinned in **both** `environment.yaml` and `envdev.yaml`; `doc/_build/` gitignored; only `doc/_build/` excluded from mypy — the `doc/` **source is type-checked**.
- **Code-generated reference tables (T3)** — `doc/_ext/ttsim_registry.py`, a build-time extension:
  - **SimOps** — every registered op-type + metadata, from the ops descriptor registry
  - **TTNN shim → SimOp** — public factory-bound shims (statically via `ast`; private + `__init__`-overridden names excluded) + a non-exhaustive note on the wrapper/composite functions
  - **ONNX → SimOp** — identity map + supported `ai.onnx` op set, from the same registry
- **Config examples** — annotated `doc/reference/config-examples.md` (workload / arch / `wl2archmapping` / `runcfg`).

## Repo links in the built site

`doc/*.md` links to repository content — source dirs (`../ttsim/ops/op.py`), the top-level
README, docs excluded from this phase. Those targets are real but sit outside the Sphinx tree,
so MyST cannot resolve them as doc xrefs. `conf.py` rewrites them at `source-read` to GitHub
URLs (`blob/main` for files, `tree/main` for directories) so the **published links work**. No
warning is suppressed anywhere: `sphinx-build -W` still fails on a genuinely broken link,
including a typo under those same directories — verified in both directions.

The markdown on disk keeps its relative links, so the files stay browsable on GitHub.

⚠️ **Rewritten links are absolute and track `main`.** A site built from a release tag would
still point at whatever `main` becomes. `_GITHUB_BLOB` / `_GITHUB_TREE` in `conf.py` must be
pinned to a tag as part of the Phase-2 publishing work.

## Verification

`sphinx-build -W --keep-going` succeeds locally. The reference tables are generated from the live ops registry and shim source at build time (with `env.note_dependency` so incremental builds regenerate them), so they never drift from the code.

**Import-cost constraint honored:** the extension lives in `doc/_ext/` (loaded only by `sphinx-build`), parses the TTNN shim via `ast` (no `import ttsim.front.ttnn`), and imports only the ops registry — no `ttsim` runtime import cost is added.

## ⚠️ Deferred to a follow-up (not in this PR)

- **CI docs-build gate** — will be added as a small separate PR (avoids touching `.github/workflows/*` in this stacked docs PR). The build is green and reproducible locally in the meantime.

## Non-goals (later phases)

- Publishing to GitHub Pages — Phase 2.
- Full API autodoc from docstrings + narrative guides (tutorial, perf-model, FAQ) — Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

