### PR TITLE
fix(517): fail loudly when filters match nothing or select no experiments

### DIFF
--- a/checkin_tests.py
+++ b/checkin_tests.py
@@ -44,7 +44,7 @@ def prepare_commands_run_all_tests(condaenvprefix: OptionalString) -> list[str]:
     wlspec     = 'config/all_workloads.yaml'
     arspec     = 'config/all_archs.yaml'
     wlmspec    = 'config/wl2archmapping.yaml'
-    filterarch = 'A100,Q1_A1'
+    filterarch = 'Q1_A1'
     filterwli  = 'gpt_nano'
     option1 = ["", ' --instr_profile']
     option2 = ["", ' --dump_ttsim_onnx']

--- a/polaris.py
+++ b/polaris.py
@@ -5,12 +5,13 @@ import os
 import sys
 import argparse
 import cProfile
+import difflib
 from loguru import logger
 import time
 import tracemalloc
 from itertools import product
 from pathlib import Path
-from typing import Any, Set, Optional
+from typing import Any, Callable, Iterable, Set, Optional, TypeVar
 
 from ttsim.config import TTSimHLRunSummary, get_arspec_from_yaml, get_wlmapspec_from_yaml, get_wlspec_from_yaml
 from ttsim.front.onnx.onnx2nx import onnx2graph  # NOTE: import from ttsim.front had potential cyclic dependency
@@ -72,11 +73,61 @@ def check_args(args):
         validate_datatype(args.datatype)
     return
 
-def apply_filter(L, filter_csv_str, get_param_func):
-    if filter_csv_str is not None:
-        filter_fields = filter_csv_str.split(',')
-        L = [x for x in L if get_param_func(x).upper() in [f.upper() for f in filter_fields]]
-    return L
+FilterItem = TypeVar('FilterItem')
+
+
+class SpecSelectionError(Exception):
+    """A --filter* entry names nothing in the spec, or the selection it produces is empty."""
+
+
+# Above this many candidates, spelling out every legal value buries the error instead of
+# explaining it (the workload-instance domain runs to three figures), so the message falls
+# back to near-matches plus a count and the full list goes to the debug log.
+MAX_LISTED_FILTER_VALUES = 20
+
+
+def describe_unmatched(flag_name: str, unmatched: list[str], available: list[str]) -> str:
+    """Build the error text for filter entries that name nothing, with near-match hints."""
+    upper2orig = {a.upper(): a for a in available}
+    parts = [f'--{flag_name}: no match for {unmatched}']
+    for u in unmatched:
+        close = difflib.get_close_matches(u.upper(), list(upper2orig), n=3)
+        if close:
+            parts.append(f"'{u}': did you mean {[upper2orig[c] for c in close]}?")
+    if len(available) <= MAX_LISTED_FILTER_VALUES:
+        parts.append(f'available: {available}')
+    else:
+        parts.append(f'{len(available)} values available -- re-run with --log_level debug to list them')
+    DEBUG('--{}: available values: {}', flag_name, available)
+    return '; '.join(parts)
+
+
+def apply_filter(L: list[FilterItem], filter_csv_str: str | None, get_param_func: Callable[[FilterItem], str],
+                 flag_name: str = 'filter', domain: Iterable[str] | None = None) -> list[FilterItem]:
+    """Narrow L to the entries whose key appears in the comma-separated filter string.
+
+    Every filter entry must name a value that exists in `domain` -- the full set of values
+    the key takes in the loaded spec, collected before any other filter is applied. An entry
+    naming nothing is a typo or a name that has since been renamed or removed, so it raises
+    instead of silently selecting nothing. Validating against the full domain (rather than
+    against whatever survived an earlier filter) keeps 'unknown name' distinct from 'these
+    filters are individually valid but jointly select nothing'.
+
+    `domain` defaults to the keys present in L, which is correct when no other filter runs
+    against the same list.
+    """
+    if filter_csv_str is None:
+        return L
+    filter_fields = [f.strip() for f in filter_csv_str.split(',') if f.strip() != '']
+    if not filter_fields:
+        raise SpecSelectionError(f'--{flag_name} was given but lists no values')
+    available = sorted({get_param_func(x) for x in L} if domain is None else set(domain))
+    available_upper = {a.upper() for a in available}
+    unmatched = sorted(f for f in filter_fields if f.upper() not in available_upper)
+    if unmatched:
+        raise SpecSelectionError(describe_unmatched(flag_name, unmatched, available))
+    wanted = {f.upper() for f in filter_fields}
+    return [x for x in L if get_param_func(x).upper() in wanted]
 
 def get_wlgraph(TBL, wlg, wln, wli, gcfg, wpath, enable_memalloc):
     xrows = [xrec for xrec in TBL if xrec[0] == wlg and xrec[1] == wln and xrec[2] == wli]
@@ -290,12 +341,11 @@ def get_devices(devspec, fsweep, filterarch):
         device_list = [(d,f) for d in devs for f in fsweep.getvals()]
     else:
         device_list = [(d,None) for d in devs]
-    devlist = sorted(apply_filter(device_list, filterarch, lambda x: x[0]))
+    devlist = sorted(apply_filter(device_list, filterarch, lambda x: x[0], 'filterarch', devs))
 
-    if (len(devlist) == 0):
-        WARNING("Device specification is unknown!")
-    else:
-        INFO('reading device specification {}: found {:4d} #devices', devspec, len(devlist))
+    if len(devlist) == 0:
+        raise SpecSelectionError(f'no devices selected from {devspec}')
+    INFO('reading device specification {}: found {:4d} #devices', devspec, len(devlist))
     if fsweep.check():
         INFO('reading frequency sweep {}: found {:4d} #frequencies', " "*26, len(fsweep.getvals()))
     return devlist, devs
@@ -314,16 +364,32 @@ def get_workloads(wlspec, bsweep, filterwlg, filterwl, filterwli):
                     wl_list += [(wlapi, wl.name, wli_name, wli_cfg, None)]
     INFO('reading workload specification {}: found {:4d} #workloads', wlspec, len(wl_list))
     #for ndx, tmp in enumerate(wl_list): INFO('{}: {}', ndx, tmp)
-    wl_list = apply_filter(wl_list, filterwlg, lambda x: x[0])
-    wl_list = apply_filter(wl_list, filterwl,  lambda x: x[1])
-    wl_list = apply_filter(wl_list, filterwli, lambda x: x[2])
+    # Domains are collected up-front, so each filter is validated against every value the
+    # spec offers rather than against whatever an earlier filter left behind.
+    wlg_domain = {x[0] for x in wl_list}
+    wln_domain = {x[1] for x in wl_list}
+    wli_domain = {x[2] for x in wl_list}
+    wl_list = apply_filter(wl_list, filterwlg, lambda x: x[0], 'filterwlg', wlg_domain)
+    wl_list = apply_filter(wl_list, filterwl,  lambda x: x[1], 'filterwl',  wln_domain)
+    wl_list = apply_filter(wl_list, filterwli, lambda x: x[2], 'filterwli', wli_domain)
     wl_list = sorted(wl_list)
     num_batches   = len(bsweep.getvals()) if bsweep.check() else 1
     num_workloads = len(wl_list) // num_batches
     if num_workloads == 0:
-        WARNING('Number of workloads is 0 - no workloads to run')
-    else:
-        INFO('reading workloads specification {}: found {:4d} #workloads', wlspec, num_workloads)
+        # An empty result means one of two different mistakes, and pointing at the wrong one
+        # sends the reader to the wrong file: with no filters given the spec itself defines
+        # nothing to run, whereas with filters given each named something real (apply_filter
+        # would have raised otherwise) but they share no workload.
+        given = [f'--{name}' for name, val in (('filterwlg', filterwlg),
+                                               ('filterwl',  filterwl),
+                                               ('filterwli', filterwli)) if val is not None]
+        if not given:
+            raise SpecSelectionError(f'{wlspec} defines no workload instances to run')
+        raise SpecSelectionError(
+            f'no workloads selected from {wlspec}: {"/".join(given)} '
+            f'{"is" if len(given) == 1 else "are"} individually valid but select no workload in common'
+        )
+    INFO('reading workloads specification {}: found {:4d} #workloads', wlspec, num_workloads)
     if bsweep.check():
         INFO('reading batch sweep                   : found {} #batch-sizes', num_batches)
     return wl_list, workload_specs
@@ -447,8 +513,18 @@ def polaris(args: argparse.Namespace | runcfgmodel.PolarisRunConfig) -> int:
     os.makedirs(odir,        exist_ok=True)
     os.makedirs(summary_dir, exist_ok=True)
 
-    device_list, devspec  = get_devices(args.archspec, freqsweep, args.filterarch)
-    workload_list, wlspec = get_workloads(args.wlspec, batchsweep, args.filterwlg, args.filterwl, args.filterwli)
+    try:
+        device_list, devspec  = get_devices(args.archspec, freqsweep, args.filterarch)
+        workload_list, wlspec = get_workloads(args.wlspec, batchsweep, args.filterwlg, args.filterwl, args.filterwli)
+    except SpecSelectionError as e:
+        ERROR('{}', e)
+        # Returning here still has to honour --enable_cprofile: the profiler was started
+        # above, and leaving it enabled would follow the caller out of polaris() for the
+        # in-process callers (polproj.py, tests).
+        if args.enable_cprofile:
+            profiler.disable()
+            profiler.dump_stats("polaris_cprofile_stats.prof")
+        return 1
     wlmapspec = get_wlmapspec_from_yaml(args.wlmapspec)
 
     if args.datatype is not None:
@@ -512,11 +588,12 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == '__main__':
     start_time = time.perf_counter()
-    num_exps   = main()
+    status     = main()
     end_time   = time.perf_counter()
     del_time   = end_time - start_time
 
-    if num_exps > 0:
-        logger.info(f"Completed {num_exps} jobs in {del_time:0.2f} seconds @ {num_exps/del_time:.0f} jobs per sec")
-    else:
-        logger.info('')
+    # main() returns a status (0 ok / non-zero failed), not a job count -- the run's own
+    # 'completed with N experiments' line reports the count. Propagate the status, or a
+    # failed run leaves this script exiting 0 and CI cannot see it.
+    logger.info(f"Polaris finished in {del_time:0.2f} seconds")
+    exit(status)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -66,15 +66,17 @@ def test_archname_population():
     assert device.devname == 'Grendel', f"Device.devname should be 'Grendel', got '{device.devname}'"
     assert device.name == 'Q1_A1', f"Device.name should be 'Q1_A1', got '{device.name}'"
 
-    # Test with n150 instance from Wormhole package (if available in config)
-    if 'n150' in packages:
-        n150 = packages['n150']
-        assert n150.devname == 'Wormhole', f"Expected package name 'Wormhole', got '{n150.devname}'"
-        assert n150.name == 'n150', f"Expected instance name 'n150', got '{n150.name}'"
+    # Test with the n150 instance, which lives in the Wormhole spec rather than all_archs.yaml
+    # (this block used to read `if 'n150' in packages:` against the Grendel-only packages
+    # above, so it never ran).
+    _, wh_packages = get_arspec_from_yaml('config/tt_wh.yaml')
+    n150 = wh_packages['n150']
+    assert n150.devname == 'Wormhole', f"Expected package name 'Wormhole', got '{n150.devname}'"
+    assert n150.name == 'n150', f"Expected instance name 'n150', got '{n150.name}'"
 
-        device_wh = Device(n150)
-        assert device_wh.devname == 'Wormhole', f"Device.devname should be 'Wormhole', got '{device_wh.devname}'"
-        assert device_wh.name == 'n150', f"Device.name should be 'n150', got '{device_wh.name}'"
+    device_wh = Device(n150)
+    assert device_wh.devname == 'Wormhole', f"Device.devname should be 'Wormhole', got '{device_wh.devname}'"
+    assert device_wh.name == 'n150', f"Device.name should be 'n150', got '{device_wh.name}'"
 
 @pytest.mark.unit
 def test_archname_in_output():

--- a/tests/test_ops/test_abs.py
+++ b/tests/test_ops/test_abs.py
@@ -322,18 +322,15 @@ def test_abs_memory_validation(capsys, request):
     # Load device configuration once
     polaris_root = Path(__file__).parent.parent.parent
     config_path = polaris_root / "config" / "tt_wh.yaml"
-    try:
-        ipgroups, packages = get_arspec_from_yaml(config_path)
-        device_pkg = packages["n150"]
-        device = Device(device_pkg)
+    ipgroups, packages = get_arspec_from_yaml(config_path)
+    device_pkg = packages["n150"]
+    device = Device(device_pkg)
 
-        logger.info(f"\nDevice: {device.devname} ({device.name})")
-        logger.info(f"Frequency: {device.freq_MHz} MHz")
-        logger.info(
-            f"Peak Bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
-        )
-    except Exception as e:
-        pytest.skip(f"Could not load device config: {e}")
+    logger.info(f"\nDevice: {device.devname} ({device.name})")
+    logger.info(f"Frequency: {device.freq_MHz} MHz")
+    logger.info(
+        f"Peak Bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
+    )
 
     # Test cases: different shapes and value ranges
     test_cases = [

--- a/tests/test_ops/test_argmax.py
+++ b/tests/test_ops/test_argmax.py
@@ -510,21 +510,16 @@ def test_argmax_memory_validation(capsys, request):
 
     # Load device configuration
     config_path = Path(polaris_root) / "config" / "tt_wh.yaml"
-    try:
-        ipgroups, packages = get_arspec_from_yaml(config_path)
-        device_pkg = packages["n150"]
-        device = Device(device_pkg)
+    ipgroups, packages = get_arspec_from_yaml(config_path)
+    device_pkg = packages["n150"]
+    device = Device(device_pkg)
 
-        logger.info(f"\nDevice: {device.devname} ({device.name})")
-        logger.info(f"Device frequency: {device.freq_MHz} MHz")
-        logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
-        logger.info(
-            f"Peak bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
-        )
-    except Exception as e:
-        logger.info(f"\nWarning: Could not load device config: {e}")
-        pytest.skip(f"Could not load device config: {e}")
-        return
+    logger.info(f"\nDevice: {device.devname} ({device.name})")
+    logger.info(f"Device frequency: {device.freq_MHz} MHz")
+    logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
+    logger.info(
+        f"Peak bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
+    )
 
     # Test cases
     test_cases = [

--- a/tests/test_ops/test_argmin.py
+++ b/tests/test_ops/test_argmin.py
@@ -514,21 +514,16 @@ def test_argmin_memory_validation(capsys, request):
 
     # Load device configuration
     config_path = Path(polaris_root) / "config" / "tt_wh.yaml"
-    try:
-        ipgroups, packages = get_arspec_from_yaml(config_path)
-        device_pkg = packages["n150"]
-        device = Device(device_pkg)
+    ipgroups, packages = get_arspec_from_yaml(config_path)
+    device_pkg = packages["n150"]
+    device = Device(device_pkg)
 
-        logger.info(f"\nDevice: {device.devname} ({device.name})")
-        logger.info(f"Device frequency: {device.freq_MHz} MHz")
-        logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
-        logger.info(
-            f"Peak bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
-        )
-    except Exception as e:
-        logger.info(f"\nWarning: Could not load device config: {e}")
-        pytest.skip(f"Could not load device config: {e}")
-        return
+    logger.info(f"\nDevice: {device.devname} ({device.name})")
+    logger.info(f"Device frequency: {device.freq_MHz} MHz")
+    logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
+    logger.info(
+        f"Peak bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
+    )
 
     # Test cases
     test_cases = [

--- a/tests/test_ops/test_atan.py
+++ b/tests/test_ops/test_atan.py
@@ -405,22 +405,16 @@ def test_atan_memory_validation(capsys, request):
 
     # Load device configuration
     config_path = os.path.join(polaris_root, "config", "tt_wh.yaml")
-    try:
-        ipgroups, packages = get_arspec_from_yaml(config_path)
-        device_pkg = packages["n150"]  # Use Wormhole n150 device
-        device = Device(device_pkg)
+    ipgroups, packages = get_arspec_from_yaml(config_path)
+    device_pkg = packages["n150"]  # Use Wormhole n150 device
+    device = Device(device_pkg)
 
-        logger.info(f"\nDevice: {device.devname} ({device.name})")
-        logger.info(f"Device frequency: {device.freq_MHz} MHz")
-        logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
-        logger.info(
-            f"Peak bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
-        )
-    except Exception as e:
-        logger.info(f"\nWarning: Could not load device config: {e}")
-        logger.info("Skipping memory validation test")
-        pytest.skip(f"Could not load device config: {e}")
-        return
+    logger.info(f"\nDevice: {device.devname} ({device.name})")
+    logger.info(f"Device frequency: {device.freq_MHz} MHz")
+    logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
+    logger.info(
+        f"Peak bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
+    )
 
     # Test cases: different shapes for unary operation
     test_cases = [

--- a/tests/test_ops/test_atan2.py
+++ b/tests/test_ops/test_atan2.py
@@ -477,22 +477,16 @@ def test_atan2_memory_validation(capsys, request):
 
     # Load device configuration
     config_path = os.path.join(polaris_root, "config", "tt_wh.yaml")
-    try:
-        ipgroups, packages = get_arspec_from_yaml(config_path)
-        device_pkg = packages["n150"]  # Use Wormhole n150 device
-        device = Device(device_pkg)
+    ipgroups, packages = get_arspec_from_yaml(config_path)
+    device_pkg = packages["n150"]  # Use Wormhole n150 device
+    device = Device(device_pkg)
 
-        logger.info(f"\nDevice: {device.devname} ({device.name})")
-        logger.info(f"Device frequency: {device.freq_MHz} MHz")
-        logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
-        logger.info(
-            f"Peak bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
-        )
-    except Exception as e:
-        logger.info(f"\nWarning: Could not load device config: {e}")
-        logger.info("Skipping memory validation test")
-        pytest.skip(f"Could not load device config: {e}")
-        return
+    logger.info(f"\nDevice: {device.devname} ({device.name})")
+    logger.info(f"Device frequency: {device.freq_MHz} MHz")
+    logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
+    logger.info(
+        f"Peak bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
+    )
 
     # Test cases: different shapes and broadcasting scenarios for binary operation
     test_cases = [

--- a/tests/test_ops/test_batchnorm_new.py
+++ b/tests/test_ops/test_batchnorm_new.py
@@ -973,22 +973,16 @@ def test_batchnorm_memory_validation(capsys, request):
 
     # Load device configuration
     config_path = os.path.join(polaris_root, "config", "tt_wh.yaml")
-    try:
-        ipgroups, packages = get_arspec_from_yaml(config_path)
-        device_pkg = packages["n150"]  # Use Wormhole n150 device
-        device = Device(device_pkg)
+    ipgroups, packages = get_arspec_from_yaml(config_path)
+    device_pkg = packages["n150"]  # Use Wormhole n150 device
+    device = Device(device_pkg)
 
-        logger.debug(f"\nDevice: {device.devname} ({device.name})")
-        logger.debug(f"Device frequency: {device.freq_MHz} MHz")
-        logger.debug(f"Memory frequency: {device.memfreq_MHz} MHz")
-        logger.debug(
-            f"Peak bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
-        )
-    except Exception as e:
-        logger.info(f"\nWarning: Could not load device config: {e}")
-        logger.info("Skipping memory validation test")
-        pytest.skip(f"Could not load device config: {e}")
-        return
+    logger.debug(f"\nDevice: {device.devname} ({device.name})")
+    logger.debug(f"Device frequency: {device.freq_MHz} MHz")
+    logger.debug(f"Memory frequency: {device.memfreq_MHz} MHz")
+    logger.debug(
+        f"Peak bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
+    )
 
     # Test cases: various batchnorm configurations
     test_cases = [

--- a/tests/test_ops/test_conv_transpose2d.py
+++ b/tests/test_ops/test_conv_transpose2d.py
@@ -677,19 +677,16 @@ def test_conv_transpose2d_memory_validation(capsys, request):
 
     # Load device configuration once
     config_path = Path(polaris_root) / "config" / "tt_wh.yaml"
-    try:
-        ipgroups, packages = get_arspec_from_yaml(config_path)
-        device_pkg = packages["n150"]
-        device = Device(device_pkg)
+    ipgroups, packages = get_arspec_from_yaml(config_path)
+    device_pkg = packages["n150"]
+    device = Device(device_pkg)
 
-        logger.info(f"\nDevice: {device.devname} ({device.name})")
-        logger.info(f"Frequency: {device.freq_MHz} MHz")
-        logger.info(
-            "Peak Bandwidth: %.2f GB/s",
-            device.simconfig_obj.peak_bandwidth(freq_units="GHz"),
-        )
-    except Exception as e:
-        pytest.skip(f"Could not load device config: {e}")
+    logger.info(f"\nDevice: {device.devname} ({device.name})")
+    logger.info(f"Frequency: {device.freq_MHz} MHz")
+    logger.info(
+        "Peak Bandwidth: %.2f GB/s",
+        device.simconfig_obj.peak_bandwidth(freq_units="GHz"),
+    )
 
     # Test cases covering different ConvTranspose2d scenarios
     test_cases = [

--- a/tests/test_ops/test_cos.py
+++ b/tests/test_ops/test_cos.py
@@ -426,26 +426,20 @@ def test_cos_memory_validation(capsys, request):
 
     # Load device configuration once for all tests
     config_path = Path(polaris_root) / "config" / "tt_wh.yaml"
-    try:
-        ipgroups, packages = get_arspec_from_yaml(config_path)
-        device_pkg = packages["n150"]  # Use Wormhole n150 device
-        device = Device(device_pkg)
+    ipgroups, packages = get_arspec_from_yaml(config_path)
+    device_pkg = packages["n150"]  # Use Wormhole n150 device
+    device = Device(device_pkg)
 
-        logger.info("\n%s", "=" * 60)
-        logger.info("Cos Operation Memory Validation")
-        logger.info("%s\n", "=" * 60)
-        logger.info("Device: Wormhole (n150)")
-        logger.info(f"Device frequency: {device.freq_MHz} MHz")
-        logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
-        logger.info(
-            "Peak bandwidth: %.2f GB/s",
-            device.simconfig_obj.peak_bandwidth(freq_units="GHz"),
-        )
-    except Exception as e:
-        logger.info(f"\nWarning: Could not load device config: {e}")
-        logger.info("Skipping memory validation test")
-        pytest.skip(f"Could not load device config: {e}")
-        return
+    logger.info("\n%s", "=" * 60)
+    logger.info("Cos Operation Memory Validation")
+    logger.info("%s\n", "=" * 60)
+    logger.info("Device: Wormhole (n150)")
+    logger.info(f"Device frequency: {device.freq_MHz} MHz")
+    logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
+    logger.info(
+        "Peak bandwidth: %.2f GB/s",
+        device.simconfig_obj.peak_bandwidth(freq_units="GHz"),
+    )
 
     logger.info("\n%s", "=" * 60)
     logger.info("Running Memory Validation Tests")

--- a/tests/test_ops/test_elementwise_mean.py
+++ b/tests/test_ops/test_elementwise_mean.py
@@ -555,22 +555,17 @@ class TestMeanMemoryValidation:
 
         # Load device configuration
         config_path = Path(polaris_root) / "config" / "tt_wh.yaml"
-        try:
-            ipgroups, packages = get_arspec_from_yaml(config_path)
-            device_pkg = packages["n150"]
-            device = Device(device_pkg)
+        ipgroups, packages = get_arspec_from_yaml(config_path)
+        device_pkg = packages["n150"]
+        device = Device(device_pkg)
 
-            logger.info(f"\nDevice: {device.devname} ({device.name})")
-            logger.info(f"Device frequency: {device.freq_MHz} MHz")
-            logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
-            logger.info(
-                "Peak bandwidth: %.2f GB/s",
-                device.simconfig_obj.peak_bandwidth(freq_units="GHz"),
-            )
-        except Exception as e:
-            logger.info(f"\nWarning: Could not load device config: {e}")
-            pytest.skip(f"Could not load device config: {e}")
-            return
+        logger.info(f"\nDevice: {device.devname} ({device.name})")
+        logger.info(f"Device frequency: {device.freq_MHz} MHz")
+        logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
+        logger.info(
+            "Peak bandwidth: %.2f GB/s",
+            device.simconfig_obj.peak_bandwidth(freq_units="GHz"),
+        )
 
         logger.info("\n%s", "=" * 60)
         logger.info("Running Memory Validation Tests")

--- a/tests/test_ops/test_elementwise_minmax.py
+++ b/tests/test_ops/test_elementwise_minmax.py
@@ -519,19 +519,16 @@ def test_minmax_memory_validation(capsys, request):
 
     # Load device configuration once
     config_path = Path(polaris_root) / "config" / "tt_wh.yaml"
-    try:
-        ipgroups, packages = get_arspec_from_yaml(config_path)
-        device_pkg = packages["n150"]
-        device = Device(device_pkg)
+    ipgroups, packages = get_arspec_from_yaml(config_path)
+    device_pkg = packages["n150"]
+    device = Device(device_pkg)
 
-        logger.info(f"\nDevice: {device.devname} ({device.name})")
-        logger.info(f"Frequency: {device.freq_MHz} MHz")
-        logger.info(
-            "Peak Bandwidth: %.2f GB/s",
-            device.simconfig_obj.peak_bandwidth(freq_units="GHz"),
-        )
-    except Exception as e:
-        pytest.skip(f"Could not load device config: {e}")
+    logger.info(f"\nDevice: {device.devname} ({device.name})")
+    logger.info(f"Frequency: {device.freq_MHz} MHz")
+    logger.info(
+        "Peak Bandwidth: %.2f GB/s",
+        device.simconfig_obj.peak_bandwidth(freq_units="GHz"),
+    )
 
     # Test cases covering both Max and Min operations
     test_cases = [

--- a/tests/test_ops/test_elementwise_sum.py
+++ b/tests/test_ops/test_elementwise_sum.py
@@ -559,22 +559,17 @@ class TestSumMemoryValidation:
 
         # Load device configuration
         config_path = Path(polaris_root) / "config" / "tt_wh.yaml"
-        try:
-            ipgroups, packages = get_arspec_from_yaml(config_path)
-            device_pkg = packages["n150"]
-            device = Device(device_pkg)
+        ipgroups, packages = get_arspec_from_yaml(config_path)
+        device_pkg = packages["n150"]
+        device = Device(device_pkg)
 
-            logger.info(f"\nDevice: {device.devname} ({device.name})")
-            logger.info(f"Device frequency: {device.freq_MHz} MHz")
-            logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
-            logger.info(
-                "Peak bandwidth: %.2f GB/s",
-                device.simconfig_obj.peak_bandwidth(freq_units="GHz"),
-            )
-        except Exception as e:
-            logger.info(f"\nWarning: Could not load device config: {e}")
-            pytest.skip(f"Could not load device config: {e}")
-            return
+        logger.info(f"\nDevice: {device.devname} ({device.name})")
+        logger.info(f"Device frequency: {device.freq_MHz} MHz")
+        logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
+        logger.info(
+            "Peak bandwidth: %.2f GB/s",
+            device.simconfig_obj.peak_bandwidth(freq_units="GHz"),
+        )
 
         logger.info("\n%s", "=" * 60)
         logger.info("Running Memory Validation Tests")

--- a/tests/test_ops/test_gather.py
+++ b/tests/test_ops/test_gather.py
@@ -145,22 +145,17 @@ def test_gather_memory_validation(capsys, request):
 
     # Load device configuration
     config_path = Path(polaris_root) / "config" / "tt_wh.yaml"
-    try:
-        ipgroups, packages = get_arspec_from_yaml(config_path)
-        device_pkg = packages["n150"]
-        device = Device(device_pkg)
+    ipgroups, packages = get_arspec_from_yaml(config_path)
+    device_pkg = packages["n150"]
+    device = Device(device_pkg)
 
-        logger.info(f"\nDevice: {device.devname} ({device.name})")
-        logger.info(f"Device frequency: {device.freq_MHz} MHz")
-        logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
-        logger.info(
-            "Peak bandwidth: %.2f GB/s",
-            device.simconfig_obj.peak_bandwidth(freq_units="GHz"),
-        )
-    except Exception as e:
-        logger.info(f"\nWarning: Could not load device config: {e}")
-        pytest.skip(f"Could not load device config: {e}")
-        return
+    logger.info(f"\nDevice: {device.devname} ({device.name})")
+    logger.info(f"Device frequency: {device.freq_MHz} MHz")
+    logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
+    logger.info(
+        "Peak bandwidth: %.2f GB/s",
+        device.simconfig_obj.peak_bandwidth(freq_units="GHz"),
+    )
 
     # Test cases: different gather patterns
     test_cases = [

--- a/tests/test_ops/test_grid_sample.py
+++ b/tests/test_ops/test_grid_sample.py
@@ -615,22 +615,17 @@ def test_gridsample_memory_validation(capsys, request):
 
     # Load device configuration
     config_path = Path(polaris_root) / "config" / "tt_wh.yaml"
-    try:
-        ipgroups, packages = get_arspec_from_yaml(config_path)
-        device_pkg = packages["n150"]
-        device = Device(device_pkg)
+    ipgroups, packages = get_arspec_from_yaml(config_path)
+    device_pkg = packages["n150"]
+    device = Device(device_pkg)
 
-        logger.info(f"\nDevice: {device.devname} ({device.name})")
-        logger.info(f"Device frequency: {device.freq_MHz} MHz")
-        logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
-        logger.info(
-            "Peak bandwidth: %.2f GB/s",
-            device.simconfig_obj.peak_bandwidth(freq_units="GHz"),
-        )
-    except Exception as e:
-        logger.info(f"\nWarning: Could not load device config: {e}")
-        pytest.skip(f"Could not load device config: {e}")
-        return
+    logger.info(f"\nDevice: {device.devname} ({device.name})")
+    logger.info(f"Device frequency: {device.freq_MHz} MHz")
+    logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
+    logger.info(
+        "Peak bandwidth: %.2f GB/s",
+        device.simconfig_obj.peak_bandwidth(freq_units="GHz"),
+    )
 
     # Test cases
     test_cases = [

--- a/tests/test_ops/test_gridsample.py
+++ b/tests/test_ops/test_gridsample.py
@@ -615,21 +615,16 @@ def test_gridsample_memory_validation(capsys, request):
 
     # Load device configuration
     config_path = Path(polaris_root) / "config" / "tt_wh.yaml"
-    try:
-        ipgroups, packages = get_arspec_from_yaml(config_path)
-        device_pkg = packages["n150"]
-        device = Device(device_pkg)
+    ipgroups, packages = get_arspec_from_yaml(config_path)
+    device_pkg = packages["n150"]
+    device = Device(device_pkg)
 
-        logger.debug(f"\nDevice: {device.devname} ({device.name})")
-        logger.debug(f"Device frequency: {device.freq_MHz} MHz")
-        logger.debug(f"Memory frequency: {device.memfreq_MHz} MHz")
-        logger.debug(
-            f"Peak bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
-        )
-    except Exception as e:
-        logger.info(f"\nWarning: Could not load device config: {e}")
-        pytest.skip(f"Could not load device config: {e}")
-        return
+    logger.debug(f"\nDevice: {device.devname} ({device.name})")
+    logger.debug(f"Device frequency: {device.freq_MHz} MHz")
+    logger.debug(f"Memory frequency: {device.memfreq_MHz} MHz")
+    logger.debug(
+        f"Peak bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
+    )
 
     # Test cases
     test_cases = [

--- a/tests/test_ops/test_groupnorm.py
+++ b/tests/test_ops/test_groupnorm.py
@@ -430,18 +430,15 @@ def test_groupnorm_memory_validation(capsys, request):
     # Load device configuration once
     polaris_root = Path(__file__).parent.parent.parent
     config_path = polaris_root / "config" / "tt_wh.yaml"
-    try:
-        ipgroups, packages = get_arspec_from_yaml(config_path)
-        device_pkg = packages["n150"]
-        device = Device(device_pkg)
+    ipgroups, packages = get_arspec_from_yaml(config_path)
+    device_pkg = packages["n150"]
+    device = Device(device_pkg)
 
-        logger.debug(f"\nDevice: {device.devname} ({device.name})")
-        logger.debug(f"Frequency: {device.freq_MHz} MHz")
-        logger.debug(
-            f"Peak Bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
-        )
-    except Exception as e:
-        pytest.skip(f"Could not load device config: {e}")
+    logger.debug(f"\nDevice: {device.devname} ({device.name})")
+    logger.debug(f"Frequency: {device.freq_MHz} MHz")
+    logger.debug(
+        f"Peak Bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
+    )
 
     # Test cases: different tensor shapes and group configurations
     test_cases = [

--- a/tests/test_ops/test_layernorm.py
+++ b/tests/test_ops/test_layernorm.py
@@ -287,18 +287,15 @@ def test_layernorm_memory_validation(capsys, request):
     # Load device configuration once
     polaris_root = Path(__file__).parent.parent.parent
     config_path = polaris_root / "config" / "tt_wh.yaml"
-    try:
-        ipgroups, packages = get_arspec_from_yaml(config_path)
-        device_pkg = packages["n150"]
-        device = Device(device_pkg)
+    ipgroups, packages = get_arspec_from_yaml(config_path)
+    device_pkg = packages["n150"]
+    device = Device(device_pkg)
 
-        logger.debug(f"\nDevice: {device.devname} ({device.name})")
-        logger.debug(f"Frequency: {device.freq_MHz} MHz")
-        logger.debug(
-            f"Peak Bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
-        )
-    except Exception as e:
-        pytest.skip(f"Could not load device config: {e}")
+    logger.debug(f"\nDevice: {device.devname} ({device.name})")
+    logger.debug(f"Frequency: {device.freq_MHz} MHz")
+    logger.debug(
+        f"Peak Bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
+    )
 
     # Test cases: different tensor shapes and normalization axes
     test_cases = [

--- a/tests/test_ops/test_less.py
+++ b/tests/test_ops/test_less.py
@@ -412,26 +412,20 @@ class TestLessMemoryValidation:
 
         # Load device configuration once for all tests
         config_path = Path(polaris_root) / "config" / "tt_wh.yaml"
-        try:
-            ipgroups, packages = get_arspec_from_yaml(config_path)
-            device_pkg = packages["n150"]  # Use Wormhole n150 device
-            device = Device(device_pkg)
+        ipgroups, packages = get_arspec_from_yaml(config_path)
+        device_pkg = packages["n150"]  # Use Wormhole n150 device
+        device = Device(device_pkg)
 
-            logger.info(f"\n{'='*60}")
-            logger.info("Less Operation Memory Validation")
-            logger.info(f"{'='*60}\n")
-            logger.info("Device: Wormhole (n150)")
-            logger.info(f"Device frequency: {device.freq_MHz} MHz")
-            logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
-            logger.info(
-                "Peak bandwidth: "
-                f"{device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
-            )
-        except Exception as e:
-            logger.info(f"\nWarning: Could not load device config: {e}")
-            logger.info("Skipping memory validation test")
-            pytest.skip(f"Could not load device config: {e}")
-            return
+        logger.info(f"\n{'='*60}")
+        logger.info("Less Operation Memory Validation")
+        logger.info(f"{'='*60}\n")
+        logger.info("Device: Wormhole (n150)")
+        logger.info(f"Device frequency: {device.freq_MHz} MHz")
+        logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
+        logger.info(
+            "Peak bandwidth: "
+            f"{device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
+        )
 
         logger.info(f"\n{'='*60}")
         logger.info("Running Memory Validation Tests")

--- a/tests/test_ops/test_neg.py
+++ b/tests/test_ops/test_neg.py
@@ -399,25 +399,19 @@ class TestNegMemoryValidation:
 
         # Load device configuration once for all tests
         config_path = Path(polaris_root) / "config" / "tt_wh.yaml"
-        try:
-            ipgroups, packages = get_arspec_from_yaml(config_path)
-            device_pkg = packages["n150"]  # Use Wormhole n150 device
-            device = Device(device_pkg)
+        ipgroups, packages = get_arspec_from_yaml(config_path)
+        device_pkg = packages["n150"]  # Use Wormhole n150 device
+        device = Device(device_pkg)
 
-            logger.info(f"\n{'='*60}")
-            logger.info("Neg Operation Memory Validation")
-            logger.info(f"{'='*60}\n")
-            logger.debug("Device: Wormhole (n150)")
-            logger.debug(f"Device frequency: {device.freq_MHz} MHz")
-            logger.debug(f"Memory frequency: {device.memfreq_MHz} MHz")
-            logger.debug(
-                f"Peak bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
-            )
-        except Exception as e:
-            logger.info(f"\nWarning: Could not load device config: {e}")
-            logger.info("Skipping memory validation test")
-            pytest.skip(f"Could not load device config: {e}")
-            return
+        logger.info(f"\n{'='*60}")
+        logger.info("Neg Operation Memory Validation")
+        logger.info(f"{'='*60}\n")
+        logger.debug("Device: Wormhole (n150)")
+        logger.debug(f"Device frequency: {device.freq_MHz} MHz")
+        logger.debug(f"Memory frequency: {device.memfreq_MHz} MHz")
+        logger.debug(
+            f"Peak bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
+        )
 
         logger.info(f"\n{'='*60}")
         logger.info("Running Memory Validation Tests")

--- a/tests/test_ops/test_reducemax.py
+++ b/tests/test_ops/test_reducemax.py
@@ -532,23 +532,17 @@ class TestReduceMaxMemoryValidation:
 
         # Load device configuration
         config_path = Path(polaris_root) / "config" / "tt_wh.yaml"
-        try:
-            ipgroups, packages = get_arspec_from_yaml(config_path)
-            device_pkg = packages["n150"]  # Use Wormhole n150 device
-            device = Device(device_pkg)
+        ipgroups, packages = get_arspec_from_yaml(config_path)
+        device_pkg = packages["n150"]  # Use Wormhole n150 device
+        device = Device(device_pkg)
 
-            logger.info(f"\nDevice: {device.devname} ({device.name})")
-            logger.info(f"Device frequency: {device.freq_MHz} MHz")
-            logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
-            logger.info(
-                "Peak bandwidth: "
-                f"{device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
-            )
-        except Exception as e:
-            logger.info(f"\nWarning: Could not load device config: {e}")
-            logger.info("Skipping memory validation test")
-            pytest.skip(f"Could not load device config: {e}")
-            return
+        logger.info(f"\nDevice: {device.devname} ({device.name})")
+        logger.info(f"Device frequency: {device.freq_MHz} MHz")
+        logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
+        logger.info(
+            "Peak bandwidth: "
+            f"{device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
+        )
 
         logger.info(f"\n{'='*60}")
         logger.info("Running Memory Validation Tests")

--- a/tests/test_ops/test_reducesum.py
+++ b/tests/test_ops/test_reducesum.py
@@ -538,23 +538,17 @@ class TestReduceSumMemoryValidation:
 
         # Load device configuration
         config_path = Path(polaris_root) / "config" / "tt_wh.yaml"
-        try:
-            ipgroups, packages = get_arspec_from_yaml(config_path)
-            device_pkg = packages["n150"]  # Use Wormhole n150 device
-            device = Device(device_pkg)
+        ipgroups, packages = get_arspec_from_yaml(config_path)
+        device_pkg = packages["n150"]  # Use Wormhole n150 device
+        device = Device(device_pkg)
 
-            logger.info(f"\nDevice: {device.devname} ({device.name})")
-            logger.info(f"Device frequency: {device.freq_MHz} MHz")
-            logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
-            logger.info(
-                "Peak bandwidth: "
-                f"{device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
-            )
-        except Exception as e:
-            logger.info(f"\nWarning: Could not load device config: {e}")
-            logger.info("Skipping memory validation test")
-            pytest.skip(f"Could not load device config: {e}")
-            return
+        logger.info(f"\nDevice: {device.devname} ({device.name})")
+        logger.info(f"Device frequency: {device.freq_MHz} MHz")
+        logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
+        logger.info(
+            "Peak bandwidth: "
+            f"{device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
+        )
 
         logger.info(f"\n{'='*60}")
         logger.info("Running Memory Validation Tests")

--- a/tests/test_ops/test_scatter_nd.py
+++ b/tests/test_ops/test_scatter_nd.py
@@ -440,19 +440,16 @@ def test_scatter_nd_memory_validation(capsys, request):
     # Load device configuration once
     polaris_root = Path(__file__).parent.parent.parent
     config_path = polaris_root / "config" / "tt_wh.yaml"
-    try:
-        ipgroups, packages = get_arspec_from_yaml(config_path)
-        device_pkg = packages["n150"]
-        device = Device(device_pkg)
+    ipgroups, packages = get_arspec_from_yaml(config_path)
+    device_pkg = packages["n150"]
+    device = Device(device_pkg)
 
-        logger.info(f"\nDevice: {device.devname} ({device.name})")
-        logger.info(f"Frequency: {device.freq_MHz} MHz")
-        logger.info(
-            "Peak Bandwidth: "
-            f"{device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
-        )
-    except Exception as e:
-        pytest.skip(f"Could not load device config: {e}")
+    logger.info(f"\nDevice: {device.devname} ({device.name})")
+    logger.info(f"Frequency: {device.freq_MHz} MHz")
+    logger.info(
+        "Peak Bandwidth: "
+        f"{device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
+    )
 
     # Test cases: different scatter patterns
     test_cases = [

--- a/tests/test_ops/test_sin.py
+++ b/tests/test_ops/test_sin.py
@@ -412,25 +412,19 @@ def test_sin_memory_validation(capsys, request):
 
     # Load device configuration once for all tests
     config_path = Path(polaris_root) / "config" / "tt_wh.yaml"
-    try:
-        ipgroups, packages = get_arspec_from_yaml(config_path)
-        device_pkg = packages["n150"]  # Use Wormhole n150 device
-        device = Device(device_pkg)
+    ipgroups, packages = get_arspec_from_yaml(config_path)
+    device_pkg = packages["n150"]  # Use Wormhole n150 device
+    device = Device(device_pkg)
 
-        logger.info(f"\n{'='*60}")
-        logger.info("Sin Operation Memory Validation")
-        logger.info(f"{'='*60}\n")
-        logger.debug("Device: Wormhole (n150)")
-        logger.debug(f"Device frequency: {device.freq_MHz} MHz")
-        logger.debug(f"Memory frequency: {device.memfreq_MHz} MHz")
-        logger.debug(
-            f"Peak bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
-        )
-    except Exception as e:
-        logger.info(f"\nWarning: Could not load device config: {e}")
-        logger.info("Skipping memory validation test")
-        pytest.skip(f"Could not load device config: {e}")
-        return
+    logger.info(f"\n{'='*60}")
+    logger.info("Sin Operation Memory Validation")
+    logger.info(f"{'='*60}\n")
+    logger.debug("Device: Wormhole (n150)")
+    logger.debug(f"Device frequency: {device.freq_MHz} MHz")
+    logger.debug(f"Memory frequency: {device.memfreq_MHz} MHz")
+    logger.debug(
+        f"Peak bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
+    )
 
     logger.info(f"\n{'='*60}")
     logger.info("Running Memory Validation Tests")

--- a/tests/test_ops/test_sqrt.py
+++ b/tests/test_ops/test_sqrt.py
@@ -541,22 +541,16 @@ def test_sqrt_memory_validation(capsys, request):
 
     # Load device configuration
     config_path = Path(polaris_root) / "config" / "tt_wh.yaml"
-    try:
-        ipgroups, packages = get_arspec_from_yaml(config_path)
-        device_pkg = packages["n150"]  # Use Wormhole n150 device
-        device = Device(device_pkg)
+    ipgroups, packages = get_arspec_from_yaml(config_path)
+    device_pkg = packages["n150"]  # Use Wormhole n150 device
+    device = Device(device_pkg)
 
-        logger.info(f"\nDevice: {device.devname} ({device.name})")
-        logger.info(f"Device frequency: {device.freq_MHz} MHz")
-        logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
-        logger.info(
-            f"Peak bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
-        )
-    except Exception as e:
-        logger.info(f"\nWarning: Could not load device config: {e}")
-        logger.info("Skipping memory validation test")
-        pytest.skip(f"Could not load device config: {e}")
-        return
+    logger.info(f"\nDevice: {device.devname} ({device.name})")
+    logger.info(f"Device frequency: {device.freq_MHz} MHz")
+    logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
+    logger.info(
+        f"Peak bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
+    )
 
     # Test cases: different shapes
     test_cases = [

--- a/tests/test_ops/test_squeeze.py
+++ b/tests/test_ops/test_squeeze.py
@@ -446,21 +446,16 @@ def test_squeeze_memory_validation(capsys, request):
 
     # Load device configuration
     config_path = Path(polaris_root) / "config" / "tt_wh.yaml"
-    try:
-        ipgroups, packages = get_arspec_from_yaml(config_path)
-        device_pkg = packages["n150"]
-        device = Device(device_pkg)
+    ipgroups, packages = get_arspec_from_yaml(config_path)
+    device_pkg = packages["n150"]
+    device = Device(device_pkg)
 
-        logger.info(f"\nDevice: {device.devname} ({device.name})")
-        logger.info(f"Device frequency: {device.freq_MHz} MHz")
-        logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
-        logger.info(
-            f"Peak bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
-        )
-    except Exception as e:
-        logger.info(f"\nWarning: Could not load device config: {e}")
-        pytest.skip(f"Could not load device config: {e}")
-        return
+    logger.info(f"\nDevice: {device.devname} ({device.name})")
+    logger.info(f"Device frequency: {device.freq_MHz} MHz")
+    logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
+    logger.info(
+        f"Peak bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
+    )
 
     # Test cases
     test_cases = [

--- a/tests/test_ops/test_sub.py
+++ b/tests/test_ops/test_sub.py
@@ -650,25 +650,19 @@ def test_sub_memory_validation(capsys, request):
 
     # Load device configuration once for all tests
     config_path = Path(polaris_root) / "config" / "tt_wh.yaml"
-    try:
-        ipgroups, packages = get_arspec_from_yaml(config_path)
-        device_pkg = packages["n150"]  # Use Wormhole n150 device
-        device = Device(device_pkg)
+    ipgroups, packages = get_arspec_from_yaml(config_path)
+    device_pkg = packages["n150"]  # Use Wormhole n150 device
+    device = Device(device_pkg)
 
-        logger.info(f"\n{'='*60}")
-        logger.info("Sub Operation Memory Validation")
-        logger.info(f"{'='*60}\n")
-        logger.info("Device: Wormhole (n150)")
-        logger.info(f"Device frequency: {device.freq_MHz} MHz")
-        logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
-        logger.info(
-            f"Peak bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
-        )
-    except Exception as e:
-        logger.info(f"\nWarning: Could not load device config: {e}")
-        logger.info("Skipping memory validation test")
-        pytest.skip(f"Could not load device config: {e}")
-        return
+    logger.info(f"\n{'='*60}")
+    logger.info("Sub Operation Memory Validation")
+    logger.info(f"{'='*60}\n")
+    logger.info("Device: Wormhole (n150)")
+    logger.info(f"Device frequency: {device.freq_MHz} MHz")
+    logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
+    logger.info(
+        f"Peak bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
+    )
 
     logger.info(f"\n{'='*60}")
     logger.info("Running Memory Validation Tests")

--- a/tests/test_ops/test_tanh.py
+++ b/tests/test_ops/test_tanh.py
@@ -506,25 +506,19 @@ def test_tanh_memory_validation(capsys, request):
 
     # Load device configuration once for all tests
     config_path = Path(polaris_root) / "config" / "tt_wh.yaml"
-    try:
-        ipgroups, packages = get_arspec_from_yaml(config_path)
-        device_pkg = packages["n150"]  # Use Wormhole n150 device
-        device = Device(device_pkg)
+    ipgroups, packages = get_arspec_from_yaml(config_path)
+    device_pkg = packages["n150"]  # Use Wormhole n150 device
+    device = Device(device_pkg)
 
-        logger.info(f"\n{'='*60}")
-        logger.info("Tanh Operation Memory Validation")
-        logger.info(f"{'='*60}\n")
-        logger.info("Device: Wormhole (n150)")
-        logger.info(f"Device frequency: {device.freq_MHz} MHz")
-        logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
-        logger.info(
-            f"Peak bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
-        )
-    except Exception as e:
-        logger.info(f"\nWarning: Could not load device config: {e}")
-        logger.info("Skipping memory validation test")
-        pytest.skip(f"Could not load device config: {e}")
-        return
+    logger.info(f"\n{'='*60}")
+    logger.info("Tanh Operation Memory Validation")
+    logger.info(f"{'='*60}\n")
+    logger.info("Device: Wormhole (n150)")
+    logger.info(f"Device frequency: {device.freq_MHz} MHz")
+    logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
+    logger.info(
+        f"Peak bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
+    )
 
     logger.info(f"\n{'='*60}")
     logger.info("Running Memory Validation Tests")

--- a/tests/test_ops/test_transpose.py
+++ b/tests/test_ops/test_transpose.py
@@ -469,18 +469,15 @@ def test_transpose_memory_validation(capsys, request):
 
     # Load device configuration once
     config_path = Path(polaris_root) / "config" / "tt_wh.yaml"
-    try:
-        ipgroups, packages = get_arspec_from_yaml(config_path)
-        device_pkg = packages["n150"]
-        device = Device(device_pkg)
+    ipgroups, packages = get_arspec_from_yaml(config_path)
+    device_pkg = packages["n150"]
+    device = Device(device_pkg)
 
-        logger.info(f"\nDevice: {device.devname} ({device.name})")
-        logger.info(f"Frequency: {device.freq_MHz} MHz")
-        logger.info(
-            f"Peak Bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
-        )
-    except Exception as e:
-        pytest.skip(f"Could not load device config: {e}")
+    logger.info(f"\nDevice: {device.devname} ({device.name})")
+    logger.info(f"Frequency: {device.freq_MHz} MHz")
+    logger.info(
+        f"Peak Bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
+    )
 
     # Test cases: different shapes and permutation patterns
     test_cases = [

--- a/tests/test_ops/test_unsqueeze.py
+++ b/tests/test_ops/test_unsqueeze.py
@@ -525,116 +525,108 @@ class TestUnsqueezeMemory:
     @pytest.mark.performance
     def test_unsqueeze_memory_performance(self, capsys):
         """Benchmark Unsqueeze operation memory performance: NumPy vs ttsim."""
-        try:
-            # Load device config
-            polaris_root = Path(__file__).parent.parent.parent
-            config_path = polaris_root / "config" / "tt_wh.yaml"
-            ipgroups, packages = get_arspec_from_yaml(config_path)
-            device_pkg = packages["n150"]
-            device = Device(device_pkg)
+        if not MEMORY_TEST_AVAILABLE:
+            pytest.skip("Device config not available for memory estimation")
 
-            # Test data - medium sized tensor with multiple axes
-            test_data = np.random.randn(64, 128).astype(np.float32)
-            test_axes = [0, 3]  # Insert dims at positions 0 and 3
+        # Load device config
+        polaris_root = Path(__file__).parent.parent.parent
+        config_path = polaris_root / "config" / "tt_wh.yaml"
+        ipgroups, packages = get_arspec_from_yaml(config_path)
+        device_pkg = packages["n150"]
+        device = Device(device_pkg)
 
-            logger.info(f"\n{'='*70}")
-            logger.info("Unsqueeze Operation Memory Performance")
-            logger.info(f"{'='*70}")
-            logger.info(f"\nDevice: {device.devname} ({device.name})")
-            logger.info(f"Compute frequency: {device.freq_MHz} MHz")
-            logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
-            logger.info(f"Test data shape: {test_data.shape}")
-            logger.info(f"Axes to unsqueeze: {test_axes}")
+        # Test data - medium sized tensor with multiple axes
+        test_data = np.random.randn(64, 128).astype(np.float32)
+        test_axes = [0, 3]  # Insert dims at positions 0 and 3
 
-            # Benchmark NumPy
-            numpy_stats = self._calculate_numpy_memory_stats(
-                test_data, test_axes, iterations=100
-            )
+        logger.info(f"\n{'='*70}")
+        logger.info("Unsqueeze Operation Memory Performance")
+        logger.info(f"{'='*70}")
+        logger.info(f"\nDevice: {device.devname} ({device.name})")
+        logger.info(f"Compute frequency: {device.freq_MHz} MHz")
+        logger.info(f"Memory frequency: {device.memfreq_MHz} MHz")
+        logger.info(f"Test data shape: {test_data.shape}")
+        logger.info(f"Axes to unsqueeze: {test_axes}")
 
-            # Benchmark ttsim
-            ttsim_stats = self._calculate_ttsim_memory_stats(
-                test_data, test_axes, device
-            )
+        # Benchmark NumPy
+        numpy_stats = self._calculate_numpy_memory_stats(
+            test_data, test_axes, iterations=100
+        )
 
-            if ttsim_stats is None:
-                logger.info(
-                    "\nWarning: Could not calculate ttsim memory stats (perf_stats unavailable)"
-                )
-                return
+        # Benchmark ttsim
+        ttsim_stats = self._calculate_ttsim_memory_stats(
+            test_data, test_axes, device
+        )
 
-            # Display comparison
-            logger.info(f"\n{'='*60}")
-            logger.info("Memory Performance Comparison")
-            logger.info(f"{'='*60}")
-
-            logger.info("\n-- Execution Time --")
-            logger.info(f"NumPy:  {numpy_stats['execution_time_ms']:.6f} ms")
-            logger.info(f"ttsim:  {ttsim_stats['execution_time_ms']:.6f} ms")
-
-            logger.info("\n-- Throughput (Inferences/sec) --")
-            logger.info(f"NumPy:  {numpy_stats['inferences_per_sec']:.2f}")
-            logger.info(f"ttsim:  {ttsim_stats['inferences_per_sec']:.2f}")
-
-            logger.info("\n-- Data Movement --")
-            logger.info(f"NumPy:  {numpy_stats['data_movement_MB']:.3f} MB")
-            logger.info(f"ttsim:  {ttsim_stats['data_movement_MB']:.3f} MB")
-
-            logger.info("\n-- Total Operations --")
-            logger.info(f"NumPy:  {numpy_stats['total_operations']:,}")
-            logger.info(f"ttsim:  {ttsim_stats['total_operations']:,}")
-
-            logger.info("\n-- Arithmetic Intensity (ops/byte) --")
-            logger.info(f"NumPy:  {numpy_stats['arithmetic_intensity']:.4f}")
-            logger.info(f"ttsim:  {ttsim_stats['arithmetic_intensity']:.4f}")
-
-            logger.info("\n-- ttsim-Only Memory Analysis --")
+        if ttsim_stats is None:
             logger.info(
-                f"Memory Efficiency (vs Effective):  {ttsim_stats['memory_efficiency']:.1%}"
+                "\nWarning: Could not calculate ttsim memory stats (perf_stats unavailable)"
             )
-            logger.info(
-                f"Memory BW Utilization (vs Peak):   {ttsim_stats['mem_bw_utilization']:.1%}"
-            )
-            logger.info(
-                f"Bottleneck:                         {ttsim_stats['bottleneck']}"
-            )
-            logger.info(
-                f"Memory Pressure Score:              {ttsim_stats['memory_pressure']:.3f}"
-            )
+            return
 
-            logger.info("\n-- ttsim Memory Cycles Breakdown --")
-            logger.info(f"Compute Cycles:    {ttsim_stats['compute_cycles']}")
-            logger.info(f"Memory Cycles:     {ttsim_stats['memory_cycles']}")
-            logger.info(f"  Read Cycles:     {ttsim_stats['mem_rd_cycles']}")
-            logger.info(f"  Write Cycles:    {ttsim_stats['mem_wr_cycles']}")
-            logger.info(f"Memory Read Util:  {ttsim_stats['mem_rd_util']:.1%}")
-            logger.info(f"Memory Write Util: {ttsim_stats['mem_wr_util']:.1%}")
+        # Display comparison
+        logger.info(f"\n{'='*60}")
+        logger.info("Memory Performance Comparison")
+        logger.info(f"{'='*60}")
 
-            logger.info(f"\n{'='*60}\n")
+        logger.info("\n-- Execution Time --")
+        logger.info(f"NumPy:  {numpy_stats['execution_time_ms']:.6f} ms")
+        logger.info(f"ttsim:  {ttsim_stats['execution_time_ms']:.6f} ms")
 
-            # Assert basic sanity checks
-            assert (
-                numpy_stats["execution_time_ms"] > 0
-            ), "NumPy execution time should be positive"
-            assert (
-                ttsim_stats["execution_time_ms"] > 0
-            ), "ttsim execution time should be positive"
-            # For unsqueeze, operations might be minimal (shape manipulation)
-            assert (
-                numpy_stats["total_operations"] >= 0
-            ), "NumPy operations should be non-negative"
-            assert (
-                ttsim_stats["total_operations"] >= 0
-            ), "ttsim operations should be non-negative"
+        logger.info("\n-- Throughput (Inferences/sec) --")
+        logger.info(f"NumPy:  {numpy_stats['inferences_per_sec']:.2f}")
+        logger.info(f"ttsim:  {ttsim_stats['inferences_per_sec']:.2f}")
 
-        except Exception as e:
-            logger.info(
-                f"\nWarning: Could not complete memory performance test: {e}"
-            )
-            import traceback
+        logger.info("\n-- Data Movement --")
+        logger.info(f"NumPy:  {numpy_stats['data_movement_MB']:.3f} MB")
+        logger.info(f"ttsim:  {ttsim_stats['data_movement_MB']:.3f} MB")
 
-            traceback.print_exc()
-            # Don't fail the test if memory profiling fails
-            pytest.skip(f"Memory performance test skipped: {e}")
+        logger.info("\n-- Total Operations --")
+        logger.info(f"NumPy:  {numpy_stats['total_operations']:,}")
+        logger.info(f"ttsim:  {ttsim_stats['total_operations']:,}")
+
+        logger.info("\n-- Arithmetic Intensity (ops/byte) --")
+        logger.info(f"NumPy:  {numpy_stats['arithmetic_intensity']:.4f}")
+        logger.info(f"ttsim:  {ttsim_stats['arithmetic_intensity']:.4f}")
+
+        logger.info("\n-- ttsim-Only Memory Analysis --")
+        logger.info(
+            f"Memory Efficiency (vs Effective):  {ttsim_stats['memory_efficiency']:.1%}"
+        )
+        logger.info(
+            f"Memory BW Utilization (vs Peak):   {ttsim_stats['mem_bw_utilization']:.1%}"
+        )
+        logger.info(
+            f"Bottleneck:                         {ttsim_stats['bottleneck']}"
+        )
+        logger.info(
+            f"Memory Pressure Score:              {ttsim_stats['memory_pressure']:.3f}"
+        )
+
+        logger.info("\n-- ttsim Memory Cycles Breakdown --")
+        logger.info(f"Compute Cycles:    {ttsim_stats['compute_cycles']}")
+        logger.info(f"Memory Cycles:     {ttsim_stats['memory_cycles']}")
+        logger.info(f"  Read Cycles:     {ttsim_stats['mem_rd_cycles']}")
+        logger.info(f"  Write Cycles:    {ttsim_stats['mem_wr_cycles']}")
+        logger.info(f"Memory Read Util:  {ttsim_stats['mem_rd_util']:.1%}")
+        logger.info(f"Memory Write Util: {ttsim_stats['mem_wr_util']:.1%}")
+
+        logger.info(f"\n{'='*60}\n")
+
+        # Assert basic sanity checks
+        assert (
+            numpy_stats["execution_time_ms"] > 0
+        ), "NumPy execution time should be positive"
+        assert (
+            ttsim_stats["execution_time_ms"] > 0
+        ), "ttsim execution time should be positive"
+        # For unsqueeze, operations might be minimal (shape manipulation)
+        assert (
+            numpy_stats["total_operations"] >= 0
+        ), "NumPy operations should be non-negative"
+        assert (
+            ttsim_stats["total_operations"] >= 0
+        ), "ttsim operations should be non-negative"
 
 
 # ===========================================================================
@@ -667,18 +659,15 @@ def test_unsqueeze_memory_validation(capsys, request):
     # Load device configuration once
     polaris_root = Path(__file__).parent.parent.parent
     config_path = polaris_root / "config" / "tt_wh.yaml"
-    try:
-        ipgroups, packages = get_arspec_from_yaml(config_path)
-        device_pkg = packages["n150"]
-        device = Device(device_pkg)
+    ipgroups, packages = get_arspec_from_yaml(config_path)
+    device_pkg = packages["n150"]
+    device = Device(device_pkg)
 
-        logger.info(f"\nDevice: {device.devname} ({device.name})")
-        logger.info(f"Frequency: {device.freq_MHz} MHz")
-        logger.info(
-            f"Peak Bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
-        )
-    except Exception as e:
-        pytest.skip(f"Could not load device config: {e}")
+    logger.info(f"\nDevice: {device.devname} ({device.name})")
+    logger.info(f"Frequency: {device.freq_MHz} MHz")
+    logger.info(
+        f"Peak Bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
+    )
 
     # Test cases: different shapes and axes patterns
     test_cases = [

--- a/tests/test_ops/test_upsample.py
+++ b/tests/test_ops/test_upsample.py
@@ -517,18 +517,15 @@ def test_upsample_memory_validation(capsys, request):
 
     # Load device configuration once
     config_path = Path(polaris_root) / "config" / "tt_wh.yaml"
-    try:
-        ipgroups, packages = get_arspec_from_yaml(config_path)
-        device_pkg = packages["n150"]
-        device = Device(device_pkg)
+    ipgroups, packages = get_arspec_from_yaml(config_path)
+    device_pkg = packages["n150"]
+    device = Device(device_pkg)
 
-        logger.info(f"\nDevice: {device.devname} ({device.name})")
-        logger.info(f"Frequency: {device.freq_MHz} MHz")
-        logger.info(
-            f"Peak Bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
-        )
-    except Exception as e:
-        pytest.skip(f"Could not load device config: {e}")
+    logger.info(f"\nDevice: {device.devname} ({device.name})")
+    logger.info(f"Frequency: {device.freq_MHz} MHz")
+    logger.info(
+        f"Peak Bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
+    )
 
     # Test cases - both upsampling (scale > 1) and downsampling (scale < 1)
     test_cases = [

--- a/tests/test_ops/test_where.py
+++ b/tests/test_ops/test_where.py
@@ -368,18 +368,15 @@ def test_where_memory_validation(capsys, request):
 
     # Load device configuration once
     config_path = Path(polaris_root) / "config" / "tt_wh.yaml"
-    try:
-        ipgroups, packages = get_arspec_from_yaml(config_path)
-        device_pkg = packages["n150"]
-        device = Device(device_pkg)
+    ipgroups, packages = get_arspec_from_yaml(config_path)
+    device_pkg = packages["n150"]
+    device = Device(device_pkg)
 
-        logger.info(f"\nDevice: {device.devname} ({device.name})")
-        logger.info(f"Frequency: {device.freq_MHz} MHz")
-        logger.info(
-            f"Peak Bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
-        )
-    except Exception as e:
-        pytest.skip(f"Could not load device config: {e}")
+    logger.info(f"\nDevice: {device.devname} ({device.name})")
+    logger.info(f"Frequency: {device.freq_MHz} MHz")
+    logger.info(
+        f"Peak Bandwidth: {device.simconfig_obj.peak_bandwidth(freq_units='GHz'):.2f} GB/s"
+    )
 
     # Test cases
     test_cases = [

--- a/tests/test_polaris.py
+++ b/tests/test_polaris.py
@@ -1,16 +1,22 @@
 #!/usr/bin/env python
 # SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
+import subprocess
+import sys
+from pathlib import Path
+
 import pytest
-from tests.common import reset_typespec 
+from tests.common import reset_typespec
 import polaris
 
+@pytest.mark.unit
 def test_polaris(reset_typespec):
     assert polaris.main(['--odir', '__dummy', '--study', 'dummy', '--wlspec', 'config/mlperf_inference.yaml',
                          '--archspec', 'config/all_archs.yaml', '--wlmapspec',  'config/wl2archmapping.yaml',
                          '--dryrun']) == 0, "Polaris main function should return 0 on success"
 
 
+@pytest.mark.unit
 def test_polaris_disable_fusion_dryrun(reset_typespec):
     assert polaris.main(
         [
@@ -28,3 +34,132 @@ def test_polaris_disable_fusion_dryrun(reset_typespec):
             '--disable-fusion',
         ]
     ) == 0, "Polaris accepts --disable-fusion with --dryrun"
+
+
+BASE_ARGS = [
+    '--odir', '__dummy', '--study', 'dummy',
+    '--wlspec', 'config/mlperf_inference.yaml',
+    '--archspec', 'config/all_archs.yaml',
+    '--wlmapspec', 'config/wl2archmapping.yaml',
+    '--dryrun',
+]
+
+
+@pytest.mark.unit
+def test_apply_filter_rejects_unmatched_entry():
+    """A filter entry naming nothing raises rather than silently selecting nothing."""
+    devices = [('Q1_A1', None), ('Q2_A2', None)]
+    with pytest.raises(polaris.SpecSelectionError) as excinfo:
+        polaris.apply_filter(devices, 'Q1_A1,NoSuchDevice', lambda x: x[0], 'filterarch')
+    msg = str(excinfo.value)
+    assert 'NoSuchDevice' in msg, f"error should name the offending entry, got: {msg}"
+    assert '--filterarch' in msg, f"error should name the flag, got: {msg}"
+
+
+@pytest.mark.unit
+def test_apply_filter_accepts_valid_entries():
+    """Matching stays case-insensitive and tolerates whitespace around entries."""
+    devices = [('Q1_A1', None), ('Q2_A2', None)]
+    assert polaris.apply_filter(devices, 'q1_a1', lambda x: x[0], 'filterarch') == [('Q1_A1', None)]
+    assert polaris.apply_filter(devices, 'Q1_A1, Q2_A2', lambda x: x[0], 'filterarch') == devices
+    assert polaris.apply_filter(devices, None, lambda x: x[0], 'filterarch') == devices
+
+
+@pytest.mark.unit
+def test_apply_filter_validates_against_full_domain():
+    """An entry valid in the spec but absent from an already-narrowed list is not an error."""
+    narrowed = [('Q1_A1', None)]
+    domain = {'Q1_A1', 'Q2_A2'}
+    assert polaris.apply_filter(narrowed, 'Q2_A2', lambda x: x[0], 'filterarch', domain) == []
+
+
+@pytest.mark.unit
+def test_polaris_rejects_unknown_device(reset_typespec):
+    """An arch name absent from the archspec fails the run instead of running nothing."""
+    assert polaris.main(BASE_ARGS + ['--filterarch', 'NoSuchDevice']) != 0, \
+        "Polaris should fail when --filterarch names a device the archspec does not define"
+
+
+@pytest.mark.unit
+def test_polaris_rejects_unknown_workload_instance(reset_typespec):
+    """Same for a workload-instance name absent from the workload spec."""
+    assert polaris.main(BASE_ARGS + ['--filterwli', 'no_such_workload_instance']) != 0, \
+        "Polaris should fail when --filterwli names an instance the wlspec does not define"
+
+
+@pytest.mark.unit
+def test_polaris_rejects_valid_but_disjoint_filters(reset_typespec):
+    """Individually valid filters that share no workload still select nothing -- also a failure."""
+    assert polaris.main(BASE_ARGS + ['--filterwl', 'BERT_SQUAD_v1p1', '--filterwli', 'rn50_b1']) != 0, \
+        "Polaris should fail when valid filters jointly select no workload"
+
+
+@pytest.mark.unit
+def test_polaris_accepts_valid_filters(reset_typespec):
+    """The rejections above must not cost us the ordinary filtered run."""
+    assert polaris.main(BASE_ARGS + ['--filterarch', 'Q1_A1', '--filterwli', 'rn50_b1']) == 0, \
+        "Polaris should run normally when every filter entry names something real"
+
+
+@pytest.mark.unit
+def test_polaris_reports_empty_spec_rather_than_blaming_filters(reset_typespec, tmp_path):
+    """An empty spec and a disjoint filter pair are different mistakes in different files.
+
+    With no filter given there is nothing to blame the filters for, so the message has to
+    point at the spec instead — otherwise it sends the reader to their command line when the
+    defect is in the YAML.
+    """
+    empty_spec = tmp_path / 'empty_workloads.yaml'
+    empty_spec.write_text('workloads: []\n')
+
+    args = [
+        '--odir', str(tmp_path), '--study', 'dummy',
+        '--wlspec', str(empty_spec),
+        '--archspec', 'config/all_archs.yaml',
+        '--wlmapspec', 'config/wl2archmapping.yaml',
+        '--dryrun',
+    ]
+    with pytest.raises(polaris.SpecSelectionError) as excinfo:
+        polaris.get_workloads(str(empty_spec), polaris.RangeArgument('batchsize', None), None, None, None)
+    msg = str(excinfo.value)
+    assert 'defines no workload instances' in msg, f"should point at the spec, got: {msg}"
+    assert '--filter' not in msg, f"should not blame filters that were never given, got: {msg}"
+
+    assert polaris.main(args) != 0, "an empty spec should still fail the run"
+
+
+def _run_polaris_cli(extra_args, tmp_path):
+    """Invoke polaris.py as a subprocess and return the CompletedProcess."""
+    repo_root = Path(polaris.__file__).parent
+    argv = [
+        sys.executable, str(repo_root / 'polaris.py'),
+        '--odir', str(tmp_path), '--study', 'dummy',
+        '--wlspec', 'config/mlperf_inference.yaml',
+        '--archspec', 'config/all_archs.yaml',
+        '--wlmapspec', 'config/wl2archmapping.yaml',
+        '--dryrun',
+    ] + extra_args
+    return subprocess.run(argv, cwd=repo_root, capture_output=True, text=True)
+
+
+@pytest.mark.unit
+def test_polaris_cli_exits_nonzero_on_unknown_filter(tmp_path):
+    """The process exit code must carry the failure, not just main()'s return value.
+
+    The in-process tests above cannot catch this: the original defect was that __main__
+    computed the status and then discarded it, so main() returned non-zero while the
+    process still exited 0. Only a subprocess observes that.
+    """
+    res = _run_polaris_cli(['--filterarch', 'NoSuchDevice'], tmp_path)
+    assert res.returncode != 0, \
+        f"polaris.py should exit non-zero on an unknown filter; got {res.returncode}\n{res.stdout}\n{res.stderr}"
+    assert 'NoSuchDevice' in (res.stdout + res.stderr), \
+        "the error should name the offending filter entry"
+
+
+@pytest.mark.unit
+def test_polaris_cli_exits_zero_on_valid_run(tmp_path):
+    """Counterpart to the above, so the check cannot pass by always failing."""
+    res = _run_polaris_cli(['--filterarch', 'Q1_A1', '--filterwli', 'rn50_b1'], tmp_path)
+    assert res.returncode == 0, \
+        f"polaris.py should exit 0 on a valid run; got {res.returncode}\n{res.stdout}\n{res.stderr}"


### PR DESCRIPTION
Fixes #517.

## Summary

A Polaris run could select zero experiments and still exit 0, so CI saw green. Three gaps combined to produce that, and all three had to be closed for any of it to matter:

1. `apply_filter()` silently discarded a `--filterarch`/`--filterwlg`/`--filterwl`/`--filterwli` entry that matched nothing.
2. An empty selection only logged a warning; the run continued to completion.
3. **`polaris.py` never propagated its return value to the process exit code.** `polaris()` returns `0 if num_failures == 0 else 1`, but `__main__` bound that to `num_exps`, treated the 0/1 status as a job count, and dropped it — there was no `sys.exit`. `polproj.py` and `checkin_tests.py` both do `exit(main())`; `polaris.py` was the only one of the three that did not.

Gap 3 is what makes gaps 1 and 2 worth fixing at all: without it, a `return 1` from `polaris()` never reaches the shell, so the new checks would be inert on the CLI path — which is exactly the path `checkin_tests.py` drives.

To be precise about the scope of gap 3, since it is easy to overstate: **experiment failures already exited non-zero.** Both handlers in `execute_wl_on_dev()` re-`raise` after counting, so a failing workload propagates an uncaught exception and the process exits 1 via the traceback. (A consequence worth noting: `num_failures` is therefore always 0 by the time `polaris()` returns, making the `else 1` branch of its return statement unreachable today.) What exited 0 was the *returned-status* path — selection failures — and that is what this PR fixes. Verified on `origin/main`: an unknown `--filterarch` exits 0, while a workload that fails to build exits 1.

The same failure mode — a silent no-op where a failure belongs — turned up twice more in the test suite while auditing this, and both are fixed here rather than deferred: a dead assertion block that never ran, and a family of memory-validation tests that swallowed a device-config load failure into a skip. Details under Changes.

## Changes

**`polaris.py`**

- `apply_filter()` validates each entry against the **full domain** of the key it filters, collected before any other filter narrows the list. That keeps "unknown name" distinct from "filters individually valid but jointly disjoint", which are different user errors deserving different messages. Unknown entries raise with `difflib` near-match hints.
- Empty selections raise instead of warn. This also removes an unhandled `ValueError` that `--dryrun` hit on an empty device list (`do_dryrun` does `max([])`), so the same bad input no longer produces a traceback in one mode and silent success in the other.
- `exit(status)` in `__main__`.

**`checkin_tests.py`** — dropped a stale entry from the regression `filterarch` that named no device in `config/all_archs.yaml` and is now rejected. It had been contributing nothing to the regression matrix for as long as it has been there.

**`tests/test_polaris.py`** — new coverage at three levels: unit tests on `apply_filter` (rejection, case/whitespace tolerance, full-domain semantics); in-process tests driving `main()` (unknown device, unknown workload instance, valid-but-disjoint filters) plus one asserting an ordinary filtered run still succeeds; and subprocess tests that run `polaris.py` and assert on the **process exit code**, since an in-process test cannot observe a status that `__main__` computes and then discards.

**`tests/test_config.py`** — `test_archname_population` guarded its Wormhole half with `if 'n150' in packages:` against packages loaded from `config/all_archs.yaml`, which defines only the Grendel instances. The condition was never true, so that half never ran. It now loads `config/tt_wh.yaml` and asserts unconditionally.

This is the same defect class as the filter fix — a device name used against a spec that does not define it, failing silently rather than loudly — and it was the only other instance in the repo. A sweep of every place device names are consumed (filter values, `packages[...]` lookups, tooling, presets, docs, LUT bindings) found no others: `tools/run_ttsi_corr.py` already validates against the arch config and warn-skips unknown devices, the profiler's `p100`/`p150` keys are deliberate tt-smi `board_type` prefixes, and the shim's `ARCH`/`BoardType` enums intentionally mirror upstream ttnn rather than the arch configs.

**Tests under `tests/test_ops/`** — the same silent-no-op failure mode one layer down. These memory-validation tests wrapped their device-config load in `try/except Exception: pytest.skip(...)`, so a device renamed or removed from `config/tt_wh.yaml` would drop the test silently instead of failing it.

The broad catch was redundant everywhere it appeared. Either the file guards its `ttsim` imports separately with an `ImportError`-only availability flag, or it imports `get_arspec_from_yaml` and `Device` unconditionally at module top level — in which case those imports have already succeeded before the handler could ever run. In both shapes the handler could only catch config-load and `KeyError` failures, which are exactly the ones worth surfacing.

One case is worse than the rest and deserves a reviewer's eye: in `test_unsqueeze.py` a `try` wraps the **entire test body** rather than just the config load, so any assertion or computation failure in that benchmark was being reported as a skip. That file holds a second such block alongside it.

Only `try` blocks containing the device lookup are removed. The unrelated device-execution skips in `test_grid_sample.py` / `test_gridsample.py` and the terminal-reporter fallback in `test_unsqueeze.py` are untouched. Each change is a pure de-indent plus handler removal.

Repo-wide, no device-config swallow remains. That is verified by an AST walk over every `Try` node whose body performs the device lookup and whose handler calls `pytest.skip` — not a text search. The distinction matters: an earlier text-window scan keyed on the first match per file and so missed `test_unsqueeze.py` entirely, which is exactly where the worst instance lived.

<details>
<summary>Proof the hardening bites</summary>

Injecting a rename (`packages["n150"]` → a name the spec does not define):

```
tests/test_ops/test_abs.py
  origin/main:  SKIPPED  Could not load device config: 'n150_RENAMED'   <- coverage lost silently
  this branch:  E  KeyError: 'n150_RENAMED'   ... failed                <- surfaced

tests/test_ops/test_unsqueeze.py   (the whole-test-body case)
  this branch:  E  KeyError: 'n150_RENAMED'   ... failed
```

</details>

<details>
<summary>Error output</summary>

```
--filterarch: no match for ['<name>']; available: ['Q1_A1', 'Q1_S1', 'Q2_A2']

--filterwli: no match for ['gpt_nanoo']; 'gpt_nanoo': did you mean ['gpt_nano']?;
  <N> values available -- re-run with --log_level debug to list them

no workloads selected from config/mlperf_inference.yaml: the given
  --filterwlg/--filterwl/--filterwli are individually valid but select no workload in common
```

The candidate list is only spelled out when the domain is small enough for it to help. The workload-instance domain runs to three figures, where listing every value buries the error instead of explaining it — so past the threshold the message falls back to near-match suggestions plus a count, and the full list goes to the debug log.

</details>

## Behavior changes worth reviewing

- **Silent no-ops become hard failures.** Any caller that fans one filter across several spec files and relies on non-matching ones quietly no-op'ing will now fail. Nothing in this repo does that.
- **A selection that matches nothing now turns CI red.** Previously such a run exited 0. This is the change most likely to surprise: any job whose filters have quietly drifted out of date starts failing rather than passing vacuously.
- **The `__main__` timing log changed.** It read `Completed {N} jobs ... @ {N/elapsed} jobs per sec`, where `N` was that same 0/1 status — so it printed "Completed 1 jobs" on failure and nothing at all on success. Those are the exact lines the exit-status fix touches, so it is now a plain elapsed-time line; the run's own "completed with N experiments" line already reports the real count. Flagging it because it is a user-visible log change that goes slightly beyond the issue title.

`checkin_tests.py` greps run logs for `ERROR:` lines under the banner *"though runs exit with code 0"*. That workaround is left alone; it now has one fewer blind spot behind it.

## Verification

| Gate | Result |
|---|---|
| `mypy ./` | clean |
| `pytest -m "not slow and not tools_secondary"` | passes; pass/skip counts unchanged vs `origin/main` |
| `checkin_tests.py workloads` | passes in full |
| Pre-fix check | the new tests all fail against the tree without this change |
| Exit-propagation regression probe | with `exit(status)` removed, the subprocess test fails while the in-process tests still pass — so it guards the actual defect |
| `ruff check` on the touched files | per-file findings identical to `origin/main`; none introduced |
| AST scan for device-config swallows | present on `origin/main`, none remaining here |

The `checkin_tests.py` result is meaningful for the first time here: before this PR those PASS verdicts were reading an exit code that was always 0. That they still pass confirms no latent experiment failures were being masked.

## Reviewing the test churn

The test diff is large but narrow in kind: de-indentation plus handler removal, with no change to any assertion, test case, or expected value. The parts worth actually reading are the `polaris.py` logic and the `test_unsqueeze.py` whole-body block; the rest is the same edit repeated.

## Non-goals

- No change to matching semantics for entries that do match — still case-insensitive, comma-separated. Whitespace around entries is now tolerated rather than causing a silent miss.
- No opt-out flag for the new checks. If a genuine "empty is acceptable" use case appears, it can be added then.
