### PR TITLE
Add ViT-base support to MLIR frontend (Concat + real TTIR)

### DIFF
--- a/config/mlir_workloads.yaml
+++ b/config/mlir_workloads.yaml
@@ -10,3 +10,5 @@ workloads:
       mlp_block:   { path: mlp_block.mlir,   bs: 1 }
       mlp_forge_real: { path: mlp_forge_real.mlir, bs: 1 }
       bert: { path: bert.ttir.mlir, bs: 1 }
+      vit: { path: vit.stablehlo.mlir, bs: 1 }
+      vit_ttir: { path: vit.ttir.mlir, bs: 1 }

--- a/tests/test_mlir2graph.py
+++ b/tests/test_mlir2graph.py
@@ -74,3 +74,30 @@ def test_bert_base_ttir_shape_inference():
         op.get_perf_counts(it, ot)
         for t in ot:
             assert t.shape is not None
+
+
+@pytest.mark.unit
+def test_parse_vit_base_real_ttir():
+    """Real Forge TTIR of a 12-layer ViT-base encoder parses to 97 MatMuls
+    (12 layers x 8 attention/FFN matmuls + 1 linear patch-embed) and emits the
+    class-token Concat that ViT needs on top of the transformer op families."""
+    fg = parse_mlir(f"{EXAMPLES}/vit.ttir.mlir")
+    matmuls = [op for op in fg.ops if op.optype == "MatMul"]
+    assert len(matmuls) == 97
+    concats = [op for op in fg.ops if op.optype == "Concat"]
+    assert len(concats) == 1                       # cls-token prepend
+    assert concats[0].attrs.get("axis") is not None  # ttir.concat `dim = N` -> axis
+    optypes = {op.optype for op in fg.ops}
+    assert {"MatMul", "Add", "Concat", "Transpose", "Reshape"} <= optypes
+
+
+@pytest.mark.unit
+def test_vit_base_ttir_shape_inference():
+    """Shape inference resolves every op of the ViT-base TTIR graph."""
+    gg = mlir2graph("vit", f"{EXAMPLES}/vit.ttir.mlir")
+    for _, op in gg._ops.items():
+        it = [gg._tensors[x] for x in op.inList]
+        ot = [gg._tensors[x] for x in op.outList]
+        op.get_perf_counts(it, ot)
+        for t in ot:
+            assert t.shape is not None

--- a/ttsim/front/mlir/mlir2nx.py
+++ b/ttsim/front/mlir/mlir2nx.py
@@ -211,8 +211,40 @@ def parse_stablehlo(text, wlname):
             g = lambda mm, k: [int(x) for x in mm.group(k).split(",") if x.strip()] if mm else []
             _emit_dot_general(fg, i, res, a, b, g(cd, 1), g(cd, 2), g(bd, 1), g(bd, 2), rshp, rdt)
             continue
+        if op == "convolution":
+            # StableHLO NCHW/OIHW conv -> Polaris Conv (ONNX-style attrs). Used by ViT's
+            # patch-embedding and by CNNs.
+            inp, wt = resolve(operands[0]), resolve(operands[1])
+
+            def _pl(key: str) -> list:
+                m = re.search(key + r"\s*=\s*\[([^\]]*)\]", rhs)
+                return [int(x) for x in re.findall(r"-?\d+", m.group(1))] if m else []
+            strides = _pl("stride") or [1, 1]
+            dilations = _pl("rhs_dilate") or [1, 1]
+            pads: list = [0, 0, 0, 0]
+            pm = re.search(r"pad\s*=\s*\[\[([^\]]*)\],\s*\[([^\]]*)\]\]", rhs)
+            if pm:
+                pt, pb = [int(x) for x in re.findall(r"-?\d+", pm.group(1))]
+                pl, pr = [int(x) for x in re.findall(r"-?\d+", pm.group(2))]
+                pads = [pt, pl, pb, pr]
+            gm = re.search(r"feature_group_count\s*=\s*(\d+)", rhs)
+            group = int(gm.group(1)) if gm else 1
+            wsh = fg.tensors[wt].shape                       # [O, I, kH, kW]
+            ksh = list(wsh[2:]) if wsh and len(wsh) >= 4 else []
+            fg.T(res, rshp, rdt)
+            fg.ops.append(FOp(name=f"conv_{i}", optype="Conv", inList=[inp, wt], outList=[res],
+                              attrs={"kernel_shape": ksh, "strides": strides, "pads": pads,
+                                     "dilations": dilations, "group": group}))
+            continue
+        if op == "concatenate":
+            ins = [resolve(x) for x in operands]
+            am = re.search(r"dim\s*=\s*(\d+)", rhs)
+            fg.T(res, rshp, rdt)
+            fg.ops.append(FOp(name=f"concat_{i}", optype="Concat", inList=ins, outList=[res],
+                              attrs={"axis": int(am.group(1)) if am else 0}))
+            continue
         if op in ("call", "gather", "compare", "select", "and", "or", "not", "slice",
-                  "dynamic_slice", "dynamic_update_slice", "concatenate", "clamp", "reverse",
+                  "dynamic_slice", "dynamic_update_slice", "clamp", "reverse",
                   "is_finite", "sign", "floor"):
             # non-compute bookkeeping (embedding lookup / attention-mask machinery):
             # native BERT models do not model these either; keep result as a leaf so the
@@ -258,6 +290,9 @@ def _ttir_reduce_attrs(attrblk):
     pm = re.search(r"permutation\s*=\s*array<i64:\s*([\d,\s]*)>", attrblk)
     if pm:
         attrs["perm"] = [int(x) for x in pm.group(1).split(",") if x.strip()]
+    cm = re.search(r"\bdim\s*=\s*(-?\d+)", attrblk)   # ttir.concat: dim = N -> Concat axis
+    if cm:
+        attrs["axis"] = int(cm.group(1))
     return attrs
 
 

--- a/workloads/mlir/examples/vit.stablehlo.mlir
+++ b/workloads/mlir/examples/vit.stablehlo.mlir
@@ -1,0 +1,1234 @@
+// SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+module @jit_vit attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
+  func.func public @main(%arg0: tensor<8x3x224x224xf32>, %arg1: tensor<768x768xf32>, %arg2: tensor<8x1x768xf32>, %arg3: tensor<1x197x768xf32>, %arg4: tensor<768x768xf32>, %arg5: tensor<768x768xf32>, %arg6: tensor<768x768xf32>, %arg7: tensor<768x768xf32>, %arg8: tensor<768xf32>, %arg9: tensor<768xf32>, %arg10: tensor<768x3072xf32>, %arg11: tensor<3072x768xf32>, %arg12: tensor<768xf32>, %arg13: tensor<768xf32>, %arg14: tensor<768x768xf32>, %arg15: tensor<768x768xf32>, %arg16: tensor<768x768xf32>, %arg17: tensor<768x768xf32>, %arg18: tensor<768xf32>, %arg19: tensor<768xf32>, %arg20: tensor<768x3072xf32>, %arg21: tensor<3072x768xf32>, %arg22: tensor<768xf32>, %arg23: tensor<768xf32>, %arg24: tensor<768x768xf32>, %arg25: tensor<768x768xf32>, %arg26: tensor<768x768xf32>, %arg27: tensor<768x768xf32>, %arg28: tensor<768xf32>, %arg29: tensor<768xf32>, %arg30: tensor<768x3072xf32>, %arg31: tensor<3072x768xf32>, %arg32: tensor<768xf32>, %arg33: tensor<768xf32>, %arg34: tensor<768x768xf32>, %arg35: tensor<768x768xf32>, %arg36: tensor<768x768xf32>, %arg37: tensor<768x768xf32>, %arg38: tensor<768xf32>, %arg39: tensor<768xf32>, %arg40: tensor<768x3072xf32>, %arg41: tensor<3072x768xf32>, %arg42: tensor<768xf32>, %arg43: tensor<768xf32>, %arg44: tensor<768x768xf32>, %arg45: tensor<768x768xf32>, %arg46: tensor<768x768xf32>, %arg47: tensor<768x768xf32>, %arg48: tensor<768xf32>, %arg49: tensor<768xf32>, %arg50: tensor<768x3072xf32>, %arg51: tensor<3072x768xf32>, %arg52: tensor<768xf32>, %arg53: tensor<768xf32>, %arg54: tensor<768x768xf32>, %arg55: tensor<768x768xf32>, %arg56: tensor<768x768xf32>, %arg57: tensor<768x768xf32>, %arg58: tensor<768xf32>, %arg59: tensor<768xf32>, %arg60: tensor<768x3072xf32>, %arg61: tensor<3072x768xf32>, %arg62: tensor<768xf32>, %arg63: tensor<768xf32>, %arg64: tensor<768x768xf32>, %arg65: tensor<768x768xf32>, %arg66: tensor<768x768xf32>, %arg67: tensor<768x768xf32>, %arg68: tensor<768xf32>, %arg69: tensor<768xf32>, %arg70: tensor<768x3072xf32>, %arg71: tensor<3072x768xf32>, %arg72: tensor<768xf32>, %arg73: tensor<768xf32>, %arg74: tensor<768x768xf32>, %arg75: tensor<768x768xf32>, %arg76: tensor<768x768xf32>, %arg77: tensor<768x768xf32>, %arg78: tensor<768xf32>, %arg79: tensor<768xf32>, %arg80: tensor<768x3072xf32>, %arg81: tensor<3072x768xf32>, %arg82: tensor<768xf32>, %arg83: tensor<768xf32>, %arg84: tensor<768x768xf32>, %arg85: tensor<768x768xf32>, %arg86: tensor<768x768xf32>, %arg87: tensor<768x768xf32>, %arg88: tensor<768xf32>, %arg89: tensor<768xf32>, %arg90: tensor<768x3072xf32>, %arg91: tensor<3072x768xf32>, %arg92: tensor<768xf32>, %arg93: tensor<768xf32>, %arg94: tensor<768x768xf32>, %arg95: tensor<768x768xf32>, %arg96: tensor<768x768xf32>, %arg97: tensor<768x768xf32>, %arg98: tensor<768xf32>, %arg99: tensor<768xf32>, %arg100: tensor<768x3072xf32>, %arg101: tensor<3072x768xf32>, %arg102: tensor<768xf32>, %arg103: tensor<768xf32>, %arg104: tensor<768x768xf32>, %arg105: tensor<768x768xf32>, %arg106: tensor<768x768xf32>, %arg107: tensor<768x768xf32>, %arg108: tensor<768xf32>, %arg109: tensor<768xf32>, %arg110: tensor<768x3072xf32>, %arg111: tensor<3072x768xf32>, %arg112: tensor<768xf32>, %arg113: tensor<768xf32>, %arg114: tensor<768x768xf32>, %arg115: tensor<768x768xf32>, %arg116: tensor<768x768xf32>, %arg117: tensor<768x768xf32>, %arg118: tensor<768xf32>, %arg119: tensor<768xf32>, %arg120: tensor<768x3072xf32>, %arg121: tensor<3072x768xf32>, %arg122: tensor<768xf32>, %arg123: tensor<768xf32>) -> (tensor<8x197x768xf32> {jax.result_info = "result"}) {
+    %0 = stablehlo.reshape %arg0 : (tensor<8x3x224x224xf32>) -> tensor<8x3x14x16x14x16xf32>
+    %1 = stablehlo.transpose %0, dims = [0, 2, 4, 1, 3, 5] : (tensor<8x3x14x16x14x16xf32>) -> tensor<8x14x14x3x16x16xf32>
+    %2 = stablehlo.reshape %1 : (tensor<8x14x14x3x16x16xf32>) -> tensor<8x196x768xf32>
+    %3 = stablehlo.dot_general %2, %arg1, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x196x768xf32>, tensor<768x768xf32>) -> tensor<8x196x768xf32>
+    %4 = stablehlo.concatenate %arg2, %3, dim = 1 : (tensor<8x1x768xf32>, tensor<8x196x768xf32>) -> tensor<8x197x768xf32>
+    %5 = stablehlo.broadcast_in_dim %arg3, dims = [0, 1, 2] : (tensor<1x197x768xf32>) -> tensor<8x197x768xf32>
+    %6 = stablehlo.add %4, %5 : tensor<8x197x768xf32>
+    %cst = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %7 = stablehlo.reduce(%6 init: %cst) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %8 = stablehlo.broadcast_in_dim %7, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %cst_0 = stablehlo.constant dense<7.680000e+02> : tensor<f32>
+    %9 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %10 = stablehlo.divide %8, %9 : tensor<8x197x1xf32>
+    %11 = stablehlo.broadcast_in_dim %10, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %12 = stablehlo.subtract %6, %11 : tensor<8x197x768xf32>
+    %13 = stablehlo.multiply %12, %12 : tensor<8x197x768xf32>
+    %cst_1 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %14 = stablehlo.reduce(%13 init: %cst_1) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %15 = stablehlo.broadcast_in_dim %14, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %16 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %17 = stablehlo.divide %15, %16 : tensor<8x197x1xf32>
+    %18 = stablehlo.broadcast_in_dim %10, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %19 = stablehlo.subtract %6, %18 : tensor<8x197x768xf32>
+    %cst_2 = stablehlo.constant dense<9.99999974E-6> : tensor<f32>
+    %20 = stablehlo.broadcast_in_dim %cst_2, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %21 = stablehlo.add %17, %20 : tensor<8x197x1xf32>
+    %22 = stablehlo.sqrt %21 : tensor<8x197x1xf32>
+    %23 = stablehlo.broadcast_in_dim %22, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %24 = stablehlo.divide %19, %23 : tensor<8x197x768xf32>
+    %25 = stablehlo.broadcast_in_dim %arg8, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %26 = stablehlo.broadcast_in_dim %25, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %27 = stablehlo.multiply %24, %26 : tensor<8x197x768xf32>
+    %28 = stablehlo.broadcast_in_dim %arg9, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %29 = stablehlo.broadcast_in_dim %28, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %30 = stablehlo.add %27, %29 : tensor<8x197x768xf32>
+    %31 = stablehlo.dot_general %30, %arg4, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %32 = stablehlo.dot_general %30, %arg5, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %33 = stablehlo.dot_general %30, %arg6, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %34 = stablehlo.reshape %31 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %35 = stablehlo.transpose %34, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %36 = stablehlo.reshape %32 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %37 = stablehlo.transpose %36, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %38 = stablehlo.reshape %33 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %39 = stablehlo.transpose %38, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %40 = stablehlo.transpose %37, dims = [0, 1, 3, 2] : (tensor<8x12x197x64xf32>) -> tensor<8x12x64x197xf32>
+    %41 = stablehlo.dot_general %35, %40, batching_dims = [0, 1] x [0, 1], contracting_dims = [3] x [2], precision = [DEFAULT, DEFAULT] : (tensor<8x12x197x64xf32>, tensor<8x12x64x197xf32>) -> tensor<8x12x197x197xf32>
+    %cst_3 = stablehlo.constant dense<6.400000e+01> : tensor<f32>
+    %42 = stablehlo.sqrt %cst_3 : tensor<f32>
+    %43 = stablehlo.convert %42 : tensor<f32>
+    %44 = stablehlo.broadcast_in_dim %43, dims = [] : (tensor<f32>) -> tensor<8x12x197x197xf32>
+    %45 = stablehlo.divide %41, %44 : tensor<8x12x197x197xf32>
+    %cst_4 = stablehlo.constant dense<0xFF800000> : tensor<f32>
+    %46 = stablehlo.reduce(%45 init: %cst_4) applies stablehlo.maximum across dimensions = [3] : (tensor<8x12x197x197xf32>, tensor<f32>) -> tensor<8x12x197xf32>
+    %cst_5 = stablehlo.constant dense<0xFF800000> : tensor<f32>
+    %47 = stablehlo.broadcast_in_dim %cst_5, dims = [] : (tensor<f32>) -> tensor<8x12x197xf32>
+    %48 = stablehlo.maximum %47, %46 : tensor<8x12x197xf32>
+    %49 = stablehlo.broadcast_in_dim %48, dims = [0, 1, 2] : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+    %50 = stablehlo.broadcast_in_dim %49, dims = [0, 1, 2, 3] : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+    %51 = stablehlo.subtract %45, %50 : tensor<8x12x197x197xf32>
+    %52 = stablehlo.exponential %51 : tensor<8x12x197x197xf32>
+    %cst_6 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %53 = stablehlo.reduce(%52 init: %cst_6) applies stablehlo.add across dimensions = [3] : (tensor<8x12x197x197xf32>, tensor<f32>) -> tensor<8x12x197xf32>
+    %54 = stablehlo.broadcast_in_dim %53, dims = [0, 1, 2] : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+    %55 = stablehlo.broadcast_in_dim %54, dims = [0, 1, 2, 3] : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+    %56 = stablehlo.divide %52, %55 : tensor<8x12x197x197xf32>
+    %57 = stablehlo.dot_general %56, %39, batching_dims = [0, 1] x [0, 1], contracting_dims = [3] x [2], precision = [DEFAULT, DEFAULT] : (tensor<8x12x197x197xf32>, tensor<8x12x197x64xf32>) -> tensor<8x12x197x64xf32>
+    %58 = stablehlo.transpose %57, dims = [0, 2, 1, 3] : (tensor<8x12x197x64xf32>) -> tensor<8x197x12x64xf32>
+    %59 = stablehlo.reshape %58 : (tensor<8x197x12x64xf32>) -> tensor<8x197x768xf32>
+    %60 = stablehlo.dot_general %59, %arg7, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %61 = stablehlo.add %6, %60 : tensor<8x197x768xf32>
+    %cst_7 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %62 = stablehlo.reduce(%61 init: %cst_7) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %63 = stablehlo.broadcast_in_dim %62, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %64 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %65 = stablehlo.divide %63, %64 : tensor<8x197x1xf32>
+    %66 = stablehlo.broadcast_in_dim %65, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %67 = stablehlo.subtract %61, %66 : tensor<8x197x768xf32>
+    %68 = stablehlo.multiply %67, %67 : tensor<8x197x768xf32>
+    %cst_8 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %69 = stablehlo.reduce(%68 init: %cst_8) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %70 = stablehlo.broadcast_in_dim %69, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %71 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %72 = stablehlo.divide %70, %71 : tensor<8x197x1xf32>
+    %73 = stablehlo.broadcast_in_dim %65, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %74 = stablehlo.subtract %61, %73 : tensor<8x197x768xf32>
+    %75 = stablehlo.broadcast_in_dim %cst_2, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %76 = stablehlo.add %72, %75 : tensor<8x197x1xf32>
+    %77 = stablehlo.sqrt %76 : tensor<8x197x1xf32>
+    %78 = stablehlo.broadcast_in_dim %77, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %79 = stablehlo.divide %74, %78 : tensor<8x197x768xf32>
+    %80 = stablehlo.broadcast_in_dim %arg12, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %81 = stablehlo.broadcast_in_dim %80, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %82 = stablehlo.multiply %79, %81 : tensor<8x197x768xf32>
+    %83 = stablehlo.broadcast_in_dim %arg13, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %84 = stablehlo.broadcast_in_dim %83, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %85 = stablehlo.add %82, %84 : tensor<8x197x768xf32>
+    %86 = stablehlo.dot_general %85, %arg10, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x3072xf32>) -> tensor<8x197x3072xf32>
+    %87 = stablehlo.multiply %86, %86 : tensor<8x197x3072xf32>
+    %88 = stablehlo.multiply %87, %86 : tensor<8x197x3072xf32>
+    %cst_9 = stablehlo.constant dense<4.471500e-02> : tensor<f32>
+    %89 = stablehlo.broadcast_in_dim %cst_9, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %90 = stablehlo.multiply %89, %88 : tensor<8x197x3072xf32>
+    %91 = stablehlo.add %86, %90 : tensor<8x197x3072xf32>
+    %cst_10 = stablehlo.constant dense<0.797884583> : tensor<f32>
+    %92 = stablehlo.broadcast_in_dim %cst_10, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %93 = stablehlo.multiply %92, %91 : tensor<8x197x3072xf32>
+    %94 = stablehlo.tanh %93 : tensor<8x197x3072xf32>
+    %cst_11 = stablehlo.constant dense<1.000000e+00> : tensor<f32>
+    %95 = stablehlo.broadcast_in_dim %cst_11, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %96 = stablehlo.add %95, %94 : tensor<8x197x3072xf32>
+    %cst_12 = stablehlo.constant dense<5.000000e-01> : tensor<f32>
+    %97 = stablehlo.broadcast_in_dim %cst_12, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %98 = stablehlo.multiply %97, %96 : tensor<8x197x3072xf32>
+    %99 = stablehlo.multiply %86, %98 : tensor<8x197x3072xf32>
+    %100 = stablehlo.dot_general %99, %arg11, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x3072xf32>, tensor<3072x768xf32>) -> tensor<8x197x768xf32>
+    %101 = stablehlo.add %61, %100 : tensor<8x197x768xf32>
+    %cst_13 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %102 = stablehlo.reduce(%101 init: %cst_13) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %103 = stablehlo.broadcast_in_dim %102, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %104 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %105 = stablehlo.divide %103, %104 : tensor<8x197x1xf32>
+    %106 = stablehlo.broadcast_in_dim %105, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %107 = stablehlo.subtract %101, %106 : tensor<8x197x768xf32>
+    %108 = stablehlo.multiply %107, %107 : tensor<8x197x768xf32>
+    %cst_14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %109 = stablehlo.reduce(%108 init: %cst_14) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %110 = stablehlo.broadcast_in_dim %109, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %111 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %112 = stablehlo.divide %110, %111 : tensor<8x197x1xf32>
+    %113 = stablehlo.broadcast_in_dim %105, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %114 = stablehlo.subtract %101, %113 : tensor<8x197x768xf32>
+    %115 = stablehlo.broadcast_in_dim %cst_2, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %116 = stablehlo.add %112, %115 : tensor<8x197x1xf32>
+    %117 = stablehlo.sqrt %116 : tensor<8x197x1xf32>
+    %118 = stablehlo.broadcast_in_dim %117, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %119 = stablehlo.divide %114, %118 : tensor<8x197x768xf32>
+    %120 = stablehlo.broadcast_in_dim %arg18, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %121 = stablehlo.broadcast_in_dim %120, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %122 = stablehlo.multiply %119, %121 : tensor<8x197x768xf32>
+    %123 = stablehlo.broadcast_in_dim %arg19, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %124 = stablehlo.broadcast_in_dim %123, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %125 = stablehlo.add %122, %124 : tensor<8x197x768xf32>
+    %126 = stablehlo.dot_general %125, %arg14, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %127 = stablehlo.dot_general %125, %arg15, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %128 = stablehlo.dot_general %125, %arg16, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %129 = stablehlo.reshape %126 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %130 = stablehlo.transpose %129, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %131 = stablehlo.reshape %127 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %132 = stablehlo.transpose %131, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %133 = stablehlo.reshape %128 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %134 = stablehlo.transpose %133, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %135 = stablehlo.transpose %132, dims = [0, 1, 3, 2] : (tensor<8x12x197x64xf32>) -> tensor<8x12x64x197xf32>
+    %136 = stablehlo.dot_general %130, %135, batching_dims = [0, 1] x [0, 1], contracting_dims = [3] x [2], precision = [DEFAULT, DEFAULT] : (tensor<8x12x197x64xf32>, tensor<8x12x64x197xf32>) -> tensor<8x12x197x197xf32>
+    %137 = stablehlo.sqrt %cst_3 : tensor<f32>
+    %138 = stablehlo.convert %137 : tensor<f32>
+    %139 = stablehlo.broadcast_in_dim %138, dims = [] : (tensor<f32>) -> tensor<8x12x197x197xf32>
+    %140 = stablehlo.divide %136, %139 : tensor<8x12x197x197xf32>
+    %cst_15 = stablehlo.constant dense<0xFF800000> : tensor<f32>
+    %141 = stablehlo.reduce(%140 init: %cst_15) applies stablehlo.maximum across dimensions = [3] : (tensor<8x12x197x197xf32>, tensor<f32>) -> tensor<8x12x197xf32>
+    %142 = stablehlo.broadcast_in_dim %cst_5, dims = [] : (tensor<f32>) -> tensor<8x12x197xf32>
+    %143 = stablehlo.maximum %142, %141 : tensor<8x12x197xf32>
+    %144 = stablehlo.broadcast_in_dim %143, dims = [0, 1, 2] : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+    %145 = stablehlo.broadcast_in_dim %144, dims = [0, 1, 2, 3] : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+    %146 = stablehlo.subtract %140, %145 : tensor<8x12x197x197xf32>
+    %147 = stablehlo.exponential %146 : tensor<8x12x197x197xf32>
+    %cst_16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %148 = stablehlo.reduce(%147 init: %cst_16) applies stablehlo.add across dimensions = [3] : (tensor<8x12x197x197xf32>, tensor<f32>) -> tensor<8x12x197xf32>
+    %149 = stablehlo.broadcast_in_dim %148, dims = [0, 1, 2] : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+    %150 = stablehlo.broadcast_in_dim %149, dims = [0, 1, 2, 3] : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+    %151 = stablehlo.divide %147, %150 : tensor<8x12x197x197xf32>
+    %152 = stablehlo.dot_general %151, %134, batching_dims = [0, 1] x [0, 1], contracting_dims = [3] x [2], precision = [DEFAULT, DEFAULT] : (tensor<8x12x197x197xf32>, tensor<8x12x197x64xf32>) -> tensor<8x12x197x64xf32>
+    %153 = stablehlo.transpose %152, dims = [0, 2, 1, 3] : (tensor<8x12x197x64xf32>) -> tensor<8x197x12x64xf32>
+    %154 = stablehlo.reshape %153 : (tensor<8x197x12x64xf32>) -> tensor<8x197x768xf32>
+    %155 = stablehlo.dot_general %154, %arg17, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %156 = stablehlo.add %101, %155 : tensor<8x197x768xf32>
+    %cst_17 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %157 = stablehlo.reduce(%156 init: %cst_17) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %158 = stablehlo.broadcast_in_dim %157, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %159 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %160 = stablehlo.divide %158, %159 : tensor<8x197x1xf32>
+    %161 = stablehlo.broadcast_in_dim %160, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %162 = stablehlo.subtract %156, %161 : tensor<8x197x768xf32>
+    %163 = stablehlo.multiply %162, %162 : tensor<8x197x768xf32>
+    %cst_18 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %164 = stablehlo.reduce(%163 init: %cst_18) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %165 = stablehlo.broadcast_in_dim %164, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %166 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %167 = stablehlo.divide %165, %166 : tensor<8x197x1xf32>
+    %168 = stablehlo.broadcast_in_dim %160, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %169 = stablehlo.subtract %156, %168 : tensor<8x197x768xf32>
+    %170 = stablehlo.broadcast_in_dim %cst_2, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %171 = stablehlo.add %167, %170 : tensor<8x197x1xf32>
+    %172 = stablehlo.sqrt %171 : tensor<8x197x1xf32>
+    %173 = stablehlo.broadcast_in_dim %172, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %174 = stablehlo.divide %169, %173 : tensor<8x197x768xf32>
+    %175 = stablehlo.broadcast_in_dim %arg22, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %176 = stablehlo.broadcast_in_dim %175, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %177 = stablehlo.multiply %174, %176 : tensor<8x197x768xf32>
+    %178 = stablehlo.broadcast_in_dim %arg23, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %179 = stablehlo.broadcast_in_dim %178, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %180 = stablehlo.add %177, %179 : tensor<8x197x768xf32>
+    %181 = stablehlo.dot_general %180, %arg20, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x3072xf32>) -> tensor<8x197x3072xf32>
+    %182 = stablehlo.multiply %181, %181 : tensor<8x197x3072xf32>
+    %183 = stablehlo.multiply %182, %181 : tensor<8x197x3072xf32>
+    %184 = stablehlo.broadcast_in_dim %cst_9, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %185 = stablehlo.multiply %184, %183 : tensor<8x197x3072xf32>
+    %186 = stablehlo.add %181, %185 : tensor<8x197x3072xf32>
+    %187 = stablehlo.broadcast_in_dim %cst_10, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %188 = stablehlo.multiply %187, %186 : tensor<8x197x3072xf32>
+    %189 = stablehlo.tanh %188 : tensor<8x197x3072xf32>
+    %190 = stablehlo.broadcast_in_dim %cst_11, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %191 = stablehlo.add %190, %189 : tensor<8x197x3072xf32>
+    %192 = stablehlo.broadcast_in_dim %cst_12, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %193 = stablehlo.multiply %192, %191 : tensor<8x197x3072xf32>
+    %194 = stablehlo.multiply %181, %193 : tensor<8x197x3072xf32>
+    %195 = stablehlo.dot_general %194, %arg21, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x3072xf32>, tensor<3072x768xf32>) -> tensor<8x197x768xf32>
+    %196 = stablehlo.add %156, %195 : tensor<8x197x768xf32>
+    %cst_19 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %197 = stablehlo.reduce(%196 init: %cst_19) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %198 = stablehlo.broadcast_in_dim %197, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %199 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %200 = stablehlo.divide %198, %199 : tensor<8x197x1xf32>
+    %201 = stablehlo.broadcast_in_dim %200, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %202 = stablehlo.subtract %196, %201 : tensor<8x197x768xf32>
+    %203 = stablehlo.multiply %202, %202 : tensor<8x197x768xf32>
+    %cst_20 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %204 = stablehlo.reduce(%203 init: %cst_20) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %205 = stablehlo.broadcast_in_dim %204, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %206 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %207 = stablehlo.divide %205, %206 : tensor<8x197x1xf32>
+    %208 = stablehlo.broadcast_in_dim %200, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %209 = stablehlo.subtract %196, %208 : tensor<8x197x768xf32>
+    %210 = stablehlo.broadcast_in_dim %cst_2, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %211 = stablehlo.add %207, %210 : tensor<8x197x1xf32>
+    %212 = stablehlo.sqrt %211 : tensor<8x197x1xf32>
+    %213 = stablehlo.broadcast_in_dim %212, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %214 = stablehlo.divide %209, %213 : tensor<8x197x768xf32>
+    %215 = stablehlo.broadcast_in_dim %arg28, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %216 = stablehlo.broadcast_in_dim %215, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %217 = stablehlo.multiply %214, %216 : tensor<8x197x768xf32>
+    %218 = stablehlo.broadcast_in_dim %arg29, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %219 = stablehlo.broadcast_in_dim %218, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %220 = stablehlo.add %217, %219 : tensor<8x197x768xf32>
+    %221 = stablehlo.dot_general %220, %arg24, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %222 = stablehlo.dot_general %220, %arg25, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %223 = stablehlo.dot_general %220, %arg26, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %224 = stablehlo.reshape %221 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %225 = stablehlo.transpose %224, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %226 = stablehlo.reshape %222 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %227 = stablehlo.transpose %226, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %228 = stablehlo.reshape %223 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %229 = stablehlo.transpose %228, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %230 = stablehlo.transpose %227, dims = [0, 1, 3, 2] : (tensor<8x12x197x64xf32>) -> tensor<8x12x64x197xf32>
+    %231 = stablehlo.dot_general %225, %230, batching_dims = [0, 1] x [0, 1], contracting_dims = [3] x [2], precision = [DEFAULT, DEFAULT] : (tensor<8x12x197x64xf32>, tensor<8x12x64x197xf32>) -> tensor<8x12x197x197xf32>
+    %232 = stablehlo.sqrt %cst_3 : tensor<f32>
+    %233 = stablehlo.convert %232 : tensor<f32>
+    %234 = stablehlo.broadcast_in_dim %233, dims = [] : (tensor<f32>) -> tensor<8x12x197x197xf32>
+    %235 = stablehlo.divide %231, %234 : tensor<8x12x197x197xf32>
+    %cst_21 = stablehlo.constant dense<0xFF800000> : tensor<f32>
+    %236 = stablehlo.reduce(%235 init: %cst_21) applies stablehlo.maximum across dimensions = [3] : (tensor<8x12x197x197xf32>, tensor<f32>) -> tensor<8x12x197xf32>
+    %237 = stablehlo.broadcast_in_dim %cst_5, dims = [] : (tensor<f32>) -> tensor<8x12x197xf32>
+    %238 = stablehlo.maximum %237, %236 : tensor<8x12x197xf32>
+    %239 = stablehlo.broadcast_in_dim %238, dims = [0, 1, 2] : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+    %240 = stablehlo.broadcast_in_dim %239, dims = [0, 1, 2, 3] : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+    %241 = stablehlo.subtract %235, %240 : tensor<8x12x197x197xf32>
+    %242 = stablehlo.exponential %241 : tensor<8x12x197x197xf32>
+    %cst_22 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %243 = stablehlo.reduce(%242 init: %cst_22) applies stablehlo.add across dimensions = [3] : (tensor<8x12x197x197xf32>, tensor<f32>) -> tensor<8x12x197xf32>
+    %244 = stablehlo.broadcast_in_dim %243, dims = [0, 1, 2] : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+    %245 = stablehlo.broadcast_in_dim %244, dims = [0, 1, 2, 3] : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+    %246 = stablehlo.divide %242, %245 : tensor<8x12x197x197xf32>
+    %247 = stablehlo.dot_general %246, %229, batching_dims = [0, 1] x [0, 1], contracting_dims = [3] x [2], precision = [DEFAULT, DEFAULT] : (tensor<8x12x197x197xf32>, tensor<8x12x197x64xf32>) -> tensor<8x12x197x64xf32>
+    %248 = stablehlo.transpose %247, dims = [0, 2, 1, 3] : (tensor<8x12x197x64xf32>) -> tensor<8x197x12x64xf32>
+    %249 = stablehlo.reshape %248 : (tensor<8x197x12x64xf32>) -> tensor<8x197x768xf32>
+    %250 = stablehlo.dot_general %249, %arg27, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %251 = stablehlo.add %196, %250 : tensor<8x197x768xf32>
+    %cst_23 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %252 = stablehlo.reduce(%251 init: %cst_23) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %253 = stablehlo.broadcast_in_dim %252, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %254 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %255 = stablehlo.divide %253, %254 : tensor<8x197x1xf32>
+    %256 = stablehlo.broadcast_in_dim %255, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %257 = stablehlo.subtract %251, %256 : tensor<8x197x768xf32>
+    %258 = stablehlo.multiply %257, %257 : tensor<8x197x768xf32>
+    %cst_24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %259 = stablehlo.reduce(%258 init: %cst_24) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %260 = stablehlo.broadcast_in_dim %259, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %261 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %262 = stablehlo.divide %260, %261 : tensor<8x197x1xf32>
+    %263 = stablehlo.broadcast_in_dim %255, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %264 = stablehlo.subtract %251, %263 : tensor<8x197x768xf32>
+    %265 = stablehlo.broadcast_in_dim %cst_2, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %266 = stablehlo.add %262, %265 : tensor<8x197x1xf32>
+    %267 = stablehlo.sqrt %266 : tensor<8x197x1xf32>
+    %268 = stablehlo.broadcast_in_dim %267, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %269 = stablehlo.divide %264, %268 : tensor<8x197x768xf32>
+    %270 = stablehlo.broadcast_in_dim %arg32, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %271 = stablehlo.broadcast_in_dim %270, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %272 = stablehlo.multiply %269, %271 : tensor<8x197x768xf32>
+    %273 = stablehlo.broadcast_in_dim %arg33, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %274 = stablehlo.broadcast_in_dim %273, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %275 = stablehlo.add %272, %274 : tensor<8x197x768xf32>
+    %276 = stablehlo.dot_general %275, %arg30, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x3072xf32>) -> tensor<8x197x3072xf32>
+    %277 = stablehlo.multiply %276, %276 : tensor<8x197x3072xf32>
+    %278 = stablehlo.multiply %277, %276 : tensor<8x197x3072xf32>
+    %279 = stablehlo.broadcast_in_dim %cst_9, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %280 = stablehlo.multiply %279, %278 : tensor<8x197x3072xf32>
+    %281 = stablehlo.add %276, %280 : tensor<8x197x3072xf32>
+    %282 = stablehlo.broadcast_in_dim %cst_10, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %283 = stablehlo.multiply %282, %281 : tensor<8x197x3072xf32>
+    %284 = stablehlo.tanh %283 : tensor<8x197x3072xf32>
+    %285 = stablehlo.broadcast_in_dim %cst_11, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %286 = stablehlo.add %285, %284 : tensor<8x197x3072xf32>
+    %287 = stablehlo.broadcast_in_dim %cst_12, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %288 = stablehlo.multiply %287, %286 : tensor<8x197x3072xf32>
+    %289 = stablehlo.multiply %276, %288 : tensor<8x197x3072xf32>
+    %290 = stablehlo.dot_general %289, %arg31, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x3072xf32>, tensor<3072x768xf32>) -> tensor<8x197x768xf32>
+    %291 = stablehlo.add %251, %290 : tensor<8x197x768xf32>
+    %cst_25 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %292 = stablehlo.reduce(%291 init: %cst_25) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %293 = stablehlo.broadcast_in_dim %292, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %294 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %295 = stablehlo.divide %293, %294 : tensor<8x197x1xf32>
+    %296 = stablehlo.broadcast_in_dim %295, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %297 = stablehlo.subtract %291, %296 : tensor<8x197x768xf32>
+    %298 = stablehlo.multiply %297, %297 : tensor<8x197x768xf32>
+    %cst_26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %299 = stablehlo.reduce(%298 init: %cst_26) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %300 = stablehlo.broadcast_in_dim %299, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %301 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %302 = stablehlo.divide %300, %301 : tensor<8x197x1xf32>
+    %303 = stablehlo.broadcast_in_dim %295, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %304 = stablehlo.subtract %291, %303 : tensor<8x197x768xf32>
+    %305 = stablehlo.broadcast_in_dim %cst_2, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %306 = stablehlo.add %302, %305 : tensor<8x197x1xf32>
+    %307 = stablehlo.sqrt %306 : tensor<8x197x1xf32>
+    %308 = stablehlo.broadcast_in_dim %307, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %309 = stablehlo.divide %304, %308 : tensor<8x197x768xf32>
+    %310 = stablehlo.broadcast_in_dim %arg38, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %311 = stablehlo.broadcast_in_dim %310, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %312 = stablehlo.multiply %309, %311 : tensor<8x197x768xf32>
+    %313 = stablehlo.broadcast_in_dim %arg39, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %314 = stablehlo.broadcast_in_dim %313, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %315 = stablehlo.add %312, %314 : tensor<8x197x768xf32>
+    %316 = stablehlo.dot_general %315, %arg34, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %317 = stablehlo.dot_general %315, %arg35, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %318 = stablehlo.dot_general %315, %arg36, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %319 = stablehlo.reshape %316 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %320 = stablehlo.transpose %319, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %321 = stablehlo.reshape %317 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %322 = stablehlo.transpose %321, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %323 = stablehlo.reshape %318 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %324 = stablehlo.transpose %323, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %325 = stablehlo.transpose %322, dims = [0, 1, 3, 2] : (tensor<8x12x197x64xf32>) -> tensor<8x12x64x197xf32>
+    %326 = stablehlo.dot_general %320, %325, batching_dims = [0, 1] x [0, 1], contracting_dims = [3] x [2], precision = [DEFAULT, DEFAULT] : (tensor<8x12x197x64xf32>, tensor<8x12x64x197xf32>) -> tensor<8x12x197x197xf32>
+    %327 = stablehlo.sqrt %cst_3 : tensor<f32>
+    %328 = stablehlo.convert %327 : tensor<f32>
+    %329 = stablehlo.broadcast_in_dim %328, dims = [] : (tensor<f32>) -> tensor<8x12x197x197xf32>
+    %330 = stablehlo.divide %326, %329 : tensor<8x12x197x197xf32>
+    %cst_27 = stablehlo.constant dense<0xFF800000> : tensor<f32>
+    %331 = stablehlo.reduce(%330 init: %cst_27) applies stablehlo.maximum across dimensions = [3] : (tensor<8x12x197x197xf32>, tensor<f32>) -> tensor<8x12x197xf32>
+    %332 = stablehlo.broadcast_in_dim %cst_5, dims = [] : (tensor<f32>) -> tensor<8x12x197xf32>
+    %333 = stablehlo.maximum %332, %331 : tensor<8x12x197xf32>
+    %334 = stablehlo.broadcast_in_dim %333, dims = [0, 1, 2] : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+    %335 = stablehlo.broadcast_in_dim %334, dims = [0, 1, 2, 3] : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+    %336 = stablehlo.subtract %330, %335 : tensor<8x12x197x197xf32>
+    %337 = stablehlo.exponential %336 : tensor<8x12x197x197xf32>
+    %cst_28 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %338 = stablehlo.reduce(%337 init: %cst_28) applies stablehlo.add across dimensions = [3] : (tensor<8x12x197x197xf32>, tensor<f32>) -> tensor<8x12x197xf32>
+    %339 = stablehlo.broadcast_in_dim %338, dims = [0, 1, 2] : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+    %340 = stablehlo.broadcast_in_dim %339, dims = [0, 1, 2, 3] : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+    %341 = stablehlo.divide %337, %340 : tensor<8x12x197x197xf32>
+    %342 = stablehlo.dot_general %341, %324, batching_dims = [0, 1] x [0, 1], contracting_dims = [3] x [2], precision = [DEFAULT, DEFAULT] : (tensor<8x12x197x197xf32>, tensor<8x12x197x64xf32>) -> tensor<8x12x197x64xf32>
+    %343 = stablehlo.transpose %342, dims = [0, 2, 1, 3] : (tensor<8x12x197x64xf32>) -> tensor<8x197x12x64xf32>
+    %344 = stablehlo.reshape %343 : (tensor<8x197x12x64xf32>) -> tensor<8x197x768xf32>
+    %345 = stablehlo.dot_general %344, %arg37, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %346 = stablehlo.add %291, %345 : tensor<8x197x768xf32>
+    %cst_29 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %347 = stablehlo.reduce(%346 init: %cst_29) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %348 = stablehlo.broadcast_in_dim %347, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %349 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %350 = stablehlo.divide %348, %349 : tensor<8x197x1xf32>
+    %351 = stablehlo.broadcast_in_dim %350, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %352 = stablehlo.subtract %346, %351 : tensor<8x197x768xf32>
+    %353 = stablehlo.multiply %352, %352 : tensor<8x197x768xf32>
+    %cst_30 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %354 = stablehlo.reduce(%353 init: %cst_30) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %355 = stablehlo.broadcast_in_dim %354, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %356 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %357 = stablehlo.divide %355, %356 : tensor<8x197x1xf32>
+    %358 = stablehlo.broadcast_in_dim %350, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %359 = stablehlo.subtract %346, %358 : tensor<8x197x768xf32>
+    %360 = stablehlo.broadcast_in_dim %cst_2, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %361 = stablehlo.add %357, %360 : tensor<8x197x1xf32>
+    %362 = stablehlo.sqrt %361 : tensor<8x197x1xf32>
+    %363 = stablehlo.broadcast_in_dim %362, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %364 = stablehlo.divide %359, %363 : tensor<8x197x768xf32>
+    %365 = stablehlo.broadcast_in_dim %arg42, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %366 = stablehlo.broadcast_in_dim %365, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %367 = stablehlo.multiply %364, %366 : tensor<8x197x768xf32>
+    %368 = stablehlo.broadcast_in_dim %arg43, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %369 = stablehlo.broadcast_in_dim %368, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %370 = stablehlo.add %367, %369 : tensor<8x197x768xf32>
+    %371 = stablehlo.dot_general %370, %arg40, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x3072xf32>) -> tensor<8x197x3072xf32>
+    %372 = stablehlo.multiply %371, %371 : tensor<8x197x3072xf32>
+    %373 = stablehlo.multiply %372, %371 : tensor<8x197x3072xf32>
+    %374 = stablehlo.broadcast_in_dim %cst_9, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %375 = stablehlo.multiply %374, %373 : tensor<8x197x3072xf32>
+    %376 = stablehlo.add %371, %375 : tensor<8x197x3072xf32>
+    %377 = stablehlo.broadcast_in_dim %cst_10, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %378 = stablehlo.multiply %377, %376 : tensor<8x197x3072xf32>
+    %379 = stablehlo.tanh %378 : tensor<8x197x3072xf32>
+    %380 = stablehlo.broadcast_in_dim %cst_11, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %381 = stablehlo.add %380, %379 : tensor<8x197x3072xf32>
+    %382 = stablehlo.broadcast_in_dim %cst_12, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %383 = stablehlo.multiply %382, %381 : tensor<8x197x3072xf32>
+    %384 = stablehlo.multiply %371, %383 : tensor<8x197x3072xf32>
+    %385 = stablehlo.dot_general %384, %arg41, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x3072xf32>, tensor<3072x768xf32>) -> tensor<8x197x768xf32>
+    %386 = stablehlo.add %346, %385 : tensor<8x197x768xf32>
+    %cst_31 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %387 = stablehlo.reduce(%386 init: %cst_31) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %388 = stablehlo.broadcast_in_dim %387, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %389 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %390 = stablehlo.divide %388, %389 : tensor<8x197x1xf32>
+    %391 = stablehlo.broadcast_in_dim %390, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %392 = stablehlo.subtract %386, %391 : tensor<8x197x768xf32>
+    %393 = stablehlo.multiply %392, %392 : tensor<8x197x768xf32>
+    %cst_32 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %394 = stablehlo.reduce(%393 init: %cst_32) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %395 = stablehlo.broadcast_in_dim %394, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %396 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %397 = stablehlo.divide %395, %396 : tensor<8x197x1xf32>
+    %398 = stablehlo.broadcast_in_dim %390, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %399 = stablehlo.subtract %386, %398 : tensor<8x197x768xf32>
+    %400 = stablehlo.broadcast_in_dim %cst_2, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %401 = stablehlo.add %397, %400 : tensor<8x197x1xf32>
+    %402 = stablehlo.sqrt %401 : tensor<8x197x1xf32>
+    %403 = stablehlo.broadcast_in_dim %402, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %404 = stablehlo.divide %399, %403 : tensor<8x197x768xf32>
+    %405 = stablehlo.broadcast_in_dim %arg48, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %406 = stablehlo.broadcast_in_dim %405, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %407 = stablehlo.multiply %404, %406 : tensor<8x197x768xf32>
+    %408 = stablehlo.broadcast_in_dim %arg49, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %409 = stablehlo.broadcast_in_dim %408, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %410 = stablehlo.add %407, %409 : tensor<8x197x768xf32>
+    %411 = stablehlo.dot_general %410, %arg44, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %412 = stablehlo.dot_general %410, %arg45, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %413 = stablehlo.dot_general %410, %arg46, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %414 = stablehlo.reshape %411 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %415 = stablehlo.transpose %414, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %416 = stablehlo.reshape %412 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %417 = stablehlo.transpose %416, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %418 = stablehlo.reshape %413 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %419 = stablehlo.transpose %418, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %420 = stablehlo.transpose %417, dims = [0, 1, 3, 2] : (tensor<8x12x197x64xf32>) -> tensor<8x12x64x197xf32>
+    %421 = stablehlo.dot_general %415, %420, batching_dims = [0, 1] x [0, 1], contracting_dims = [3] x [2], precision = [DEFAULT, DEFAULT] : (tensor<8x12x197x64xf32>, tensor<8x12x64x197xf32>) -> tensor<8x12x197x197xf32>
+    %422 = stablehlo.sqrt %cst_3 : tensor<f32>
+    %423 = stablehlo.convert %422 : tensor<f32>
+    %424 = stablehlo.broadcast_in_dim %423, dims = [] : (tensor<f32>) -> tensor<8x12x197x197xf32>
+    %425 = stablehlo.divide %421, %424 : tensor<8x12x197x197xf32>
+    %cst_33 = stablehlo.constant dense<0xFF800000> : tensor<f32>
+    %426 = stablehlo.reduce(%425 init: %cst_33) applies stablehlo.maximum across dimensions = [3] : (tensor<8x12x197x197xf32>, tensor<f32>) -> tensor<8x12x197xf32>
+    %427 = stablehlo.broadcast_in_dim %cst_5, dims = [] : (tensor<f32>) -> tensor<8x12x197xf32>
+    %428 = stablehlo.maximum %427, %426 : tensor<8x12x197xf32>
+    %429 = stablehlo.broadcast_in_dim %428, dims = [0, 1, 2] : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+    %430 = stablehlo.broadcast_in_dim %429, dims = [0, 1, 2, 3] : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+    %431 = stablehlo.subtract %425, %430 : tensor<8x12x197x197xf32>
+    %432 = stablehlo.exponential %431 : tensor<8x12x197x197xf32>
+    %cst_34 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %433 = stablehlo.reduce(%432 init: %cst_34) applies stablehlo.add across dimensions = [3] : (tensor<8x12x197x197xf32>, tensor<f32>) -> tensor<8x12x197xf32>
+    %434 = stablehlo.broadcast_in_dim %433, dims = [0, 1, 2] : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+    %435 = stablehlo.broadcast_in_dim %434, dims = [0, 1, 2, 3] : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+    %436 = stablehlo.divide %432, %435 : tensor<8x12x197x197xf32>
+    %437 = stablehlo.dot_general %436, %419, batching_dims = [0, 1] x [0, 1], contracting_dims = [3] x [2], precision = [DEFAULT, DEFAULT] : (tensor<8x12x197x197xf32>, tensor<8x12x197x64xf32>) -> tensor<8x12x197x64xf32>
+    %438 = stablehlo.transpose %437, dims = [0, 2, 1, 3] : (tensor<8x12x197x64xf32>) -> tensor<8x197x12x64xf32>
+    %439 = stablehlo.reshape %438 : (tensor<8x197x12x64xf32>) -> tensor<8x197x768xf32>
+    %440 = stablehlo.dot_general %439, %arg47, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %441 = stablehlo.add %386, %440 : tensor<8x197x768xf32>
+    %cst_35 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %442 = stablehlo.reduce(%441 init: %cst_35) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %443 = stablehlo.broadcast_in_dim %442, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %444 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %445 = stablehlo.divide %443, %444 : tensor<8x197x1xf32>
+    %446 = stablehlo.broadcast_in_dim %445, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %447 = stablehlo.subtract %441, %446 : tensor<8x197x768xf32>
+    %448 = stablehlo.multiply %447, %447 : tensor<8x197x768xf32>
+    %cst_36 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %449 = stablehlo.reduce(%448 init: %cst_36) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %450 = stablehlo.broadcast_in_dim %449, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %451 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %452 = stablehlo.divide %450, %451 : tensor<8x197x1xf32>
+    %453 = stablehlo.broadcast_in_dim %445, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %454 = stablehlo.subtract %441, %453 : tensor<8x197x768xf32>
+    %455 = stablehlo.broadcast_in_dim %cst_2, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %456 = stablehlo.add %452, %455 : tensor<8x197x1xf32>
+    %457 = stablehlo.sqrt %456 : tensor<8x197x1xf32>
+    %458 = stablehlo.broadcast_in_dim %457, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %459 = stablehlo.divide %454, %458 : tensor<8x197x768xf32>
+    %460 = stablehlo.broadcast_in_dim %arg52, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %461 = stablehlo.broadcast_in_dim %460, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %462 = stablehlo.multiply %459, %461 : tensor<8x197x768xf32>
+    %463 = stablehlo.broadcast_in_dim %arg53, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %464 = stablehlo.broadcast_in_dim %463, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %465 = stablehlo.add %462, %464 : tensor<8x197x768xf32>
+    %466 = stablehlo.dot_general %465, %arg50, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x3072xf32>) -> tensor<8x197x3072xf32>
+    %467 = stablehlo.multiply %466, %466 : tensor<8x197x3072xf32>
+    %468 = stablehlo.multiply %467, %466 : tensor<8x197x3072xf32>
+    %469 = stablehlo.broadcast_in_dim %cst_9, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %470 = stablehlo.multiply %469, %468 : tensor<8x197x3072xf32>
+    %471 = stablehlo.add %466, %470 : tensor<8x197x3072xf32>
+    %472 = stablehlo.broadcast_in_dim %cst_10, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %473 = stablehlo.multiply %472, %471 : tensor<8x197x3072xf32>
+    %474 = stablehlo.tanh %473 : tensor<8x197x3072xf32>
+    %475 = stablehlo.broadcast_in_dim %cst_11, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %476 = stablehlo.add %475, %474 : tensor<8x197x3072xf32>
+    %477 = stablehlo.broadcast_in_dim %cst_12, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %478 = stablehlo.multiply %477, %476 : tensor<8x197x3072xf32>
+    %479 = stablehlo.multiply %466, %478 : tensor<8x197x3072xf32>
+    %480 = stablehlo.dot_general %479, %arg51, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x3072xf32>, tensor<3072x768xf32>) -> tensor<8x197x768xf32>
+    %481 = stablehlo.add %441, %480 : tensor<8x197x768xf32>
+    %cst_37 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %482 = stablehlo.reduce(%481 init: %cst_37) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %483 = stablehlo.broadcast_in_dim %482, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %484 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %485 = stablehlo.divide %483, %484 : tensor<8x197x1xf32>
+    %486 = stablehlo.broadcast_in_dim %485, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %487 = stablehlo.subtract %481, %486 : tensor<8x197x768xf32>
+    %488 = stablehlo.multiply %487, %487 : tensor<8x197x768xf32>
+    %cst_38 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %489 = stablehlo.reduce(%488 init: %cst_38) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %490 = stablehlo.broadcast_in_dim %489, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %491 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %492 = stablehlo.divide %490, %491 : tensor<8x197x1xf32>
+    %493 = stablehlo.broadcast_in_dim %485, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %494 = stablehlo.subtract %481, %493 : tensor<8x197x768xf32>
+    %495 = stablehlo.broadcast_in_dim %cst_2, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %496 = stablehlo.add %492, %495 : tensor<8x197x1xf32>
+    %497 = stablehlo.sqrt %496 : tensor<8x197x1xf32>
+    %498 = stablehlo.broadcast_in_dim %497, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %499 = stablehlo.divide %494, %498 : tensor<8x197x768xf32>
+    %500 = stablehlo.broadcast_in_dim %arg58, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %501 = stablehlo.broadcast_in_dim %500, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %502 = stablehlo.multiply %499, %501 : tensor<8x197x768xf32>
+    %503 = stablehlo.broadcast_in_dim %arg59, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %504 = stablehlo.broadcast_in_dim %503, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %505 = stablehlo.add %502, %504 : tensor<8x197x768xf32>
+    %506 = stablehlo.dot_general %505, %arg54, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %507 = stablehlo.dot_general %505, %arg55, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %508 = stablehlo.dot_general %505, %arg56, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %509 = stablehlo.reshape %506 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %510 = stablehlo.transpose %509, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %511 = stablehlo.reshape %507 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %512 = stablehlo.transpose %511, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %513 = stablehlo.reshape %508 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %514 = stablehlo.transpose %513, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %515 = stablehlo.transpose %512, dims = [0, 1, 3, 2] : (tensor<8x12x197x64xf32>) -> tensor<8x12x64x197xf32>
+    %516 = stablehlo.dot_general %510, %515, batching_dims = [0, 1] x [0, 1], contracting_dims = [3] x [2], precision = [DEFAULT, DEFAULT] : (tensor<8x12x197x64xf32>, tensor<8x12x64x197xf32>) -> tensor<8x12x197x197xf32>
+    %517 = stablehlo.sqrt %cst_3 : tensor<f32>
+    %518 = stablehlo.convert %517 : tensor<f32>
+    %519 = stablehlo.broadcast_in_dim %518, dims = [] : (tensor<f32>) -> tensor<8x12x197x197xf32>
+    %520 = stablehlo.divide %516, %519 : tensor<8x12x197x197xf32>
+    %cst_39 = stablehlo.constant dense<0xFF800000> : tensor<f32>
+    %521 = stablehlo.reduce(%520 init: %cst_39) applies stablehlo.maximum across dimensions = [3] : (tensor<8x12x197x197xf32>, tensor<f32>) -> tensor<8x12x197xf32>
+    %522 = stablehlo.broadcast_in_dim %cst_5, dims = [] : (tensor<f32>) -> tensor<8x12x197xf32>
+    %523 = stablehlo.maximum %522, %521 : tensor<8x12x197xf32>
+    %524 = stablehlo.broadcast_in_dim %523, dims = [0, 1, 2] : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+    %525 = stablehlo.broadcast_in_dim %524, dims = [0, 1, 2, 3] : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+    %526 = stablehlo.subtract %520, %525 : tensor<8x12x197x197xf32>
+    %527 = stablehlo.exponential %526 : tensor<8x12x197x197xf32>
+    %cst_40 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %528 = stablehlo.reduce(%527 init: %cst_40) applies stablehlo.add across dimensions = [3] : (tensor<8x12x197x197xf32>, tensor<f32>) -> tensor<8x12x197xf32>
+    %529 = stablehlo.broadcast_in_dim %528, dims = [0, 1, 2] : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+    %530 = stablehlo.broadcast_in_dim %529, dims = [0, 1, 2, 3] : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+    %531 = stablehlo.divide %527, %530 : tensor<8x12x197x197xf32>
+    %532 = stablehlo.dot_general %531, %514, batching_dims = [0, 1] x [0, 1], contracting_dims = [3] x [2], precision = [DEFAULT, DEFAULT] : (tensor<8x12x197x197xf32>, tensor<8x12x197x64xf32>) -> tensor<8x12x197x64xf32>
+    %533 = stablehlo.transpose %532, dims = [0, 2, 1, 3] : (tensor<8x12x197x64xf32>) -> tensor<8x197x12x64xf32>
+    %534 = stablehlo.reshape %533 : (tensor<8x197x12x64xf32>) -> tensor<8x197x768xf32>
+    %535 = stablehlo.dot_general %534, %arg57, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %536 = stablehlo.add %481, %535 : tensor<8x197x768xf32>
+    %cst_41 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %537 = stablehlo.reduce(%536 init: %cst_41) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %538 = stablehlo.broadcast_in_dim %537, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %539 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %540 = stablehlo.divide %538, %539 : tensor<8x197x1xf32>
+    %541 = stablehlo.broadcast_in_dim %540, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %542 = stablehlo.subtract %536, %541 : tensor<8x197x768xf32>
+    %543 = stablehlo.multiply %542, %542 : tensor<8x197x768xf32>
+    %cst_42 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %544 = stablehlo.reduce(%543 init: %cst_42) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %545 = stablehlo.broadcast_in_dim %544, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %546 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %547 = stablehlo.divide %545, %546 : tensor<8x197x1xf32>
+    %548 = stablehlo.broadcast_in_dim %540, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %549 = stablehlo.subtract %536, %548 : tensor<8x197x768xf32>
+    %550 = stablehlo.broadcast_in_dim %cst_2, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %551 = stablehlo.add %547, %550 : tensor<8x197x1xf32>
+    %552 = stablehlo.sqrt %551 : tensor<8x197x1xf32>
+    %553 = stablehlo.broadcast_in_dim %552, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %554 = stablehlo.divide %549, %553 : tensor<8x197x768xf32>
+    %555 = stablehlo.broadcast_in_dim %arg62, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %556 = stablehlo.broadcast_in_dim %555, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %557 = stablehlo.multiply %554, %556 : tensor<8x197x768xf32>
+    %558 = stablehlo.broadcast_in_dim %arg63, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %559 = stablehlo.broadcast_in_dim %558, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %560 = stablehlo.add %557, %559 : tensor<8x197x768xf32>
+    %561 = stablehlo.dot_general %560, %arg60, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x3072xf32>) -> tensor<8x197x3072xf32>
+    %562 = stablehlo.multiply %561, %561 : tensor<8x197x3072xf32>
+    %563 = stablehlo.multiply %562, %561 : tensor<8x197x3072xf32>
+    %564 = stablehlo.broadcast_in_dim %cst_9, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %565 = stablehlo.multiply %564, %563 : tensor<8x197x3072xf32>
+    %566 = stablehlo.add %561, %565 : tensor<8x197x3072xf32>
+    %567 = stablehlo.broadcast_in_dim %cst_10, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %568 = stablehlo.multiply %567, %566 : tensor<8x197x3072xf32>
+    %569 = stablehlo.tanh %568 : tensor<8x197x3072xf32>
+    %570 = stablehlo.broadcast_in_dim %cst_11, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %571 = stablehlo.add %570, %569 : tensor<8x197x3072xf32>
+    %572 = stablehlo.broadcast_in_dim %cst_12, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %573 = stablehlo.multiply %572, %571 : tensor<8x197x3072xf32>
+    %574 = stablehlo.multiply %561, %573 : tensor<8x197x3072xf32>
+    %575 = stablehlo.dot_general %574, %arg61, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x3072xf32>, tensor<3072x768xf32>) -> tensor<8x197x768xf32>
+    %576 = stablehlo.add %536, %575 : tensor<8x197x768xf32>
+    %cst_43 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %577 = stablehlo.reduce(%576 init: %cst_43) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %578 = stablehlo.broadcast_in_dim %577, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %579 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %580 = stablehlo.divide %578, %579 : tensor<8x197x1xf32>
+    %581 = stablehlo.broadcast_in_dim %580, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %582 = stablehlo.subtract %576, %581 : tensor<8x197x768xf32>
+    %583 = stablehlo.multiply %582, %582 : tensor<8x197x768xf32>
+    %cst_44 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %584 = stablehlo.reduce(%583 init: %cst_44) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %585 = stablehlo.broadcast_in_dim %584, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %586 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %587 = stablehlo.divide %585, %586 : tensor<8x197x1xf32>
+    %588 = stablehlo.broadcast_in_dim %580, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %589 = stablehlo.subtract %576, %588 : tensor<8x197x768xf32>
+    %590 = stablehlo.broadcast_in_dim %cst_2, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %591 = stablehlo.add %587, %590 : tensor<8x197x1xf32>
+    %592 = stablehlo.sqrt %591 : tensor<8x197x1xf32>
+    %593 = stablehlo.broadcast_in_dim %592, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %594 = stablehlo.divide %589, %593 : tensor<8x197x768xf32>
+    %595 = stablehlo.broadcast_in_dim %arg68, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %596 = stablehlo.broadcast_in_dim %595, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %597 = stablehlo.multiply %594, %596 : tensor<8x197x768xf32>
+    %598 = stablehlo.broadcast_in_dim %arg69, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %599 = stablehlo.broadcast_in_dim %598, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %600 = stablehlo.add %597, %599 : tensor<8x197x768xf32>
+    %601 = stablehlo.dot_general %600, %arg64, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %602 = stablehlo.dot_general %600, %arg65, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %603 = stablehlo.dot_general %600, %arg66, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %604 = stablehlo.reshape %601 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %605 = stablehlo.transpose %604, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %606 = stablehlo.reshape %602 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %607 = stablehlo.transpose %606, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %608 = stablehlo.reshape %603 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %609 = stablehlo.transpose %608, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %610 = stablehlo.transpose %607, dims = [0, 1, 3, 2] : (tensor<8x12x197x64xf32>) -> tensor<8x12x64x197xf32>
+    %611 = stablehlo.dot_general %605, %610, batching_dims = [0, 1] x [0, 1], contracting_dims = [3] x [2], precision = [DEFAULT, DEFAULT] : (tensor<8x12x197x64xf32>, tensor<8x12x64x197xf32>) -> tensor<8x12x197x197xf32>
+    %612 = stablehlo.sqrt %cst_3 : tensor<f32>
+    %613 = stablehlo.convert %612 : tensor<f32>
+    %614 = stablehlo.broadcast_in_dim %613, dims = [] : (tensor<f32>) -> tensor<8x12x197x197xf32>
+    %615 = stablehlo.divide %611, %614 : tensor<8x12x197x197xf32>
+    %cst_45 = stablehlo.constant dense<0xFF800000> : tensor<f32>
+    %616 = stablehlo.reduce(%615 init: %cst_45) applies stablehlo.maximum across dimensions = [3] : (tensor<8x12x197x197xf32>, tensor<f32>) -> tensor<8x12x197xf32>
+    %617 = stablehlo.broadcast_in_dim %cst_5, dims = [] : (tensor<f32>) -> tensor<8x12x197xf32>
+    %618 = stablehlo.maximum %617, %616 : tensor<8x12x197xf32>
+    %619 = stablehlo.broadcast_in_dim %618, dims = [0, 1, 2] : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+    %620 = stablehlo.broadcast_in_dim %619, dims = [0, 1, 2, 3] : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+    %621 = stablehlo.subtract %615, %620 : tensor<8x12x197x197xf32>
+    %622 = stablehlo.exponential %621 : tensor<8x12x197x197xf32>
+    %cst_46 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %623 = stablehlo.reduce(%622 init: %cst_46) applies stablehlo.add across dimensions = [3] : (tensor<8x12x197x197xf32>, tensor<f32>) -> tensor<8x12x197xf32>
+    %624 = stablehlo.broadcast_in_dim %623, dims = [0, 1, 2] : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+    %625 = stablehlo.broadcast_in_dim %624, dims = [0, 1, 2, 3] : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+    %626 = stablehlo.divide %622, %625 : tensor<8x12x197x197xf32>
+    %627 = stablehlo.dot_general %626, %609, batching_dims = [0, 1] x [0, 1], contracting_dims = [3] x [2], precision = [DEFAULT, DEFAULT] : (tensor<8x12x197x197xf32>, tensor<8x12x197x64xf32>) -> tensor<8x12x197x64xf32>
+    %628 = stablehlo.transpose %627, dims = [0, 2, 1, 3] : (tensor<8x12x197x64xf32>) -> tensor<8x197x12x64xf32>
+    %629 = stablehlo.reshape %628 : (tensor<8x197x12x64xf32>) -> tensor<8x197x768xf32>
+    %630 = stablehlo.dot_general %629, %arg67, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %631 = stablehlo.add %576, %630 : tensor<8x197x768xf32>
+    %cst_47 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %632 = stablehlo.reduce(%631 init: %cst_47) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %633 = stablehlo.broadcast_in_dim %632, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %634 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %635 = stablehlo.divide %633, %634 : tensor<8x197x1xf32>
+    %636 = stablehlo.broadcast_in_dim %635, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %637 = stablehlo.subtract %631, %636 : tensor<8x197x768xf32>
+    %638 = stablehlo.multiply %637, %637 : tensor<8x197x768xf32>
+    %cst_48 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %639 = stablehlo.reduce(%638 init: %cst_48) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %640 = stablehlo.broadcast_in_dim %639, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %641 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %642 = stablehlo.divide %640, %641 : tensor<8x197x1xf32>
+    %643 = stablehlo.broadcast_in_dim %635, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %644 = stablehlo.subtract %631, %643 : tensor<8x197x768xf32>
+    %645 = stablehlo.broadcast_in_dim %cst_2, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %646 = stablehlo.add %642, %645 : tensor<8x197x1xf32>
+    %647 = stablehlo.sqrt %646 : tensor<8x197x1xf32>
+    %648 = stablehlo.broadcast_in_dim %647, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %649 = stablehlo.divide %644, %648 : tensor<8x197x768xf32>
+    %650 = stablehlo.broadcast_in_dim %arg72, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %651 = stablehlo.broadcast_in_dim %650, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %652 = stablehlo.multiply %649, %651 : tensor<8x197x768xf32>
+    %653 = stablehlo.broadcast_in_dim %arg73, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %654 = stablehlo.broadcast_in_dim %653, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %655 = stablehlo.add %652, %654 : tensor<8x197x768xf32>
+    %656 = stablehlo.dot_general %655, %arg70, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x3072xf32>) -> tensor<8x197x3072xf32>
+    %657 = stablehlo.multiply %656, %656 : tensor<8x197x3072xf32>
+    %658 = stablehlo.multiply %657, %656 : tensor<8x197x3072xf32>
+    %659 = stablehlo.broadcast_in_dim %cst_9, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %660 = stablehlo.multiply %659, %658 : tensor<8x197x3072xf32>
+    %661 = stablehlo.add %656, %660 : tensor<8x197x3072xf32>
+    %662 = stablehlo.broadcast_in_dim %cst_10, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %663 = stablehlo.multiply %662, %661 : tensor<8x197x3072xf32>
+    %664 = stablehlo.tanh %663 : tensor<8x197x3072xf32>
+    %665 = stablehlo.broadcast_in_dim %cst_11, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %666 = stablehlo.add %665, %664 : tensor<8x197x3072xf32>
+    %667 = stablehlo.broadcast_in_dim %cst_12, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %668 = stablehlo.multiply %667, %666 : tensor<8x197x3072xf32>
+    %669 = stablehlo.multiply %656, %668 : tensor<8x197x3072xf32>
+    %670 = stablehlo.dot_general %669, %arg71, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x3072xf32>, tensor<3072x768xf32>) -> tensor<8x197x768xf32>
+    %671 = stablehlo.add %631, %670 : tensor<8x197x768xf32>
+    %cst_49 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %672 = stablehlo.reduce(%671 init: %cst_49) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %673 = stablehlo.broadcast_in_dim %672, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %674 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %675 = stablehlo.divide %673, %674 : tensor<8x197x1xf32>
+    %676 = stablehlo.broadcast_in_dim %675, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %677 = stablehlo.subtract %671, %676 : tensor<8x197x768xf32>
+    %678 = stablehlo.multiply %677, %677 : tensor<8x197x768xf32>
+    %cst_50 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %679 = stablehlo.reduce(%678 init: %cst_50) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %680 = stablehlo.broadcast_in_dim %679, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %681 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %682 = stablehlo.divide %680, %681 : tensor<8x197x1xf32>
+    %683 = stablehlo.broadcast_in_dim %675, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %684 = stablehlo.subtract %671, %683 : tensor<8x197x768xf32>
+    %685 = stablehlo.broadcast_in_dim %cst_2, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %686 = stablehlo.add %682, %685 : tensor<8x197x1xf32>
+    %687 = stablehlo.sqrt %686 : tensor<8x197x1xf32>
+    %688 = stablehlo.broadcast_in_dim %687, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %689 = stablehlo.divide %684, %688 : tensor<8x197x768xf32>
+    %690 = stablehlo.broadcast_in_dim %arg78, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %691 = stablehlo.broadcast_in_dim %690, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %692 = stablehlo.multiply %689, %691 : tensor<8x197x768xf32>
+    %693 = stablehlo.broadcast_in_dim %arg79, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %694 = stablehlo.broadcast_in_dim %693, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %695 = stablehlo.add %692, %694 : tensor<8x197x768xf32>
+    %696 = stablehlo.dot_general %695, %arg74, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %697 = stablehlo.dot_general %695, %arg75, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %698 = stablehlo.dot_general %695, %arg76, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %699 = stablehlo.reshape %696 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %700 = stablehlo.transpose %699, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %701 = stablehlo.reshape %697 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %702 = stablehlo.transpose %701, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %703 = stablehlo.reshape %698 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %704 = stablehlo.transpose %703, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %705 = stablehlo.transpose %702, dims = [0, 1, 3, 2] : (tensor<8x12x197x64xf32>) -> tensor<8x12x64x197xf32>
+    %706 = stablehlo.dot_general %700, %705, batching_dims = [0, 1] x [0, 1], contracting_dims = [3] x [2], precision = [DEFAULT, DEFAULT] : (tensor<8x12x197x64xf32>, tensor<8x12x64x197xf32>) -> tensor<8x12x197x197xf32>
+    %707 = stablehlo.sqrt %cst_3 : tensor<f32>
+    %708 = stablehlo.convert %707 : tensor<f32>
+    %709 = stablehlo.broadcast_in_dim %708, dims = [] : (tensor<f32>) -> tensor<8x12x197x197xf32>
+    %710 = stablehlo.divide %706, %709 : tensor<8x12x197x197xf32>
+    %cst_51 = stablehlo.constant dense<0xFF800000> : tensor<f32>
+    %711 = stablehlo.reduce(%710 init: %cst_51) applies stablehlo.maximum across dimensions = [3] : (tensor<8x12x197x197xf32>, tensor<f32>) -> tensor<8x12x197xf32>
+    %712 = stablehlo.broadcast_in_dim %cst_5, dims = [] : (tensor<f32>) -> tensor<8x12x197xf32>
+    %713 = stablehlo.maximum %712, %711 : tensor<8x12x197xf32>
+    %714 = stablehlo.broadcast_in_dim %713, dims = [0, 1, 2] : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+    %715 = stablehlo.broadcast_in_dim %714, dims = [0, 1, 2, 3] : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+    %716 = stablehlo.subtract %710, %715 : tensor<8x12x197x197xf32>
+    %717 = stablehlo.exponential %716 : tensor<8x12x197x197xf32>
+    %cst_52 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %718 = stablehlo.reduce(%717 init: %cst_52) applies stablehlo.add across dimensions = [3] : (tensor<8x12x197x197xf32>, tensor<f32>) -> tensor<8x12x197xf32>
+    %719 = stablehlo.broadcast_in_dim %718, dims = [0, 1, 2] : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+    %720 = stablehlo.broadcast_in_dim %719, dims = [0, 1, 2, 3] : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+    %721 = stablehlo.divide %717, %720 : tensor<8x12x197x197xf32>
+    %722 = stablehlo.dot_general %721, %704, batching_dims = [0, 1] x [0, 1], contracting_dims = [3] x [2], precision = [DEFAULT, DEFAULT] : (tensor<8x12x197x197xf32>, tensor<8x12x197x64xf32>) -> tensor<8x12x197x64xf32>
+    %723 = stablehlo.transpose %722, dims = [0, 2, 1, 3] : (tensor<8x12x197x64xf32>) -> tensor<8x197x12x64xf32>
+    %724 = stablehlo.reshape %723 : (tensor<8x197x12x64xf32>) -> tensor<8x197x768xf32>
+    %725 = stablehlo.dot_general %724, %arg77, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %726 = stablehlo.add %671, %725 : tensor<8x197x768xf32>
+    %cst_53 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %727 = stablehlo.reduce(%726 init: %cst_53) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %728 = stablehlo.broadcast_in_dim %727, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %729 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %730 = stablehlo.divide %728, %729 : tensor<8x197x1xf32>
+    %731 = stablehlo.broadcast_in_dim %730, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %732 = stablehlo.subtract %726, %731 : tensor<8x197x768xf32>
+    %733 = stablehlo.multiply %732, %732 : tensor<8x197x768xf32>
+    %cst_54 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %734 = stablehlo.reduce(%733 init: %cst_54) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %735 = stablehlo.broadcast_in_dim %734, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %736 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %737 = stablehlo.divide %735, %736 : tensor<8x197x1xf32>
+    %738 = stablehlo.broadcast_in_dim %730, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %739 = stablehlo.subtract %726, %738 : tensor<8x197x768xf32>
+    %740 = stablehlo.broadcast_in_dim %cst_2, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %741 = stablehlo.add %737, %740 : tensor<8x197x1xf32>
+    %742 = stablehlo.sqrt %741 : tensor<8x197x1xf32>
+    %743 = stablehlo.broadcast_in_dim %742, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %744 = stablehlo.divide %739, %743 : tensor<8x197x768xf32>
+    %745 = stablehlo.broadcast_in_dim %arg82, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %746 = stablehlo.broadcast_in_dim %745, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %747 = stablehlo.multiply %744, %746 : tensor<8x197x768xf32>
+    %748 = stablehlo.broadcast_in_dim %arg83, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %749 = stablehlo.broadcast_in_dim %748, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %750 = stablehlo.add %747, %749 : tensor<8x197x768xf32>
+    %751 = stablehlo.dot_general %750, %arg80, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x3072xf32>) -> tensor<8x197x3072xf32>
+    %752 = stablehlo.multiply %751, %751 : tensor<8x197x3072xf32>
+    %753 = stablehlo.multiply %752, %751 : tensor<8x197x3072xf32>
+    %754 = stablehlo.broadcast_in_dim %cst_9, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %755 = stablehlo.multiply %754, %753 : tensor<8x197x3072xf32>
+    %756 = stablehlo.add %751, %755 : tensor<8x197x3072xf32>
+    %757 = stablehlo.broadcast_in_dim %cst_10, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %758 = stablehlo.multiply %757, %756 : tensor<8x197x3072xf32>
+    %759 = stablehlo.tanh %758 : tensor<8x197x3072xf32>
+    %760 = stablehlo.broadcast_in_dim %cst_11, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %761 = stablehlo.add %760, %759 : tensor<8x197x3072xf32>
+    %762 = stablehlo.broadcast_in_dim %cst_12, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %763 = stablehlo.multiply %762, %761 : tensor<8x197x3072xf32>
+    %764 = stablehlo.multiply %751, %763 : tensor<8x197x3072xf32>
+    %765 = stablehlo.dot_general %764, %arg81, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x3072xf32>, tensor<3072x768xf32>) -> tensor<8x197x768xf32>
+    %766 = stablehlo.add %726, %765 : tensor<8x197x768xf32>
+    %cst_55 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %767 = stablehlo.reduce(%766 init: %cst_55) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %768 = stablehlo.broadcast_in_dim %767, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %769 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %770 = stablehlo.divide %768, %769 : tensor<8x197x1xf32>
+    %771 = stablehlo.broadcast_in_dim %770, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %772 = stablehlo.subtract %766, %771 : tensor<8x197x768xf32>
+    %773 = stablehlo.multiply %772, %772 : tensor<8x197x768xf32>
+    %cst_56 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %774 = stablehlo.reduce(%773 init: %cst_56) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %775 = stablehlo.broadcast_in_dim %774, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %776 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %777 = stablehlo.divide %775, %776 : tensor<8x197x1xf32>
+    %778 = stablehlo.broadcast_in_dim %770, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %779 = stablehlo.subtract %766, %778 : tensor<8x197x768xf32>
+    %780 = stablehlo.broadcast_in_dim %cst_2, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %781 = stablehlo.add %777, %780 : tensor<8x197x1xf32>
+    %782 = stablehlo.sqrt %781 : tensor<8x197x1xf32>
+    %783 = stablehlo.broadcast_in_dim %782, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %784 = stablehlo.divide %779, %783 : tensor<8x197x768xf32>
+    %785 = stablehlo.broadcast_in_dim %arg88, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %786 = stablehlo.broadcast_in_dim %785, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %787 = stablehlo.multiply %784, %786 : tensor<8x197x768xf32>
+    %788 = stablehlo.broadcast_in_dim %arg89, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %789 = stablehlo.broadcast_in_dim %788, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %790 = stablehlo.add %787, %789 : tensor<8x197x768xf32>
+    %791 = stablehlo.dot_general %790, %arg84, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %792 = stablehlo.dot_general %790, %arg85, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %793 = stablehlo.dot_general %790, %arg86, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %794 = stablehlo.reshape %791 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %795 = stablehlo.transpose %794, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %796 = stablehlo.reshape %792 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %797 = stablehlo.transpose %796, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %798 = stablehlo.reshape %793 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %799 = stablehlo.transpose %798, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %800 = stablehlo.transpose %797, dims = [0, 1, 3, 2] : (tensor<8x12x197x64xf32>) -> tensor<8x12x64x197xf32>
+    %801 = stablehlo.dot_general %795, %800, batching_dims = [0, 1] x [0, 1], contracting_dims = [3] x [2], precision = [DEFAULT, DEFAULT] : (tensor<8x12x197x64xf32>, tensor<8x12x64x197xf32>) -> tensor<8x12x197x197xf32>
+    %802 = stablehlo.sqrt %cst_3 : tensor<f32>
+    %803 = stablehlo.convert %802 : tensor<f32>
+    %804 = stablehlo.broadcast_in_dim %803, dims = [] : (tensor<f32>) -> tensor<8x12x197x197xf32>
+    %805 = stablehlo.divide %801, %804 : tensor<8x12x197x197xf32>
+    %cst_57 = stablehlo.constant dense<0xFF800000> : tensor<f32>
+    %806 = stablehlo.reduce(%805 init: %cst_57) applies stablehlo.maximum across dimensions = [3] : (tensor<8x12x197x197xf32>, tensor<f32>) -> tensor<8x12x197xf32>
+    %807 = stablehlo.broadcast_in_dim %cst_5, dims = [] : (tensor<f32>) -> tensor<8x12x197xf32>
+    %808 = stablehlo.maximum %807, %806 : tensor<8x12x197xf32>
+    %809 = stablehlo.broadcast_in_dim %808, dims = [0, 1, 2] : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+    %810 = stablehlo.broadcast_in_dim %809, dims = [0, 1, 2, 3] : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+    %811 = stablehlo.subtract %805, %810 : tensor<8x12x197x197xf32>
+    %812 = stablehlo.exponential %811 : tensor<8x12x197x197xf32>
+    %cst_58 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %813 = stablehlo.reduce(%812 init: %cst_58) applies stablehlo.add across dimensions = [3] : (tensor<8x12x197x197xf32>, tensor<f32>) -> tensor<8x12x197xf32>
+    %814 = stablehlo.broadcast_in_dim %813, dims = [0, 1, 2] : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+    %815 = stablehlo.broadcast_in_dim %814, dims = [0, 1, 2, 3] : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+    %816 = stablehlo.divide %812, %815 : tensor<8x12x197x197xf32>
+    %817 = stablehlo.dot_general %816, %799, batching_dims = [0, 1] x [0, 1], contracting_dims = [3] x [2], precision = [DEFAULT, DEFAULT] : (tensor<8x12x197x197xf32>, tensor<8x12x197x64xf32>) -> tensor<8x12x197x64xf32>
+    %818 = stablehlo.transpose %817, dims = [0, 2, 1, 3] : (tensor<8x12x197x64xf32>) -> tensor<8x197x12x64xf32>
+    %819 = stablehlo.reshape %818 : (tensor<8x197x12x64xf32>) -> tensor<8x197x768xf32>
+    %820 = stablehlo.dot_general %819, %arg87, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %821 = stablehlo.add %766, %820 : tensor<8x197x768xf32>
+    %cst_59 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %822 = stablehlo.reduce(%821 init: %cst_59) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %823 = stablehlo.broadcast_in_dim %822, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %824 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %825 = stablehlo.divide %823, %824 : tensor<8x197x1xf32>
+    %826 = stablehlo.broadcast_in_dim %825, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %827 = stablehlo.subtract %821, %826 : tensor<8x197x768xf32>
+    %828 = stablehlo.multiply %827, %827 : tensor<8x197x768xf32>
+    %cst_60 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %829 = stablehlo.reduce(%828 init: %cst_60) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %830 = stablehlo.broadcast_in_dim %829, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %831 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %832 = stablehlo.divide %830, %831 : tensor<8x197x1xf32>
+    %833 = stablehlo.broadcast_in_dim %825, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %834 = stablehlo.subtract %821, %833 : tensor<8x197x768xf32>
+    %835 = stablehlo.broadcast_in_dim %cst_2, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %836 = stablehlo.add %832, %835 : tensor<8x197x1xf32>
+    %837 = stablehlo.sqrt %836 : tensor<8x197x1xf32>
+    %838 = stablehlo.broadcast_in_dim %837, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %839 = stablehlo.divide %834, %838 : tensor<8x197x768xf32>
+    %840 = stablehlo.broadcast_in_dim %arg92, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %841 = stablehlo.broadcast_in_dim %840, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %842 = stablehlo.multiply %839, %841 : tensor<8x197x768xf32>
+    %843 = stablehlo.broadcast_in_dim %arg93, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %844 = stablehlo.broadcast_in_dim %843, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %845 = stablehlo.add %842, %844 : tensor<8x197x768xf32>
+    %846 = stablehlo.dot_general %845, %arg90, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x3072xf32>) -> tensor<8x197x3072xf32>
+    %847 = stablehlo.multiply %846, %846 : tensor<8x197x3072xf32>
+    %848 = stablehlo.multiply %847, %846 : tensor<8x197x3072xf32>
+    %849 = stablehlo.broadcast_in_dim %cst_9, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %850 = stablehlo.multiply %849, %848 : tensor<8x197x3072xf32>
+    %851 = stablehlo.add %846, %850 : tensor<8x197x3072xf32>
+    %852 = stablehlo.broadcast_in_dim %cst_10, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %853 = stablehlo.multiply %852, %851 : tensor<8x197x3072xf32>
+    %854 = stablehlo.tanh %853 : tensor<8x197x3072xf32>
+    %855 = stablehlo.broadcast_in_dim %cst_11, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %856 = stablehlo.add %855, %854 : tensor<8x197x3072xf32>
+    %857 = stablehlo.broadcast_in_dim %cst_12, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %858 = stablehlo.multiply %857, %856 : tensor<8x197x3072xf32>
+    %859 = stablehlo.multiply %846, %858 : tensor<8x197x3072xf32>
+    %860 = stablehlo.dot_general %859, %arg91, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x3072xf32>, tensor<3072x768xf32>) -> tensor<8x197x768xf32>
+    %861 = stablehlo.add %821, %860 : tensor<8x197x768xf32>
+    %cst_61 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %862 = stablehlo.reduce(%861 init: %cst_61) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %863 = stablehlo.broadcast_in_dim %862, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %864 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %865 = stablehlo.divide %863, %864 : tensor<8x197x1xf32>
+    %866 = stablehlo.broadcast_in_dim %865, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %867 = stablehlo.subtract %861, %866 : tensor<8x197x768xf32>
+    %868 = stablehlo.multiply %867, %867 : tensor<8x197x768xf32>
+    %cst_62 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %869 = stablehlo.reduce(%868 init: %cst_62) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %870 = stablehlo.broadcast_in_dim %869, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %871 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %872 = stablehlo.divide %870, %871 : tensor<8x197x1xf32>
+    %873 = stablehlo.broadcast_in_dim %865, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %874 = stablehlo.subtract %861, %873 : tensor<8x197x768xf32>
+    %875 = stablehlo.broadcast_in_dim %cst_2, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %876 = stablehlo.add %872, %875 : tensor<8x197x1xf32>
+    %877 = stablehlo.sqrt %876 : tensor<8x197x1xf32>
+    %878 = stablehlo.broadcast_in_dim %877, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %879 = stablehlo.divide %874, %878 : tensor<8x197x768xf32>
+    %880 = stablehlo.broadcast_in_dim %arg98, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %881 = stablehlo.broadcast_in_dim %880, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %882 = stablehlo.multiply %879, %881 : tensor<8x197x768xf32>
+    %883 = stablehlo.broadcast_in_dim %arg99, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %884 = stablehlo.broadcast_in_dim %883, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %885 = stablehlo.add %882, %884 : tensor<8x197x768xf32>
+    %886 = stablehlo.dot_general %885, %arg94, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %887 = stablehlo.dot_general %885, %arg95, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %888 = stablehlo.dot_general %885, %arg96, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %889 = stablehlo.reshape %886 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %890 = stablehlo.transpose %889, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %891 = stablehlo.reshape %887 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %892 = stablehlo.transpose %891, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %893 = stablehlo.reshape %888 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %894 = stablehlo.transpose %893, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %895 = stablehlo.transpose %892, dims = [0, 1, 3, 2] : (tensor<8x12x197x64xf32>) -> tensor<8x12x64x197xf32>
+    %896 = stablehlo.dot_general %890, %895, batching_dims = [0, 1] x [0, 1], contracting_dims = [3] x [2], precision = [DEFAULT, DEFAULT] : (tensor<8x12x197x64xf32>, tensor<8x12x64x197xf32>) -> tensor<8x12x197x197xf32>
+    %897 = stablehlo.sqrt %cst_3 : tensor<f32>
+    %898 = stablehlo.convert %897 : tensor<f32>
+    %899 = stablehlo.broadcast_in_dim %898, dims = [] : (tensor<f32>) -> tensor<8x12x197x197xf32>
+    %900 = stablehlo.divide %896, %899 : tensor<8x12x197x197xf32>
+    %cst_63 = stablehlo.constant dense<0xFF800000> : tensor<f32>
+    %901 = stablehlo.reduce(%900 init: %cst_63) applies stablehlo.maximum across dimensions = [3] : (tensor<8x12x197x197xf32>, tensor<f32>) -> tensor<8x12x197xf32>
+    %902 = stablehlo.broadcast_in_dim %cst_5, dims = [] : (tensor<f32>) -> tensor<8x12x197xf32>
+    %903 = stablehlo.maximum %902, %901 : tensor<8x12x197xf32>
+    %904 = stablehlo.broadcast_in_dim %903, dims = [0, 1, 2] : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+    %905 = stablehlo.broadcast_in_dim %904, dims = [0, 1, 2, 3] : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+    %906 = stablehlo.subtract %900, %905 : tensor<8x12x197x197xf32>
+    %907 = stablehlo.exponential %906 : tensor<8x12x197x197xf32>
+    %cst_64 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %908 = stablehlo.reduce(%907 init: %cst_64) applies stablehlo.add across dimensions = [3] : (tensor<8x12x197x197xf32>, tensor<f32>) -> tensor<8x12x197xf32>
+    %909 = stablehlo.broadcast_in_dim %908, dims = [0, 1, 2] : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+    %910 = stablehlo.broadcast_in_dim %909, dims = [0, 1, 2, 3] : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+    %911 = stablehlo.divide %907, %910 : tensor<8x12x197x197xf32>
+    %912 = stablehlo.dot_general %911, %894, batching_dims = [0, 1] x [0, 1], contracting_dims = [3] x [2], precision = [DEFAULT, DEFAULT] : (tensor<8x12x197x197xf32>, tensor<8x12x197x64xf32>) -> tensor<8x12x197x64xf32>
+    %913 = stablehlo.transpose %912, dims = [0, 2, 1, 3] : (tensor<8x12x197x64xf32>) -> tensor<8x197x12x64xf32>
+    %914 = stablehlo.reshape %913 : (tensor<8x197x12x64xf32>) -> tensor<8x197x768xf32>
+    %915 = stablehlo.dot_general %914, %arg97, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %916 = stablehlo.add %861, %915 : tensor<8x197x768xf32>
+    %cst_65 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %917 = stablehlo.reduce(%916 init: %cst_65) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %918 = stablehlo.broadcast_in_dim %917, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %919 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %920 = stablehlo.divide %918, %919 : tensor<8x197x1xf32>
+    %921 = stablehlo.broadcast_in_dim %920, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %922 = stablehlo.subtract %916, %921 : tensor<8x197x768xf32>
+    %923 = stablehlo.multiply %922, %922 : tensor<8x197x768xf32>
+    %cst_66 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %924 = stablehlo.reduce(%923 init: %cst_66) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %925 = stablehlo.broadcast_in_dim %924, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %926 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %927 = stablehlo.divide %925, %926 : tensor<8x197x1xf32>
+    %928 = stablehlo.broadcast_in_dim %920, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %929 = stablehlo.subtract %916, %928 : tensor<8x197x768xf32>
+    %930 = stablehlo.broadcast_in_dim %cst_2, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %931 = stablehlo.add %927, %930 : tensor<8x197x1xf32>
+    %932 = stablehlo.sqrt %931 : tensor<8x197x1xf32>
+    %933 = stablehlo.broadcast_in_dim %932, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %934 = stablehlo.divide %929, %933 : tensor<8x197x768xf32>
+    %935 = stablehlo.broadcast_in_dim %arg102, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %936 = stablehlo.broadcast_in_dim %935, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %937 = stablehlo.multiply %934, %936 : tensor<8x197x768xf32>
+    %938 = stablehlo.broadcast_in_dim %arg103, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %939 = stablehlo.broadcast_in_dim %938, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %940 = stablehlo.add %937, %939 : tensor<8x197x768xf32>
+    %941 = stablehlo.dot_general %940, %arg100, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x3072xf32>) -> tensor<8x197x3072xf32>
+    %942 = stablehlo.multiply %941, %941 : tensor<8x197x3072xf32>
+    %943 = stablehlo.multiply %942, %941 : tensor<8x197x3072xf32>
+    %944 = stablehlo.broadcast_in_dim %cst_9, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %945 = stablehlo.multiply %944, %943 : tensor<8x197x3072xf32>
+    %946 = stablehlo.add %941, %945 : tensor<8x197x3072xf32>
+    %947 = stablehlo.broadcast_in_dim %cst_10, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %948 = stablehlo.multiply %947, %946 : tensor<8x197x3072xf32>
+    %949 = stablehlo.tanh %948 : tensor<8x197x3072xf32>
+    %950 = stablehlo.broadcast_in_dim %cst_11, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %951 = stablehlo.add %950, %949 : tensor<8x197x3072xf32>
+    %952 = stablehlo.broadcast_in_dim %cst_12, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %953 = stablehlo.multiply %952, %951 : tensor<8x197x3072xf32>
+    %954 = stablehlo.multiply %941, %953 : tensor<8x197x3072xf32>
+    %955 = stablehlo.dot_general %954, %arg101, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x3072xf32>, tensor<3072x768xf32>) -> tensor<8x197x768xf32>
+    %956 = stablehlo.add %916, %955 : tensor<8x197x768xf32>
+    %cst_67 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %957 = stablehlo.reduce(%956 init: %cst_67) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %958 = stablehlo.broadcast_in_dim %957, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %959 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %960 = stablehlo.divide %958, %959 : tensor<8x197x1xf32>
+    %961 = stablehlo.broadcast_in_dim %960, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %962 = stablehlo.subtract %956, %961 : tensor<8x197x768xf32>
+    %963 = stablehlo.multiply %962, %962 : tensor<8x197x768xf32>
+    %cst_68 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %964 = stablehlo.reduce(%963 init: %cst_68) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %965 = stablehlo.broadcast_in_dim %964, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %966 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %967 = stablehlo.divide %965, %966 : tensor<8x197x1xf32>
+    %968 = stablehlo.broadcast_in_dim %960, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %969 = stablehlo.subtract %956, %968 : tensor<8x197x768xf32>
+    %970 = stablehlo.broadcast_in_dim %cst_2, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %971 = stablehlo.add %967, %970 : tensor<8x197x1xf32>
+    %972 = stablehlo.sqrt %971 : tensor<8x197x1xf32>
+    %973 = stablehlo.broadcast_in_dim %972, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %974 = stablehlo.divide %969, %973 : tensor<8x197x768xf32>
+    %975 = stablehlo.broadcast_in_dim %arg108, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %976 = stablehlo.broadcast_in_dim %975, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %977 = stablehlo.multiply %974, %976 : tensor<8x197x768xf32>
+    %978 = stablehlo.broadcast_in_dim %arg109, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %979 = stablehlo.broadcast_in_dim %978, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %980 = stablehlo.add %977, %979 : tensor<8x197x768xf32>
+    %981 = stablehlo.dot_general %980, %arg104, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %982 = stablehlo.dot_general %980, %arg105, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %983 = stablehlo.dot_general %980, %arg106, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %984 = stablehlo.reshape %981 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %985 = stablehlo.transpose %984, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %986 = stablehlo.reshape %982 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %987 = stablehlo.transpose %986, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %988 = stablehlo.reshape %983 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %989 = stablehlo.transpose %988, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %990 = stablehlo.transpose %987, dims = [0, 1, 3, 2] : (tensor<8x12x197x64xf32>) -> tensor<8x12x64x197xf32>
+    %991 = stablehlo.dot_general %985, %990, batching_dims = [0, 1] x [0, 1], contracting_dims = [3] x [2], precision = [DEFAULT, DEFAULT] : (tensor<8x12x197x64xf32>, tensor<8x12x64x197xf32>) -> tensor<8x12x197x197xf32>
+    %992 = stablehlo.sqrt %cst_3 : tensor<f32>
+    %993 = stablehlo.convert %992 : tensor<f32>
+    %994 = stablehlo.broadcast_in_dim %993, dims = [] : (tensor<f32>) -> tensor<8x12x197x197xf32>
+    %995 = stablehlo.divide %991, %994 : tensor<8x12x197x197xf32>
+    %cst_69 = stablehlo.constant dense<0xFF800000> : tensor<f32>
+    %996 = stablehlo.reduce(%995 init: %cst_69) applies stablehlo.maximum across dimensions = [3] : (tensor<8x12x197x197xf32>, tensor<f32>) -> tensor<8x12x197xf32>
+    %997 = stablehlo.broadcast_in_dim %cst_5, dims = [] : (tensor<f32>) -> tensor<8x12x197xf32>
+    %998 = stablehlo.maximum %997, %996 : tensor<8x12x197xf32>
+    %999 = stablehlo.broadcast_in_dim %998, dims = [0, 1, 2] : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+    %1000 = stablehlo.broadcast_in_dim %999, dims = [0, 1, 2, 3] : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+    %1001 = stablehlo.subtract %995, %1000 : tensor<8x12x197x197xf32>
+    %1002 = stablehlo.exponential %1001 : tensor<8x12x197x197xf32>
+    %cst_70 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %1003 = stablehlo.reduce(%1002 init: %cst_70) applies stablehlo.add across dimensions = [3] : (tensor<8x12x197x197xf32>, tensor<f32>) -> tensor<8x12x197xf32>
+    %1004 = stablehlo.broadcast_in_dim %1003, dims = [0, 1, 2] : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+    %1005 = stablehlo.broadcast_in_dim %1004, dims = [0, 1, 2, 3] : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+    %1006 = stablehlo.divide %1002, %1005 : tensor<8x12x197x197xf32>
+    %1007 = stablehlo.dot_general %1006, %989, batching_dims = [0, 1] x [0, 1], contracting_dims = [3] x [2], precision = [DEFAULT, DEFAULT] : (tensor<8x12x197x197xf32>, tensor<8x12x197x64xf32>) -> tensor<8x12x197x64xf32>
+    %1008 = stablehlo.transpose %1007, dims = [0, 2, 1, 3] : (tensor<8x12x197x64xf32>) -> tensor<8x197x12x64xf32>
+    %1009 = stablehlo.reshape %1008 : (tensor<8x197x12x64xf32>) -> tensor<8x197x768xf32>
+    %1010 = stablehlo.dot_general %1009, %arg107, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %1011 = stablehlo.add %956, %1010 : tensor<8x197x768xf32>
+    %cst_71 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %1012 = stablehlo.reduce(%1011 init: %cst_71) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %1013 = stablehlo.broadcast_in_dim %1012, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %1014 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %1015 = stablehlo.divide %1013, %1014 : tensor<8x197x1xf32>
+    %1016 = stablehlo.broadcast_in_dim %1015, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %1017 = stablehlo.subtract %1011, %1016 : tensor<8x197x768xf32>
+    %1018 = stablehlo.multiply %1017, %1017 : tensor<8x197x768xf32>
+    %cst_72 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %1019 = stablehlo.reduce(%1018 init: %cst_72) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %1020 = stablehlo.broadcast_in_dim %1019, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %1021 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %1022 = stablehlo.divide %1020, %1021 : tensor<8x197x1xf32>
+    %1023 = stablehlo.broadcast_in_dim %1015, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %1024 = stablehlo.subtract %1011, %1023 : tensor<8x197x768xf32>
+    %1025 = stablehlo.broadcast_in_dim %cst_2, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %1026 = stablehlo.add %1022, %1025 : tensor<8x197x1xf32>
+    %1027 = stablehlo.sqrt %1026 : tensor<8x197x1xf32>
+    %1028 = stablehlo.broadcast_in_dim %1027, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %1029 = stablehlo.divide %1024, %1028 : tensor<8x197x768xf32>
+    %1030 = stablehlo.broadcast_in_dim %arg112, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %1031 = stablehlo.broadcast_in_dim %1030, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %1032 = stablehlo.multiply %1029, %1031 : tensor<8x197x768xf32>
+    %1033 = stablehlo.broadcast_in_dim %arg113, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %1034 = stablehlo.broadcast_in_dim %1033, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %1035 = stablehlo.add %1032, %1034 : tensor<8x197x768xf32>
+    %1036 = stablehlo.dot_general %1035, %arg110, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x3072xf32>) -> tensor<8x197x3072xf32>
+    %1037 = stablehlo.multiply %1036, %1036 : tensor<8x197x3072xf32>
+    %1038 = stablehlo.multiply %1037, %1036 : tensor<8x197x3072xf32>
+    %1039 = stablehlo.broadcast_in_dim %cst_9, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %1040 = stablehlo.multiply %1039, %1038 : tensor<8x197x3072xf32>
+    %1041 = stablehlo.add %1036, %1040 : tensor<8x197x3072xf32>
+    %1042 = stablehlo.broadcast_in_dim %cst_10, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %1043 = stablehlo.multiply %1042, %1041 : tensor<8x197x3072xf32>
+    %1044 = stablehlo.tanh %1043 : tensor<8x197x3072xf32>
+    %1045 = stablehlo.broadcast_in_dim %cst_11, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %1046 = stablehlo.add %1045, %1044 : tensor<8x197x3072xf32>
+    %1047 = stablehlo.broadcast_in_dim %cst_12, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %1048 = stablehlo.multiply %1047, %1046 : tensor<8x197x3072xf32>
+    %1049 = stablehlo.multiply %1036, %1048 : tensor<8x197x3072xf32>
+    %1050 = stablehlo.dot_general %1049, %arg111, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x3072xf32>, tensor<3072x768xf32>) -> tensor<8x197x768xf32>
+    %1051 = stablehlo.add %1011, %1050 : tensor<8x197x768xf32>
+    %cst_73 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %1052 = stablehlo.reduce(%1051 init: %cst_73) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %1053 = stablehlo.broadcast_in_dim %1052, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %1054 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %1055 = stablehlo.divide %1053, %1054 : tensor<8x197x1xf32>
+    %1056 = stablehlo.broadcast_in_dim %1055, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %1057 = stablehlo.subtract %1051, %1056 : tensor<8x197x768xf32>
+    %1058 = stablehlo.multiply %1057, %1057 : tensor<8x197x768xf32>
+    %cst_74 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %1059 = stablehlo.reduce(%1058 init: %cst_74) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %1060 = stablehlo.broadcast_in_dim %1059, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %1061 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %1062 = stablehlo.divide %1060, %1061 : tensor<8x197x1xf32>
+    %1063 = stablehlo.broadcast_in_dim %1055, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %1064 = stablehlo.subtract %1051, %1063 : tensor<8x197x768xf32>
+    %1065 = stablehlo.broadcast_in_dim %cst_2, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %1066 = stablehlo.add %1062, %1065 : tensor<8x197x1xf32>
+    %1067 = stablehlo.sqrt %1066 : tensor<8x197x1xf32>
+    %1068 = stablehlo.broadcast_in_dim %1067, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %1069 = stablehlo.divide %1064, %1068 : tensor<8x197x768xf32>
+    %1070 = stablehlo.broadcast_in_dim %arg118, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %1071 = stablehlo.broadcast_in_dim %1070, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %1072 = stablehlo.multiply %1069, %1071 : tensor<8x197x768xf32>
+    %1073 = stablehlo.broadcast_in_dim %arg119, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %1074 = stablehlo.broadcast_in_dim %1073, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %1075 = stablehlo.add %1072, %1074 : tensor<8x197x768xf32>
+    %1076 = stablehlo.dot_general %1075, %arg114, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %1077 = stablehlo.dot_general %1075, %arg115, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %1078 = stablehlo.dot_general %1075, %arg116, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %1079 = stablehlo.reshape %1076 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %1080 = stablehlo.transpose %1079, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %1081 = stablehlo.reshape %1077 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %1082 = stablehlo.transpose %1081, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %1083 = stablehlo.reshape %1078 : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+    %1084 = stablehlo.transpose %1083, dims = [0, 2, 1, 3] : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+    %1085 = stablehlo.transpose %1082, dims = [0, 1, 3, 2] : (tensor<8x12x197x64xf32>) -> tensor<8x12x64x197xf32>
+    %1086 = stablehlo.dot_general %1080, %1085, batching_dims = [0, 1] x [0, 1], contracting_dims = [3] x [2], precision = [DEFAULT, DEFAULT] : (tensor<8x12x197x64xf32>, tensor<8x12x64x197xf32>) -> tensor<8x12x197x197xf32>
+    %1087 = stablehlo.sqrt %cst_3 : tensor<f32>
+    %1088 = stablehlo.convert %1087 : tensor<f32>
+    %1089 = stablehlo.broadcast_in_dim %1088, dims = [] : (tensor<f32>) -> tensor<8x12x197x197xf32>
+    %1090 = stablehlo.divide %1086, %1089 : tensor<8x12x197x197xf32>
+    %cst_75 = stablehlo.constant dense<0xFF800000> : tensor<f32>
+    %1091 = stablehlo.reduce(%1090 init: %cst_75) applies stablehlo.maximum across dimensions = [3] : (tensor<8x12x197x197xf32>, tensor<f32>) -> tensor<8x12x197xf32>
+    %1092 = stablehlo.broadcast_in_dim %cst_5, dims = [] : (tensor<f32>) -> tensor<8x12x197xf32>
+    %1093 = stablehlo.maximum %1092, %1091 : tensor<8x12x197xf32>
+    %1094 = stablehlo.broadcast_in_dim %1093, dims = [0, 1, 2] : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+    %1095 = stablehlo.broadcast_in_dim %1094, dims = [0, 1, 2, 3] : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+    %1096 = stablehlo.subtract %1090, %1095 : tensor<8x12x197x197xf32>
+    %1097 = stablehlo.exponential %1096 : tensor<8x12x197x197xf32>
+    %cst_76 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %1098 = stablehlo.reduce(%1097 init: %cst_76) applies stablehlo.add across dimensions = [3] : (tensor<8x12x197x197xf32>, tensor<f32>) -> tensor<8x12x197xf32>
+    %1099 = stablehlo.broadcast_in_dim %1098, dims = [0, 1, 2] : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+    %1100 = stablehlo.broadcast_in_dim %1099, dims = [0, 1, 2, 3] : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+    %1101 = stablehlo.divide %1097, %1100 : tensor<8x12x197x197xf32>
+    %1102 = stablehlo.dot_general %1101, %1084, batching_dims = [0, 1] x [0, 1], contracting_dims = [3] x [2], precision = [DEFAULT, DEFAULT] : (tensor<8x12x197x197xf32>, tensor<8x12x197x64xf32>) -> tensor<8x12x197x64xf32>
+    %1103 = stablehlo.transpose %1102, dims = [0, 2, 1, 3] : (tensor<8x12x197x64xf32>) -> tensor<8x197x12x64xf32>
+    %1104 = stablehlo.reshape %1103 : (tensor<8x197x12x64xf32>) -> tensor<8x197x768xf32>
+    %1105 = stablehlo.dot_general %1104, %arg117, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+    %1106 = stablehlo.add %1051, %1105 : tensor<8x197x768xf32>
+    %cst_77 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %1107 = stablehlo.reduce(%1106 init: %cst_77) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %1108 = stablehlo.broadcast_in_dim %1107, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %1109 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %1110 = stablehlo.divide %1108, %1109 : tensor<8x197x1xf32>
+    %1111 = stablehlo.broadcast_in_dim %1110, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %1112 = stablehlo.subtract %1106, %1111 : tensor<8x197x768xf32>
+    %1113 = stablehlo.multiply %1112, %1112 : tensor<8x197x768xf32>
+    %cst_78 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+    %1114 = stablehlo.reduce(%1113 init: %cst_78) applies stablehlo.add across dimensions = [2] : (tensor<8x197x768xf32>, tensor<f32>) -> tensor<8x197xf32>
+    %1115 = stablehlo.broadcast_in_dim %1114, dims = [0, 1] : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+    %1116 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %1117 = stablehlo.divide %1115, %1116 : tensor<8x197x1xf32>
+    %1118 = stablehlo.broadcast_in_dim %1110, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %1119 = stablehlo.subtract %1106, %1118 : tensor<8x197x768xf32>
+    %1120 = stablehlo.broadcast_in_dim %cst_2, dims = [] : (tensor<f32>) -> tensor<8x197x1xf32>
+    %1121 = stablehlo.add %1117, %1120 : tensor<8x197x1xf32>
+    %1122 = stablehlo.sqrt %1121 : tensor<8x197x1xf32>
+    %1123 = stablehlo.broadcast_in_dim %1122, dims = [0, 1, 2] : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+    %1124 = stablehlo.divide %1119, %1123 : tensor<8x197x768xf32>
+    %1125 = stablehlo.broadcast_in_dim %arg122, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %1126 = stablehlo.broadcast_in_dim %1125, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %1127 = stablehlo.multiply %1124, %1126 : tensor<8x197x768xf32>
+    %1128 = stablehlo.broadcast_in_dim %arg123, dims = [2] : (tensor<768xf32>) -> tensor<1x1x768xf32>
+    %1129 = stablehlo.broadcast_in_dim %1128, dims = [0, 1, 2] : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+    %1130 = stablehlo.add %1127, %1129 : tensor<8x197x768xf32>
+    %1131 = stablehlo.dot_general %1130, %arg120, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x768xf32>, tensor<768x3072xf32>) -> tensor<8x197x3072xf32>
+    %1132 = stablehlo.multiply %1131, %1131 : tensor<8x197x3072xf32>
+    %1133 = stablehlo.multiply %1132, %1131 : tensor<8x197x3072xf32>
+    %1134 = stablehlo.broadcast_in_dim %cst_9, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %1135 = stablehlo.multiply %1134, %1133 : tensor<8x197x3072xf32>
+    %1136 = stablehlo.add %1131, %1135 : tensor<8x197x3072xf32>
+    %1137 = stablehlo.broadcast_in_dim %cst_10, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %1138 = stablehlo.multiply %1137, %1136 : tensor<8x197x3072xf32>
+    %1139 = stablehlo.tanh %1138 : tensor<8x197x3072xf32>
+    %1140 = stablehlo.broadcast_in_dim %cst_11, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %1141 = stablehlo.add %1140, %1139 : tensor<8x197x3072xf32>
+    %1142 = stablehlo.broadcast_in_dim %cst_12, dims = [] : (tensor<f32>) -> tensor<8x197x3072xf32>
+    %1143 = stablehlo.multiply %1142, %1141 : tensor<8x197x3072xf32>
+    %1144 = stablehlo.multiply %1131, %1143 : tensor<8x197x3072xf32>
+    %1145 = stablehlo.dot_general %1144, %arg121, contracting_dims = [2] x [0], precision = [DEFAULT, DEFAULT] : (tensor<8x197x3072xf32>, tensor<3072x768xf32>) -> tensor<8x197x768xf32>
+    %1146 = stablehlo.add %1106, %1145 : tensor<8x197x768xf32>
+    return %1146 : tensor<8x197x768xf32>
+  }
+}

--- a/workloads/mlir/examples/vit.ttir.mlir
+++ b/workloads/mlir/examples/vit.ttir.mlir
@@ -1,0 +1,1432 @@
+// SPDX-FileCopyrightText: (C) 2025 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+module @jit_vit attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
+  ttcore.device_module {
+    builtin.module @jit_vit attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
+      func.func public @main(%arg0: tensor<8x3x224x224xf32>, %arg1: tensor<768x768xf32>, %arg2: tensor<8x1x768xf32>, %arg3: tensor<1x197x768xf32>, %arg4: tensor<768x768xf32>, %arg5: tensor<768x768xf32>, %arg6: tensor<768x768xf32>, %arg7: tensor<768x768xf32>, %arg8: tensor<768xf32>, %arg9: tensor<768xf32>, %arg10: tensor<768x3072xf32>, %arg11: tensor<3072x768xf32>, %arg12: tensor<768xf32>, %arg13: tensor<768xf32>, %arg14: tensor<768x768xf32>, %arg15: tensor<768x768xf32>, %arg16: tensor<768x768xf32>, %arg17: tensor<768x768xf32>, %arg18: tensor<768xf32>, %arg19: tensor<768xf32>, %arg20: tensor<768x3072xf32>, %arg21: tensor<3072x768xf32>, %arg22: tensor<768xf32>, %arg23: tensor<768xf32>, %arg24: tensor<768x768xf32>, %arg25: tensor<768x768xf32>, %arg26: tensor<768x768xf32>, %arg27: tensor<768x768xf32>, %arg28: tensor<768xf32>, %arg29: tensor<768xf32>, %arg30: tensor<768x3072xf32>, %arg31: tensor<3072x768xf32>, %arg32: tensor<768xf32>, %arg33: tensor<768xf32>, %arg34: tensor<768x768xf32>, %arg35: tensor<768x768xf32>, %arg36: tensor<768x768xf32>, %arg37: tensor<768x768xf32>, %arg38: tensor<768xf32>, %arg39: tensor<768xf32>, %arg40: tensor<768x3072xf32>, %arg41: tensor<3072x768xf32>, %arg42: tensor<768xf32>, %arg43: tensor<768xf32>, %arg44: tensor<768x768xf32>, %arg45: tensor<768x768xf32>, %arg46: tensor<768x768xf32>, %arg47: tensor<768x768xf32>, %arg48: tensor<768xf32>, %arg49: tensor<768xf32>, %arg50: tensor<768x3072xf32>, %arg51: tensor<3072x768xf32>, %arg52: tensor<768xf32>, %arg53: tensor<768xf32>, %arg54: tensor<768x768xf32>, %arg55: tensor<768x768xf32>, %arg56: tensor<768x768xf32>, %arg57: tensor<768x768xf32>, %arg58: tensor<768xf32>, %arg59: tensor<768xf32>, %arg60: tensor<768x3072xf32>, %arg61: tensor<3072x768xf32>, %arg62: tensor<768xf32>, %arg63: tensor<768xf32>, %arg64: tensor<768x768xf32>, %arg65: tensor<768x768xf32>, %arg66: tensor<768x768xf32>, %arg67: tensor<768x768xf32>, %arg68: tensor<768xf32>, %arg69: tensor<768xf32>, %arg70: tensor<768x3072xf32>, %arg71: tensor<3072x768xf32>, %arg72: tensor<768xf32>, %arg73: tensor<768xf32>, %arg74: tensor<768x768xf32>, %arg75: tensor<768x768xf32>, %arg76: tensor<768x768xf32>, %arg77: tensor<768x768xf32>, %arg78: tensor<768xf32>, %arg79: tensor<768xf32>, %arg80: tensor<768x3072xf32>, %arg81: tensor<3072x768xf32>, %arg82: tensor<768xf32>, %arg83: tensor<768xf32>, %arg84: tensor<768x768xf32>, %arg85: tensor<768x768xf32>, %arg86: tensor<768x768xf32>, %arg87: tensor<768x768xf32>, %arg88: tensor<768xf32>, %arg89: tensor<768xf32>, %arg90: tensor<768x3072xf32>, %arg91: tensor<3072x768xf32>, %arg92: tensor<768xf32>, %arg93: tensor<768xf32>, %arg94: tensor<768x768xf32>, %arg95: tensor<768x768xf32>, %arg96: tensor<768x768xf32>, %arg97: tensor<768x768xf32>, %arg98: tensor<768xf32>, %arg99: tensor<768xf32>, %arg100: tensor<768x3072xf32>, %arg101: tensor<3072x768xf32>, %arg102: tensor<768xf32>, %arg103: tensor<768xf32>, %arg104: tensor<768x768xf32>, %arg105: tensor<768x768xf32>, %arg106: tensor<768x768xf32>, %arg107: tensor<768x768xf32>, %arg108: tensor<768xf32>, %arg109: tensor<768xf32>, %arg110: tensor<768x3072xf32>, %arg111: tensor<3072x768xf32>, %arg112: tensor<768xf32>, %arg113: tensor<768xf32>, %arg114: tensor<768x768xf32>, %arg115: tensor<768x768xf32>, %arg116: tensor<768x768xf32>, %arg117: tensor<768x768xf32>, %arg118: tensor<768xf32>, %arg119: tensor<768xf32>, %arg120: tensor<768x3072xf32>, %arg121: tensor<3072x768xf32>, %arg122: tensor<768xf32>, %arg123: tensor<768xf32>) -> (tensor<8x197x768xf32> {jax.result_info = "result"}) {
+        %0 = "ttir.constant"() <{value = dense<5.000000e-01> : tensor<f32>}> : () -> tensor<f32>
+        %1 = "ttir.constant"() <{value = dense<1.000000e+00> : tensor<f32>}> : () -> tensor<f32>
+        %2 = "ttir.constant"() <{value = dense<0.797884583> : tensor<f32>}> : () -> tensor<f32>
+        %3 = "ttir.constant"() <{value = dense<4.471500e-02> : tensor<f32>}> : () -> tensor<f32>
+        %4 = "ttir.constant"() <{value = dense<0xFF800000> : tensor<f32>}> : () -> tensor<f32>
+        %5 = "ttir.constant"() <{value = dense<6.400000e+01> : tensor<f32>}> : () -> tensor<f32>
+        %6 = "ttir.constant"() <{value = dense<9.99999974E-6> : tensor<f32>}> : () -> tensor<f32>
+        %7 = "ttir.constant"() <{value = dense<7.680000e+02> : tensor<f32>}> : () -> tensor<f32>
+        %8 = "ttir.constant"() <{value = dense<0.000000e+00> : tensor<f32>}> : () -> tensor<f32>
+        %9 = "ttir.reshape"(%arg0) <{shape = [8 : i32, 3 : i32, 14 : i32, 16 : i32, 14 : i32, 16 : i32]}> : (tensor<8x3x224x224xf32>) -> tensor<8x3x14x16x14x16xf32>
+        %10 = "ttir.permute"(%9) <{permutation = array<i64: 0, 2, 4, 1, 3, 5>}> : (tensor<8x3x14x16x14x16xf32>) -> tensor<8x14x14x3x16x16xf32>
+        %11 = "ttir.reshape"(%10) <{shape = [8 : i32, 196 : i32, 768 : i32]}> : (tensor<8x14x14x3x16x16xf32>) -> tensor<8x196x768xf32>
+        %12 = "ttir.dot_general"(%11, %arg1) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x196x768xf32>, tensor<768x768xf32>) -> tensor<8x196x768xf32>
+        %13 = "ttir.concat"(%arg2, %12) <{dim = 1 : si32}> : (tensor<8x1x768xf32>, tensor<8x196x768xf32>) -> tensor<8x197x768xf32>
+        %14 = "ttir.broadcast"(%arg3) <{broadcast_dimensions = array<i64: 8, 1, 1>}> : (tensor<1x197x768xf32>) -> tensor<8x197x768xf32>
+        %15 = "ttir.add"(%13, %14) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %16 = "ttir.sum"(%15) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %17 = "ttir.reshape"(%16) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %18 = "ttir.broadcast"(%17) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %19 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %20 = "ttir.broadcast"(%19) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %21 = "ttir.div"(%18, %20) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %22 = "ttir.broadcast"(%21) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %23 = "ttir.subtract"(%15, %22) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %24 = "ttir.multiply"(%23, %23) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %25 = "ttir.sum"(%24) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %26 = "ttir.reshape"(%25) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %27 = "ttir.broadcast"(%26) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %28 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %29 = "ttir.broadcast"(%28) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %30 = "ttir.div"(%27, %29) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %31 = "ttir.broadcast"(%21) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %32 = "ttir.subtract"(%15, %31) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %33 = "ttir.reshape"(%6) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %34 = "ttir.broadcast"(%33) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %35 = "ttir.add"(%30, %34) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %36 = "ttir.sqrt"(%35) : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %37 = "ttir.broadcast"(%36) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %38 = "ttir.div"(%32, %37) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %39 = "ttir.reshape"(%arg8) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %40 = "ttir.broadcast"(%39) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %41 = "ttir.broadcast"(%40) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %42 = "ttir.multiply"(%38, %41) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %43 = "ttir.reshape"(%arg9) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %44 = "ttir.broadcast"(%43) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %45 = "ttir.broadcast"(%44) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %46 = "ttir.add"(%42, %45) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %47 = "ttir.dot_general"(%46, %arg4) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %48 = "ttir.dot_general"(%46, %arg5) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %49 = "ttir.dot_general"(%46, %arg6) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %50 = "ttir.reshape"(%47) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %51 = "ttir.permute"(%50) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %52 = "ttir.reshape"(%48) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %53 = "ttir.permute"(%52) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %54 = "ttir.reshape"(%49) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %55 = "ttir.permute"(%54) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %56 = "ttir.permute"(%53) <{permutation = array<i64: 0, 1, 3, 2>}> : (tensor<8x12x197x64xf32>) -> tensor<8x12x64x197xf32>
+        %57 = "ttir.dot_general"(%51, %56) <{batch_dims_lhs = array<i64: 0, 1>, batch_dims_rhs = array<i64: 0, 1>, contract_dims_lhs = array<i64: 3>, contract_dims_rhs = array<i64: 2>}> : (tensor<8x12x197x64xf32>, tensor<8x12x64x197xf32>) -> tensor<8x12x197x197xf32>
+        %58 = "ttir.sqrt"(%5) : (tensor<f32>) -> tensor<f32>
+        %59 = "ttir.typecast"(%58) <{conservative_folding = false}> : (tensor<f32>) -> tensor<f32>
+        %60 = "ttir.reshape"(%59) <{shape = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1x1xf32>
+        %61 = "ttir.broadcast"(%60) <{broadcast_dimensions = array<i64: 8, 12, 197, 197>}> : (tensor<1x1x1x1xf32>) -> tensor<8x12x197x197xf32>
+        %62 = "ttir.div"(%57, %61) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %63 = "ttir.max"(%62) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<8x12x197x197xf32>) -> tensor<8x12x197xf32>
+        %64 = "ttir.reshape"(%4) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %65 = "ttir.broadcast"(%64) <{broadcast_dimensions = array<i64: 8, 12, 197>}> : (tensor<1x1x1xf32>) -> tensor<8x12x197xf32>
+        %66 = "ttir.maximum"(%65, %63) : (tensor<8x12x197xf32>, tensor<8x12x197xf32>) -> tensor<8x12x197xf32>
+        %67 = "ttir.reshape"(%66) <{shape = [8 : i32, 12 : i32, 197 : i32, 1 : i32]}> : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+        %68 = "ttir.broadcast"(%67) <{broadcast_dimensions = array<i64: 1, 1, 1, 1>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x1xf32>
+        %69 = "ttir.broadcast"(%68) <{broadcast_dimensions = array<i64: 1, 1, 1, 197>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+        %70 = "ttir.subtract"(%62, %69) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %71 = "ttir.exp"(%70) : (tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %72 = "ttir.sum"(%71) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<8x12x197x197xf32>) -> tensor<8x12x197xf32>
+        %73 = "ttir.reshape"(%72) <{shape = [8 : i32, 12 : i32, 197 : i32, 1 : i32]}> : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+        %74 = "ttir.broadcast"(%73) <{broadcast_dimensions = array<i64: 1, 1, 1, 1>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x1xf32>
+        %75 = "ttir.broadcast"(%74) <{broadcast_dimensions = array<i64: 1, 1, 1, 197>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+        %76 = "ttir.div"(%71, %75) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %77 = "ttir.dot_general"(%76, %55) <{batch_dims_lhs = array<i64: 0, 1>, batch_dims_rhs = array<i64: 0, 1>, contract_dims_lhs = array<i64: 3>, contract_dims_rhs = array<i64: 2>}> : (tensor<8x12x197x197xf32>, tensor<8x12x197x64xf32>) -> tensor<8x12x197x64xf32>
+        %78 = "ttir.permute"(%77) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x12x197x64xf32>) -> tensor<8x197x12x64xf32>
+        %79 = "ttir.reshape"(%78) <{shape = [8 : i32, 197 : i32, 768 : i32]}> : (tensor<8x197x12x64xf32>) -> tensor<8x197x768xf32>
+        %80 = "ttir.dot_general"(%79, %arg7) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %81 = "ttir.add"(%15, %80) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %82 = "ttir.sum"(%81) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %83 = "ttir.reshape"(%82) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %84 = "ttir.broadcast"(%83) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %85 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %86 = "ttir.broadcast"(%85) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %87 = "ttir.div"(%84, %86) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %88 = "ttir.broadcast"(%87) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %89 = "ttir.subtract"(%81, %88) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %90 = "ttir.multiply"(%89, %89) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %91 = "ttir.sum"(%90) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %92 = "ttir.reshape"(%91) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %93 = "ttir.broadcast"(%92) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %94 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %95 = "ttir.broadcast"(%94) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %96 = "ttir.div"(%93, %95) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %97 = "ttir.broadcast"(%87) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %98 = "ttir.subtract"(%81, %97) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %99 = "ttir.reshape"(%6) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %100 = "ttir.broadcast"(%99) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %101 = "ttir.add"(%96, %100) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %102 = "ttir.sqrt"(%101) : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %103 = "ttir.broadcast"(%102) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %104 = "ttir.div"(%98, %103) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %105 = "ttir.reshape"(%arg12) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %106 = "ttir.broadcast"(%105) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %107 = "ttir.broadcast"(%106) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %108 = "ttir.multiply"(%104, %107) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %109 = "ttir.reshape"(%arg13) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %110 = "ttir.broadcast"(%109) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %111 = "ttir.broadcast"(%110) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %112 = "ttir.add"(%108, %111) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %113 = "ttir.dot_general"(%112, %arg10) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x3072xf32>) -> tensor<8x197x3072xf32>
+        %114 = "ttir.multiply"(%113, %113) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %115 = "ttir.multiply"(%114, %113) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %116 = "ttir.reshape"(%3) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %117 = "ttir.broadcast"(%116) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %118 = "ttir.multiply"(%117, %115) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %119 = "ttir.add"(%113, %118) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %120 = "ttir.reshape"(%2) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %121 = "ttir.broadcast"(%120) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %122 = "ttir.multiply"(%121, %119) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %123 = "ttir.tanh"(%122) : (tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %124 = "ttir.reshape"(%1) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %125 = "ttir.broadcast"(%124) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %126 = "ttir.add"(%125, %123) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %127 = "ttir.reshape"(%0) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %128 = "ttir.broadcast"(%127) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %129 = "ttir.multiply"(%128, %126) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %130 = "ttir.multiply"(%113, %129) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %131 = "ttir.dot_general"(%130, %arg11) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x3072xf32>, tensor<3072x768xf32>) -> tensor<8x197x768xf32>
+        %132 = "ttir.add"(%81, %131) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %133 = "ttir.sum"(%132) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %134 = "ttir.reshape"(%133) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %135 = "ttir.broadcast"(%134) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %136 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %137 = "ttir.broadcast"(%136) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %138 = "ttir.div"(%135, %137) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %139 = "ttir.broadcast"(%138) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %140 = "ttir.subtract"(%132, %139) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %141 = "ttir.multiply"(%140, %140) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %142 = "ttir.sum"(%141) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %143 = "ttir.reshape"(%142) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %144 = "ttir.broadcast"(%143) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %145 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %146 = "ttir.broadcast"(%145) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %147 = "ttir.div"(%144, %146) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %148 = "ttir.broadcast"(%138) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %149 = "ttir.subtract"(%132, %148) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %150 = "ttir.reshape"(%6) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %151 = "ttir.broadcast"(%150) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %152 = "ttir.add"(%147, %151) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %153 = "ttir.sqrt"(%152) : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %154 = "ttir.broadcast"(%153) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %155 = "ttir.div"(%149, %154) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %156 = "ttir.reshape"(%arg18) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %157 = "ttir.broadcast"(%156) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %158 = "ttir.broadcast"(%157) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %159 = "ttir.multiply"(%155, %158) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %160 = "ttir.reshape"(%arg19) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %161 = "ttir.broadcast"(%160) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %162 = "ttir.broadcast"(%161) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %163 = "ttir.add"(%159, %162) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %164 = "ttir.dot_general"(%163, %arg14) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %165 = "ttir.dot_general"(%163, %arg15) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %166 = "ttir.dot_general"(%163, %arg16) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %167 = "ttir.reshape"(%164) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %168 = "ttir.permute"(%167) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %169 = "ttir.reshape"(%165) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %170 = "ttir.permute"(%169) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %171 = "ttir.reshape"(%166) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %172 = "ttir.permute"(%171) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %173 = "ttir.permute"(%170) <{permutation = array<i64: 0, 1, 3, 2>}> : (tensor<8x12x197x64xf32>) -> tensor<8x12x64x197xf32>
+        %174 = "ttir.dot_general"(%168, %173) <{batch_dims_lhs = array<i64: 0, 1>, batch_dims_rhs = array<i64: 0, 1>, contract_dims_lhs = array<i64: 3>, contract_dims_rhs = array<i64: 2>}> : (tensor<8x12x197x64xf32>, tensor<8x12x64x197xf32>) -> tensor<8x12x197x197xf32>
+        %175 = "ttir.sqrt"(%5) : (tensor<f32>) -> tensor<f32>
+        %176 = "ttir.typecast"(%175) <{conservative_folding = false}> : (tensor<f32>) -> tensor<f32>
+        %177 = "ttir.reshape"(%176) <{shape = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1x1xf32>
+        %178 = "ttir.broadcast"(%177) <{broadcast_dimensions = array<i64: 8, 12, 197, 197>}> : (tensor<1x1x1x1xf32>) -> tensor<8x12x197x197xf32>
+        %179 = "ttir.div"(%174, %178) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %180 = "ttir.max"(%179) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<8x12x197x197xf32>) -> tensor<8x12x197xf32>
+        %181 = "ttir.reshape"(%4) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %182 = "ttir.broadcast"(%181) <{broadcast_dimensions = array<i64: 8, 12, 197>}> : (tensor<1x1x1xf32>) -> tensor<8x12x197xf32>
+        %183 = "ttir.maximum"(%182, %180) : (tensor<8x12x197xf32>, tensor<8x12x197xf32>) -> tensor<8x12x197xf32>
+        %184 = "ttir.reshape"(%183) <{shape = [8 : i32, 12 : i32, 197 : i32, 1 : i32]}> : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+        %185 = "ttir.broadcast"(%184) <{broadcast_dimensions = array<i64: 1, 1, 1, 1>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x1xf32>
+        %186 = "ttir.broadcast"(%185) <{broadcast_dimensions = array<i64: 1, 1, 1, 197>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+        %187 = "ttir.subtract"(%179, %186) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %188 = "ttir.exp"(%187) : (tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %189 = "ttir.sum"(%188) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<8x12x197x197xf32>) -> tensor<8x12x197xf32>
+        %190 = "ttir.reshape"(%189) <{shape = [8 : i32, 12 : i32, 197 : i32, 1 : i32]}> : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+        %191 = "ttir.broadcast"(%190) <{broadcast_dimensions = array<i64: 1, 1, 1, 1>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x1xf32>
+        %192 = "ttir.broadcast"(%191) <{broadcast_dimensions = array<i64: 1, 1, 1, 197>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+        %193 = "ttir.div"(%188, %192) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %194 = "ttir.dot_general"(%193, %172) <{batch_dims_lhs = array<i64: 0, 1>, batch_dims_rhs = array<i64: 0, 1>, contract_dims_lhs = array<i64: 3>, contract_dims_rhs = array<i64: 2>}> : (tensor<8x12x197x197xf32>, tensor<8x12x197x64xf32>) -> tensor<8x12x197x64xf32>
+        %195 = "ttir.permute"(%194) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x12x197x64xf32>) -> tensor<8x197x12x64xf32>
+        %196 = "ttir.reshape"(%195) <{shape = [8 : i32, 197 : i32, 768 : i32]}> : (tensor<8x197x12x64xf32>) -> tensor<8x197x768xf32>
+        %197 = "ttir.dot_general"(%196, %arg17) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %198 = "ttir.add"(%132, %197) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %199 = "ttir.sum"(%198) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %200 = "ttir.reshape"(%199) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %201 = "ttir.broadcast"(%200) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %202 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %203 = "ttir.broadcast"(%202) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %204 = "ttir.div"(%201, %203) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %205 = "ttir.broadcast"(%204) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %206 = "ttir.subtract"(%198, %205) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %207 = "ttir.multiply"(%206, %206) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %208 = "ttir.sum"(%207) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %209 = "ttir.reshape"(%208) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %210 = "ttir.broadcast"(%209) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %211 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %212 = "ttir.broadcast"(%211) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %213 = "ttir.div"(%210, %212) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %214 = "ttir.broadcast"(%204) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %215 = "ttir.subtract"(%198, %214) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %216 = "ttir.reshape"(%6) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %217 = "ttir.broadcast"(%216) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %218 = "ttir.add"(%213, %217) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %219 = "ttir.sqrt"(%218) : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %220 = "ttir.broadcast"(%219) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %221 = "ttir.div"(%215, %220) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %222 = "ttir.reshape"(%arg22) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %223 = "ttir.broadcast"(%222) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %224 = "ttir.broadcast"(%223) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %225 = "ttir.multiply"(%221, %224) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %226 = "ttir.reshape"(%arg23) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %227 = "ttir.broadcast"(%226) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %228 = "ttir.broadcast"(%227) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %229 = "ttir.add"(%225, %228) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %230 = "ttir.dot_general"(%229, %arg20) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x3072xf32>) -> tensor<8x197x3072xf32>
+        %231 = "ttir.multiply"(%230, %230) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %232 = "ttir.multiply"(%231, %230) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %233 = "ttir.reshape"(%3) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %234 = "ttir.broadcast"(%233) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %235 = "ttir.multiply"(%234, %232) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %236 = "ttir.add"(%230, %235) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %237 = "ttir.reshape"(%2) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %238 = "ttir.broadcast"(%237) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %239 = "ttir.multiply"(%238, %236) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %240 = "ttir.tanh"(%239) : (tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %241 = "ttir.reshape"(%1) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %242 = "ttir.broadcast"(%241) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %243 = "ttir.add"(%242, %240) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %244 = "ttir.reshape"(%0) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %245 = "ttir.broadcast"(%244) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %246 = "ttir.multiply"(%245, %243) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %247 = "ttir.multiply"(%230, %246) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %248 = "ttir.dot_general"(%247, %arg21) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x3072xf32>, tensor<3072x768xf32>) -> tensor<8x197x768xf32>
+        %249 = "ttir.add"(%198, %248) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %250 = "ttir.sum"(%249) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %251 = "ttir.reshape"(%250) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %252 = "ttir.broadcast"(%251) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %253 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %254 = "ttir.broadcast"(%253) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %255 = "ttir.div"(%252, %254) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %256 = "ttir.broadcast"(%255) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %257 = "ttir.subtract"(%249, %256) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %258 = "ttir.multiply"(%257, %257) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %259 = "ttir.sum"(%258) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %260 = "ttir.reshape"(%259) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %261 = "ttir.broadcast"(%260) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %262 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %263 = "ttir.broadcast"(%262) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %264 = "ttir.div"(%261, %263) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %265 = "ttir.broadcast"(%255) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %266 = "ttir.subtract"(%249, %265) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %267 = "ttir.reshape"(%6) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %268 = "ttir.broadcast"(%267) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %269 = "ttir.add"(%264, %268) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %270 = "ttir.sqrt"(%269) : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %271 = "ttir.broadcast"(%270) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %272 = "ttir.div"(%266, %271) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %273 = "ttir.reshape"(%arg28) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %274 = "ttir.broadcast"(%273) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %275 = "ttir.broadcast"(%274) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %276 = "ttir.multiply"(%272, %275) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %277 = "ttir.reshape"(%arg29) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %278 = "ttir.broadcast"(%277) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %279 = "ttir.broadcast"(%278) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %280 = "ttir.add"(%276, %279) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %281 = "ttir.dot_general"(%280, %arg24) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %282 = "ttir.dot_general"(%280, %arg25) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %283 = "ttir.dot_general"(%280, %arg26) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %284 = "ttir.reshape"(%281) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %285 = "ttir.permute"(%284) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %286 = "ttir.reshape"(%282) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %287 = "ttir.permute"(%286) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %288 = "ttir.reshape"(%283) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %289 = "ttir.permute"(%288) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %290 = "ttir.permute"(%287) <{permutation = array<i64: 0, 1, 3, 2>}> : (tensor<8x12x197x64xf32>) -> tensor<8x12x64x197xf32>
+        %291 = "ttir.dot_general"(%285, %290) <{batch_dims_lhs = array<i64: 0, 1>, batch_dims_rhs = array<i64: 0, 1>, contract_dims_lhs = array<i64: 3>, contract_dims_rhs = array<i64: 2>}> : (tensor<8x12x197x64xf32>, tensor<8x12x64x197xf32>) -> tensor<8x12x197x197xf32>
+        %292 = "ttir.sqrt"(%5) : (tensor<f32>) -> tensor<f32>
+        %293 = "ttir.typecast"(%292) <{conservative_folding = false}> : (tensor<f32>) -> tensor<f32>
+        %294 = "ttir.reshape"(%293) <{shape = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1x1xf32>
+        %295 = "ttir.broadcast"(%294) <{broadcast_dimensions = array<i64: 8, 12, 197, 197>}> : (tensor<1x1x1x1xf32>) -> tensor<8x12x197x197xf32>
+        %296 = "ttir.div"(%291, %295) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %297 = "ttir.max"(%296) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<8x12x197x197xf32>) -> tensor<8x12x197xf32>
+        %298 = "ttir.reshape"(%4) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %299 = "ttir.broadcast"(%298) <{broadcast_dimensions = array<i64: 8, 12, 197>}> : (tensor<1x1x1xf32>) -> tensor<8x12x197xf32>
+        %300 = "ttir.maximum"(%299, %297) : (tensor<8x12x197xf32>, tensor<8x12x197xf32>) -> tensor<8x12x197xf32>
+        %301 = "ttir.reshape"(%300) <{shape = [8 : i32, 12 : i32, 197 : i32, 1 : i32]}> : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+        %302 = "ttir.broadcast"(%301) <{broadcast_dimensions = array<i64: 1, 1, 1, 1>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x1xf32>
+        %303 = "ttir.broadcast"(%302) <{broadcast_dimensions = array<i64: 1, 1, 1, 197>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+        %304 = "ttir.subtract"(%296, %303) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %305 = "ttir.exp"(%304) : (tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %306 = "ttir.sum"(%305) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<8x12x197x197xf32>) -> tensor<8x12x197xf32>
+        %307 = "ttir.reshape"(%306) <{shape = [8 : i32, 12 : i32, 197 : i32, 1 : i32]}> : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+        %308 = "ttir.broadcast"(%307) <{broadcast_dimensions = array<i64: 1, 1, 1, 1>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x1xf32>
+        %309 = "ttir.broadcast"(%308) <{broadcast_dimensions = array<i64: 1, 1, 1, 197>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+        %310 = "ttir.div"(%305, %309) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %311 = "ttir.dot_general"(%310, %289) <{batch_dims_lhs = array<i64: 0, 1>, batch_dims_rhs = array<i64: 0, 1>, contract_dims_lhs = array<i64: 3>, contract_dims_rhs = array<i64: 2>}> : (tensor<8x12x197x197xf32>, tensor<8x12x197x64xf32>) -> tensor<8x12x197x64xf32>
+        %312 = "ttir.permute"(%311) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x12x197x64xf32>) -> tensor<8x197x12x64xf32>
+        %313 = "ttir.reshape"(%312) <{shape = [8 : i32, 197 : i32, 768 : i32]}> : (tensor<8x197x12x64xf32>) -> tensor<8x197x768xf32>
+        %314 = "ttir.dot_general"(%313, %arg27) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %315 = "ttir.add"(%249, %314) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %316 = "ttir.sum"(%315) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %317 = "ttir.reshape"(%316) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %318 = "ttir.broadcast"(%317) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %319 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %320 = "ttir.broadcast"(%319) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %321 = "ttir.div"(%318, %320) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %322 = "ttir.broadcast"(%321) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %323 = "ttir.subtract"(%315, %322) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %324 = "ttir.multiply"(%323, %323) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %325 = "ttir.sum"(%324) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %326 = "ttir.reshape"(%325) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %327 = "ttir.broadcast"(%326) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %328 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %329 = "ttir.broadcast"(%328) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %330 = "ttir.div"(%327, %329) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %331 = "ttir.broadcast"(%321) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %332 = "ttir.subtract"(%315, %331) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %333 = "ttir.reshape"(%6) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %334 = "ttir.broadcast"(%333) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %335 = "ttir.add"(%330, %334) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %336 = "ttir.sqrt"(%335) : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %337 = "ttir.broadcast"(%336) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %338 = "ttir.div"(%332, %337) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %339 = "ttir.reshape"(%arg32) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %340 = "ttir.broadcast"(%339) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %341 = "ttir.broadcast"(%340) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %342 = "ttir.multiply"(%338, %341) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %343 = "ttir.reshape"(%arg33) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %344 = "ttir.broadcast"(%343) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %345 = "ttir.broadcast"(%344) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %346 = "ttir.add"(%342, %345) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %347 = "ttir.dot_general"(%346, %arg30) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x3072xf32>) -> tensor<8x197x3072xf32>
+        %348 = "ttir.multiply"(%347, %347) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %349 = "ttir.multiply"(%348, %347) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %350 = "ttir.reshape"(%3) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %351 = "ttir.broadcast"(%350) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %352 = "ttir.multiply"(%351, %349) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %353 = "ttir.add"(%347, %352) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %354 = "ttir.reshape"(%2) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %355 = "ttir.broadcast"(%354) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %356 = "ttir.multiply"(%355, %353) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %357 = "ttir.tanh"(%356) : (tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %358 = "ttir.reshape"(%1) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %359 = "ttir.broadcast"(%358) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %360 = "ttir.add"(%359, %357) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %361 = "ttir.reshape"(%0) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %362 = "ttir.broadcast"(%361) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %363 = "ttir.multiply"(%362, %360) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %364 = "ttir.multiply"(%347, %363) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %365 = "ttir.dot_general"(%364, %arg31) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x3072xf32>, tensor<3072x768xf32>) -> tensor<8x197x768xf32>
+        %366 = "ttir.add"(%315, %365) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %367 = "ttir.sum"(%366) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %368 = "ttir.reshape"(%367) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %369 = "ttir.broadcast"(%368) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %370 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %371 = "ttir.broadcast"(%370) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %372 = "ttir.div"(%369, %371) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %373 = "ttir.broadcast"(%372) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %374 = "ttir.subtract"(%366, %373) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %375 = "ttir.multiply"(%374, %374) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %376 = "ttir.sum"(%375) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %377 = "ttir.reshape"(%376) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %378 = "ttir.broadcast"(%377) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %379 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %380 = "ttir.broadcast"(%379) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %381 = "ttir.div"(%378, %380) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %382 = "ttir.broadcast"(%372) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %383 = "ttir.subtract"(%366, %382) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %384 = "ttir.reshape"(%6) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %385 = "ttir.broadcast"(%384) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %386 = "ttir.add"(%381, %385) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %387 = "ttir.sqrt"(%386) : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %388 = "ttir.broadcast"(%387) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %389 = "ttir.div"(%383, %388) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %390 = "ttir.reshape"(%arg38) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %391 = "ttir.broadcast"(%390) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %392 = "ttir.broadcast"(%391) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %393 = "ttir.multiply"(%389, %392) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %394 = "ttir.reshape"(%arg39) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %395 = "ttir.broadcast"(%394) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %396 = "ttir.broadcast"(%395) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %397 = "ttir.add"(%393, %396) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %398 = "ttir.dot_general"(%397, %arg34) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %399 = "ttir.dot_general"(%397, %arg35) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %400 = "ttir.dot_general"(%397, %arg36) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %401 = "ttir.reshape"(%398) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %402 = "ttir.permute"(%401) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %403 = "ttir.reshape"(%399) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %404 = "ttir.permute"(%403) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %405 = "ttir.reshape"(%400) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %406 = "ttir.permute"(%405) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %407 = "ttir.permute"(%404) <{permutation = array<i64: 0, 1, 3, 2>}> : (tensor<8x12x197x64xf32>) -> tensor<8x12x64x197xf32>
+        %408 = "ttir.dot_general"(%402, %407) <{batch_dims_lhs = array<i64: 0, 1>, batch_dims_rhs = array<i64: 0, 1>, contract_dims_lhs = array<i64: 3>, contract_dims_rhs = array<i64: 2>}> : (tensor<8x12x197x64xf32>, tensor<8x12x64x197xf32>) -> tensor<8x12x197x197xf32>
+        %409 = "ttir.sqrt"(%5) : (tensor<f32>) -> tensor<f32>
+        %410 = "ttir.typecast"(%409) <{conservative_folding = false}> : (tensor<f32>) -> tensor<f32>
+        %411 = "ttir.reshape"(%410) <{shape = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1x1xf32>
+        %412 = "ttir.broadcast"(%411) <{broadcast_dimensions = array<i64: 8, 12, 197, 197>}> : (tensor<1x1x1x1xf32>) -> tensor<8x12x197x197xf32>
+        %413 = "ttir.div"(%408, %412) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %414 = "ttir.max"(%413) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<8x12x197x197xf32>) -> tensor<8x12x197xf32>
+        %415 = "ttir.reshape"(%4) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %416 = "ttir.broadcast"(%415) <{broadcast_dimensions = array<i64: 8, 12, 197>}> : (tensor<1x1x1xf32>) -> tensor<8x12x197xf32>
+        %417 = "ttir.maximum"(%416, %414) : (tensor<8x12x197xf32>, tensor<8x12x197xf32>) -> tensor<8x12x197xf32>
+        %418 = "ttir.reshape"(%417) <{shape = [8 : i32, 12 : i32, 197 : i32, 1 : i32]}> : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+        %419 = "ttir.broadcast"(%418) <{broadcast_dimensions = array<i64: 1, 1, 1, 1>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x1xf32>
+        %420 = "ttir.broadcast"(%419) <{broadcast_dimensions = array<i64: 1, 1, 1, 197>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+        %421 = "ttir.subtract"(%413, %420) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %422 = "ttir.exp"(%421) : (tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %423 = "ttir.sum"(%422) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<8x12x197x197xf32>) -> tensor<8x12x197xf32>
+        %424 = "ttir.reshape"(%423) <{shape = [8 : i32, 12 : i32, 197 : i32, 1 : i32]}> : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+        %425 = "ttir.broadcast"(%424) <{broadcast_dimensions = array<i64: 1, 1, 1, 1>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x1xf32>
+        %426 = "ttir.broadcast"(%425) <{broadcast_dimensions = array<i64: 1, 1, 1, 197>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+        %427 = "ttir.div"(%422, %426) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %428 = "ttir.dot_general"(%427, %406) <{batch_dims_lhs = array<i64: 0, 1>, batch_dims_rhs = array<i64: 0, 1>, contract_dims_lhs = array<i64: 3>, contract_dims_rhs = array<i64: 2>}> : (tensor<8x12x197x197xf32>, tensor<8x12x197x64xf32>) -> tensor<8x12x197x64xf32>
+        %429 = "ttir.permute"(%428) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x12x197x64xf32>) -> tensor<8x197x12x64xf32>
+        %430 = "ttir.reshape"(%429) <{shape = [8 : i32, 197 : i32, 768 : i32]}> : (tensor<8x197x12x64xf32>) -> tensor<8x197x768xf32>
+        %431 = "ttir.dot_general"(%430, %arg37) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %432 = "ttir.add"(%366, %431) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %433 = "ttir.sum"(%432) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %434 = "ttir.reshape"(%433) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %435 = "ttir.broadcast"(%434) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %436 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %437 = "ttir.broadcast"(%436) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %438 = "ttir.div"(%435, %437) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %439 = "ttir.broadcast"(%438) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %440 = "ttir.subtract"(%432, %439) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %441 = "ttir.multiply"(%440, %440) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %442 = "ttir.sum"(%441) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %443 = "ttir.reshape"(%442) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %444 = "ttir.broadcast"(%443) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %445 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %446 = "ttir.broadcast"(%445) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %447 = "ttir.div"(%444, %446) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %448 = "ttir.broadcast"(%438) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %449 = "ttir.subtract"(%432, %448) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %450 = "ttir.reshape"(%6) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %451 = "ttir.broadcast"(%450) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %452 = "ttir.add"(%447, %451) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %453 = "ttir.sqrt"(%452) : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %454 = "ttir.broadcast"(%453) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %455 = "ttir.div"(%449, %454) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %456 = "ttir.reshape"(%arg42) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %457 = "ttir.broadcast"(%456) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %458 = "ttir.broadcast"(%457) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %459 = "ttir.multiply"(%455, %458) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %460 = "ttir.reshape"(%arg43) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %461 = "ttir.broadcast"(%460) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %462 = "ttir.broadcast"(%461) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %463 = "ttir.add"(%459, %462) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %464 = "ttir.dot_general"(%463, %arg40) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x3072xf32>) -> tensor<8x197x3072xf32>
+        %465 = "ttir.multiply"(%464, %464) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %466 = "ttir.multiply"(%465, %464) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %467 = "ttir.reshape"(%3) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %468 = "ttir.broadcast"(%467) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %469 = "ttir.multiply"(%468, %466) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %470 = "ttir.add"(%464, %469) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %471 = "ttir.reshape"(%2) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %472 = "ttir.broadcast"(%471) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %473 = "ttir.multiply"(%472, %470) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %474 = "ttir.tanh"(%473) : (tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %475 = "ttir.reshape"(%1) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %476 = "ttir.broadcast"(%475) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %477 = "ttir.add"(%476, %474) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %478 = "ttir.reshape"(%0) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %479 = "ttir.broadcast"(%478) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %480 = "ttir.multiply"(%479, %477) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %481 = "ttir.multiply"(%464, %480) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %482 = "ttir.dot_general"(%481, %arg41) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x3072xf32>, tensor<3072x768xf32>) -> tensor<8x197x768xf32>
+        %483 = "ttir.add"(%432, %482) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %484 = "ttir.sum"(%483) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %485 = "ttir.reshape"(%484) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %486 = "ttir.broadcast"(%485) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %487 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %488 = "ttir.broadcast"(%487) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %489 = "ttir.div"(%486, %488) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %490 = "ttir.broadcast"(%489) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %491 = "ttir.subtract"(%483, %490) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %492 = "ttir.multiply"(%491, %491) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %493 = "ttir.sum"(%492) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %494 = "ttir.reshape"(%493) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %495 = "ttir.broadcast"(%494) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %496 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %497 = "ttir.broadcast"(%496) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %498 = "ttir.div"(%495, %497) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %499 = "ttir.broadcast"(%489) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %500 = "ttir.subtract"(%483, %499) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %501 = "ttir.reshape"(%6) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %502 = "ttir.broadcast"(%501) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %503 = "ttir.add"(%498, %502) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %504 = "ttir.sqrt"(%503) : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %505 = "ttir.broadcast"(%504) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %506 = "ttir.div"(%500, %505) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %507 = "ttir.reshape"(%arg48) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %508 = "ttir.broadcast"(%507) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %509 = "ttir.broadcast"(%508) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %510 = "ttir.multiply"(%506, %509) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %511 = "ttir.reshape"(%arg49) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %512 = "ttir.broadcast"(%511) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %513 = "ttir.broadcast"(%512) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %514 = "ttir.add"(%510, %513) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %515 = "ttir.dot_general"(%514, %arg44) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %516 = "ttir.dot_general"(%514, %arg45) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %517 = "ttir.dot_general"(%514, %arg46) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %518 = "ttir.reshape"(%515) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %519 = "ttir.permute"(%518) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %520 = "ttir.reshape"(%516) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %521 = "ttir.permute"(%520) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %522 = "ttir.reshape"(%517) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %523 = "ttir.permute"(%522) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %524 = "ttir.permute"(%521) <{permutation = array<i64: 0, 1, 3, 2>}> : (tensor<8x12x197x64xf32>) -> tensor<8x12x64x197xf32>
+        %525 = "ttir.dot_general"(%519, %524) <{batch_dims_lhs = array<i64: 0, 1>, batch_dims_rhs = array<i64: 0, 1>, contract_dims_lhs = array<i64: 3>, contract_dims_rhs = array<i64: 2>}> : (tensor<8x12x197x64xf32>, tensor<8x12x64x197xf32>) -> tensor<8x12x197x197xf32>
+        %526 = "ttir.sqrt"(%5) : (tensor<f32>) -> tensor<f32>
+        %527 = "ttir.typecast"(%526) <{conservative_folding = false}> : (tensor<f32>) -> tensor<f32>
+        %528 = "ttir.reshape"(%527) <{shape = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1x1xf32>
+        %529 = "ttir.broadcast"(%528) <{broadcast_dimensions = array<i64: 8, 12, 197, 197>}> : (tensor<1x1x1x1xf32>) -> tensor<8x12x197x197xf32>
+        %530 = "ttir.div"(%525, %529) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %531 = "ttir.max"(%530) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<8x12x197x197xf32>) -> tensor<8x12x197xf32>
+        %532 = "ttir.reshape"(%4) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %533 = "ttir.broadcast"(%532) <{broadcast_dimensions = array<i64: 8, 12, 197>}> : (tensor<1x1x1xf32>) -> tensor<8x12x197xf32>
+        %534 = "ttir.maximum"(%533, %531) : (tensor<8x12x197xf32>, tensor<8x12x197xf32>) -> tensor<8x12x197xf32>
+        %535 = "ttir.reshape"(%534) <{shape = [8 : i32, 12 : i32, 197 : i32, 1 : i32]}> : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+        %536 = "ttir.broadcast"(%535) <{broadcast_dimensions = array<i64: 1, 1, 1, 1>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x1xf32>
+        %537 = "ttir.broadcast"(%536) <{broadcast_dimensions = array<i64: 1, 1, 1, 197>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+        %538 = "ttir.subtract"(%530, %537) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %539 = "ttir.exp"(%538) : (tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %540 = "ttir.sum"(%539) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<8x12x197x197xf32>) -> tensor<8x12x197xf32>
+        %541 = "ttir.reshape"(%540) <{shape = [8 : i32, 12 : i32, 197 : i32, 1 : i32]}> : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+        %542 = "ttir.broadcast"(%541) <{broadcast_dimensions = array<i64: 1, 1, 1, 1>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x1xf32>
+        %543 = "ttir.broadcast"(%542) <{broadcast_dimensions = array<i64: 1, 1, 1, 197>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+        %544 = "ttir.div"(%539, %543) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %545 = "ttir.dot_general"(%544, %523) <{batch_dims_lhs = array<i64: 0, 1>, batch_dims_rhs = array<i64: 0, 1>, contract_dims_lhs = array<i64: 3>, contract_dims_rhs = array<i64: 2>}> : (tensor<8x12x197x197xf32>, tensor<8x12x197x64xf32>) -> tensor<8x12x197x64xf32>
+        %546 = "ttir.permute"(%545) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x12x197x64xf32>) -> tensor<8x197x12x64xf32>
+        %547 = "ttir.reshape"(%546) <{shape = [8 : i32, 197 : i32, 768 : i32]}> : (tensor<8x197x12x64xf32>) -> tensor<8x197x768xf32>
+        %548 = "ttir.dot_general"(%547, %arg47) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %549 = "ttir.add"(%483, %548) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %550 = "ttir.sum"(%549) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %551 = "ttir.reshape"(%550) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %552 = "ttir.broadcast"(%551) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %553 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %554 = "ttir.broadcast"(%553) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %555 = "ttir.div"(%552, %554) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %556 = "ttir.broadcast"(%555) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %557 = "ttir.subtract"(%549, %556) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %558 = "ttir.multiply"(%557, %557) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %559 = "ttir.sum"(%558) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %560 = "ttir.reshape"(%559) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %561 = "ttir.broadcast"(%560) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %562 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %563 = "ttir.broadcast"(%562) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %564 = "ttir.div"(%561, %563) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %565 = "ttir.broadcast"(%555) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %566 = "ttir.subtract"(%549, %565) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %567 = "ttir.reshape"(%6) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %568 = "ttir.broadcast"(%567) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %569 = "ttir.add"(%564, %568) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %570 = "ttir.sqrt"(%569) : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %571 = "ttir.broadcast"(%570) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %572 = "ttir.div"(%566, %571) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %573 = "ttir.reshape"(%arg52) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %574 = "ttir.broadcast"(%573) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %575 = "ttir.broadcast"(%574) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %576 = "ttir.multiply"(%572, %575) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %577 = "ttir.reshape"(%arg53) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %578 = "ttir.broadcast"(%577) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %579 = "ttir.broadcast"(%578) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %580 = "ttir.add"(%576, %579) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %581 = "ttir.dot_general"(%580, %arg50) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x3072xf32>) -> tensor<8x197x3072xf32>
+        %582 = "ttir.multiply"(%581, %581) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %583 = "ttir.multiply"(%582, %581) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %584 = "ttir.reshape"(%3) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %585 = "ttir.broadcast"(%584) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %586 = "ttir.multiply"(%585, %583) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %587 = "ttir.add"(%581, %586) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %588 = "ttir.reshape"(%2) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %589 = "ttir.broadcast"(%588) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %590 = "ttir.multiply"(%589, %587) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %591 = "ttir.tanh"(%590) : (tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %592 = "ttir.reshape"(%1) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %593 = "ttir.broadcast"(%592) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %594 = "ttir.add"(%593, %591) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %595 = "ttir.reshape"(%0) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %596 = "ttir.broadcast"(%595) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %597 = "ttir.multiply"(%596, %594) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %598 = "ttir.multiply"(%581, %597) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %599 = "ttir.dot_general"(%598, %arg51) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x3072xf32>, tensor<3072x768xf32>) -> tensor<8x197x768xf32>
+        %600 = "ttir.add"(%549, %599) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %601 = "ttir.sum"(%600) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %602 = "ttir.reshape"(%601) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %603 = "ttir.broadcast"(%602) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %604 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %605 = "ttir.broadcast"(%604) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %606 = "ttir.div"(%603, %605) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %607 = "ttir.broadcast"(%606) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %608 = "ttir.subtract"(%600, %607) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %609 = "ttir.multiply"(%608, %608) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %610 = "ttir.sum"(%609) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %611 = "ttir.reshape"(%610) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %612 = "ttir.broadcast"(%611) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %613 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %614 = "ttir.broadcast"(%613) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %615 = "ttir.div"(%612, %614) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %616 = "ttir.broadcast"(%606) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %617 = "ttir.subtract"(%600, %616) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %618 = "ttir.reshape"(%6) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %619 = "ttir.broadcast"(%618) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %620 = "ttir.add"(%615, %619) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %621 = "ttir.sqrt"(%620) : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %622 = "ttir.broadcast"(%621) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %623 = "ttir.div"(%617, %622) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %624 = "ttir.reshape"(%arg58) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %625 = "ttir.broadcast"(%624) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %626 = "ttir.broadcast"(%625) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %627 = "ttir.multiply"(%623, %626) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %628 = "ttir.reshape"(%arg59) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %629 = "ttir.broadcast"(%628) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %630 = "ttir.broadcast"(%629) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %631 = "ttir.add"(%627, %630) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %632 = "ttir.dot_general"(%631, %arg54) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %633 = "ttir.dot_general"(%631, %arg55) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %634 = "ttir.dot_general"(%631, %arg56) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %635 = "ttir.reshape"(%632) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %636 = "ttir.permute"(%635) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %637 = "ttir.reshape"(%633) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %638 = "ttir.permute"(%637) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %639 = "ttir.reshape"(%634) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %640 = "ttir.permute"(%639) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %641 = "ttir.permute"(%638) <{permutation = array<i64: 0, 1, 3, 2>}> : (tensor<8x12x197x64xf32>) -> tensor<8x12x64x197xf32>
+        %642 = "ttir.dot_general"(%636, %641) <{batch_dims_lhs = array<i64: 0, 1>, batch_dims_rhs = array<i64: 0, 1>, contract_dims_lhs = array<i64: 3>, contract_dims_rhs = array<i64: 2>}> : (tensor<8x12x197x64xf32>, tensor<8x12x64x197xf32>) -> tensor<8x12x197x197xf32>
+        %643 = "ttir.sqrt"(%5) : (tensor<f32>) -> tensor<f32>
+        %644 = "ttir.typecast"(%643) <{conservative_folding = false}> : (tensor<f32>) -> tensor<f32>
+        %645 = "ttir.reshape"(%644) <{shape = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1x1xf32>
+        %646 = "ttir.broadcast"(%645) <{broadcast_dimensions = array<i64: 8, 12, 197, 197>}> : (tensor<1x1x1x1xf32>) -> tensor<8x12x197x197xf32>
+        %647 = "ttir.div"(%642, %646) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %648 = "ttir.max"(%647) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<8x12x197x197xf32>) -> tensor<8x12x197xf32>
+        %649 = "ttir.reshape"(%4) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %650 = "ttir.broadcast"(%649) <{broadcast_dimensions = array<i64: 8, 12, 197>}> : (tensor<1x1x1xf32>) -> tensor<8x12x197xf32>
+        %651 = "ttir.maximum"(%650, %648) : (tensor<8x12x197xf32>, tensor<8x12x197xf32>) -> tensor<8x12x197xf32>
+        %652 = "ttir.reshape"(%651) <{shape = [8 : i32, 12 : i32, 197 : i32, 1 : i32]}> : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+        %653 = "ttir.broadcast"(%652) <{broadcast_dimensions = array<i64: 1, 1, 1, 1>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x1xf32>
+        %654 = "ttir.broadcast"(%653) <{broadcast_dimensions = array<i64: 1, 1, 1, 197>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+        %655 = "ttir.subtract"(%647, %654) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %656 = "ttir.exp"(%655) : (tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %657 = "ttir.sum"(%656) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<8x12x197x197xf32>) -> tensor<8x12x197xf32>
+        %658 = "ttir.reshape"(%657) <{shape = [8 : i32, 12 : i32, 197 : i32, 1 : i32]}> : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+        %659 = "ttir.broadcast"(%658) <{broadcast_dimensions = array<i64: 1, 1, 1, 1>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x1xf32>
+        %660 = "ttir.broadcast"(%659) <{broadcast_dimensions = array<i64: 1, 1, 1, 197>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+        %661 = "ttir.div"(%656, %660) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %662 = "ttir.dot_general"(%661, %640) <{batch_dims_lhs = array<i64: 0, 1>, batch_dims_rhs = array<i64: 0, 1>, contract_dims_lhs = array<i64: 3>, contract_dims_rhs = array<i64: 2>}> : (tensor<8x12x197x197xf32>, tensor<8x12x197x64xf32>) -> tensor<8x12x197x64xf32>
+        %663 = "ttir.permute"(%662) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x12x197x64xf32>) -> tensor<8x197x12x64xf32>
+        %664 = "ttir.reshape"(%663) <{shape = [8 : i32, 197 : i32, 768 : i32]}> : (tensor<8x197x12x64xf32>) -> tensor<8x197x768xf32>
+        %665 = "ttir.dot_general"(%664, %arg57) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %666 = "ttir.add"(%600, %665) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %667 = "ttir.sum"(%666) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %668 = "ttir.reshape"(%667) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %669 = "ttir.broadcast"(%668) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %670 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %671 = "ttir.broadcast"(%670) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %672 = "ttir.div"(%669, %671) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %673 = "ttir.broadcast"(%672) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %674 = "ttir.subtract"(%666, %673) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %675 = "ttir.multiply"(%674, %674) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %676 = "ttir.sum"(%675) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %677 = "ttir.reshape"(%676) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %678 = "ttir.broadcast"(%677) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %679 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %680 = "ttir.broadcast"(%679) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %681 = "ttir.div"(%678, %680) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %682 = "ttir.broadcast"(%672) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %683 = "ttir.subtract"(%666, %682) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %684 = "ttir.reshape"(%6) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %685 = "ttir.broadcast"(%684) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %686 = "ttir.add"(%681, %685) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %687 = "ttir.sqrt"(%686) : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %688 = "ttir.broadcast"(%687) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %689 = "ttir.div"(%683, %688) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %690 = "ttir.reshape"(%arg62) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %691 = "ttir.broadcast"(%690) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %692 = "ttir.broadcast"(%691) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %693 = "ttir.multiply"(%689, %692) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %694 = "ttir.reshape"(%arg63) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %695 = "ttir.broadcast"(%694) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %696 = "ttir.broadcast"(%695) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %697 = "ttir.add"(%693, %696) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %698 = "ttir.dot_general"(%697, %arg60) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x3072xf32>) -> tensor<8x197x3072xf32>
+        %699 = "ttir.multiply"(%698, %698) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %700 = "ttir.multiply"(%699, %698) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %701 = "ttir.reshape"(%3) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %702 = "ttir.broadcast"(%701) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %703 = "ttir.multiply"(%702, %700) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %704 = "ttir.add"(%698, %703) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %705 = "ttir.reshape"(%2) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %706 = "ttir.broadcast"(%705) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %707 = "ttir.multiply"(%706, %704) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %708 = "ttir.tanh"(%707) : (tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %709 = "ttir.reshape"(%1) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %710 = "ttir.broadcast"(%709) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %711 = "ttir.add"(%710, %708) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %712 = "ttir.reshape"(%0) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %713 = "ttir.broadcast"(%712) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %714 = "ttir.multiply"(%713, %711) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %715 = "ttir.multiply"(%698, %714) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %716 = "ttir.dot_general"(%715, %arg61) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x3072xf32>, tensor<3072x768xf32>) -> tensor<8x197x768xf32>
+        %717 = "ttir.add"(%666, %716) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %718 = "ttir.sum"(%717) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %719 = "ttir.reshape"(%718) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %720 = "ttir.broadcast"(%719) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %721 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %722 = "ttir.broadcast"(%721) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %723 = "ttir.div"(%720, %722) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %724 = "ttir.broadcast"(%723) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %725 = "ttir.subtract"(%717, %724) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %726 = "ttir.multiply"(%725, %725) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %727 = "ttir.sum"(%726) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %728 = "ttir.reshape"(%727) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %729 = "ttir.broadcast"(%728) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %730 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %731 = "ttir.broadcast"(%730) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %732 = "ttir.div"(%729, %731) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %733 = "ttir.broadcast"(%723) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %734 = "ttir.subtract"(%717, %733) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %735 = "ttir.reshape"(%6) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %736 = "ttir.broadcast"(%735) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %737 = "ttir.add"(%732, %736) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %738 = "ttir.sqrt"(%737) : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %739 = "ttir.broadcast"(%738) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %740 = "ttir.div"(%734, %739) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %741 = "ttir.reshape"(%arg68) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %742 = "ttir.broadcast"(%741) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %743 = "ttir.broadcast"(%742) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %744 = "ttir.multiply"(%740, %743) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %745 = "ttir.reshape"(%arg69) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %746 = "ttir.broadcast"(%745) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %747 = "ttir.broadcast"(%746) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %748 = "ttir.add"(%744, %747) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %749 = "ttir.dot_general"(%748, %arg64) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %750 = "ttir.dot_general"(%748, %arg65) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %751 = "ttir.dot_general"(%748, %arg66) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %752 = "ttir.reshape"(%749) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %753 = "ttir.permute"(%752) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %754 = "ttir.reshape"(%750) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %755 = "ttir.permute"(%754) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %756 = "ttir.reshape"(%751) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %757 = "ttir.permute"(%756) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %758 = "ttir.permute"(%755) <{permutation = array<i64: 0, 1, 3, 2>}> : (tensor<8x12x197x64xf32>) -> tensor<8x12x64x197xf32>
+        %759 = "ttir.dot_general"(%753, %758) <{batch_dims_lhs = array<i64: 0, 1>, batch_dims_rhs = array<i64: 0, 1>, contract_dims_lhs = array<i64: 3>, contract_dims_rhs = array<i64: 2>}> : (tensor<8x12x197x64xf32>, tensor<8x12x64x197xf32>) -> tensor<8x12x197x197xf32>
+        %760 = "ttir.sqrt"(%5) : (tensor<f32>) -> tensor<f32>
+        %761 = "ttir.typecast"(%760) <{conservative_folding = false}> : (tensor<f32>) -> tensor<f32>
+        %762 = "ttir.reshape"(%761) <{shape = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1x1xf32>
+        %763 = "ttir.broadcast"(%762) <{broadcast_dimensions = array<i64: 8, 12, 197, 197>}> : (tensor<1x1x1x1xf32>) -> tensor<8x12x197x197xf32>
+        %764 = "ttir.div"(%759, %763) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %765 = "ttir.max"(%764) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<8x12x197x197xf32>) -> tensor<8x12x197xf32>
+        %766 = "ttir.reshape"(%4) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %767 = "ttir.broadcast"(%766) <{broadcast_dimensions = array<i64: 8, 12, 197>}> : (tensor<1x1x1xf32>) -> tensor<8x12x197xf32>
+        %768 = "ttir.maximum"(%767, %765) : (tensor<8x12x197xf32>, tensor<8x12x197xf32>) -> tensor<8x12x197xf32>
+        %769 = "ttir.reshape"(%768) <{shape = [8 : i32, 12 : i32, 197 : i32, 1 : i32]}> : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+        %770 = "ttir.broadcast"(%769) <{broadcast_dimensions = array<i64: 1, 1, 1, 1>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x1xf32>
+        %771 = "ttir.broadcast"(%770) <{broadcast_dimensions = array<i64: 1, 1, 1, 197>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+        %772 = "ttir.subtract"(%764, %771) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %773 = "ttir.exp"(%772) : (tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %774 = "ttir.sum"(%773) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<8x12x197x197xf32>) -> tensor<8x12x197xf32>
+        %775 = "ttir.reshape"(%774) <{shape = [8 : i32, 12 : i32, 197 : i32, 1 : i32]}> : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+        %776 = "ttir.broadcast"(%775) <{broadcast_dimensions = array<i64: 1, 1, 1, 1>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x1xf32>
+        %777 = "ttir.broadcast"(%776) <{broadcast_dimensions = array<i64: 1, 1, 1, 197>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+        %778 = "ttir.div"(%773, %777) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %779 = "ttir.dot_general"(%778, %757) <{batch_dims_lhs = array<i64: 0, 1>, batch_dims_rhs = array<i64: 0, 1>, contract_dims_lhs = array<i64: 3>, contract_dims_rhs = array<i64: 2>}> : (tensor<8x12x197x197xf32>, tensor<8x12x197x64xf32>) -> tensor<8x12x197x64xf32>
+        %780 = "ttir.permute"(%779) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x12x197x64xf32>) -> tensor<8x197x12x64xf32>
+        %781 = "ttir.reshape"(%780) <{shape = [8 : i32, 197 : i32, 768 : i32]}> : (tensor<8x197x12x64xf32>) -> tensor<8x197x768xf32>
+        %782 = "ttir.dot_general"(%781, %arg67) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %783 = "ttir.add"(%717, %782) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %784 = "ttir.sum"(%783) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %785 = "ttir.reshape"(%784) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %786 = "ttir.broadcast"(%785) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %787 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %788 = "ttir.broadcast"(%787) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %789 = "ttir.div"(%786, %788) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %790 = "ttir.broadcast"(%789) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %791 = "ttir.subtract"(%783, %790) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %792 = "ttir.multiply"(%791, %791) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %793 = "ttir.sum"(%792) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %794 = "ttir.reshape"(%793) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %795 = "ttir.broadcast"(%794) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %796 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %797 = "ttir.broadcast"(%796) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %798 = "ttir.div"(%795, %797) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %799 = "ttir.broadcast"(%789) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %800 = "ttir.subtract"(%783, %799) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %801 = "ttir.reshape"(%6) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %802 = "ttir.broadcast"(%801) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %803 = "ttir.add"(%798, %802) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %804 = "ttir.sqrt"(%803) : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %805 = "ttir.broadcast"(%804) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %806 = "ttir.div"(%800, %805) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %807 = "ttir.reshape"(%arg72) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %808 = "ttir.broadcast"(%807) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %809 = "ttir.broadcast"(%808) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %810 = "ttir.multiply"(%806, %809) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %811 = "ttir.reshape"(%arg73) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %812 = "ttir.broadcast"(%811) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %813 = "ttir.broadcast"(%812) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %814 = "ttir.add"(%810, %813) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %815 = "ttir.dot_general"(%814, %arg70) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x3072xf32>) -> tensor<8x197x3072xf32>
+        %816 = "ttir.multiply"(%815, %815) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %817 = "ttir.multiply"(%816, %815) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %818 = "ttir.reshape"(%3) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %819 = "ttir.broadcast"(%818) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %820 = "ttir.multiply"(%819, %817) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %821 = "ttir.add"(%815, %820) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %822 = "ttir.reshape"(%2) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %823 = "ttir.broadcast"(%822) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %824 = "ttir.multiply"(%823, %821) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %825 = "ttir.tanh"(%824) : (tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %826 = "ttir.reshape"(%1) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %827 = "ttir.broadcast"(%826) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %828 = "ttir.add"(%827, %825) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %829 = "ttir.reshape"(%0) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %830 = "ttir.broadcast"(%829) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %831 = "ttir.multiply"(%830, %828) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %832 = "ttir.multiply"(%815, %831) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %833 = "ttir.dot_general"(%832, %arg71) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x3072xf32>, tensor<3072x768xf32>) -> tensor<8x197x768xf32>
+        %834 = "ttir.add"(%783, %833) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %835 = "ttir.sum"(%834) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %836 = "ttir.reshape"(%835) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %837 = "ttir.broadcast"(%836) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %838 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %839 = "ttir.broadcast"(%838) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %840 = "ttir.div"(%837, %839) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %841 = "ttir.broadcast"(%840) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %842 = "ttir.subtract"(%834, %841) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %843 = "ttir.multiply"(%842, %842) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %844 = "ttir.sum"(%843) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %845 = "ttir.reshape"(%844) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %846 = "ttir.broadcast"(%845) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %847 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %848 = "ttir.broadcast"(%847) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %849 = "ttir.div"(%846, %848) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %850 = "ttir.broadcast"(%840) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %851 = "ttir.subtract"(%834, %850) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %852 = "ttir.reshape"(%6) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %853 = "ttir.broadcast"(%852) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %854 = "ttir.add"(%849, %853) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %855 = "ttir.sqrt"(%854) : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %856 = "ttir.broadcast"(%855) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %857 = "ttir.div"(%851, %856) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %858 = "ttir.reshape"(%arg78) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %859 = "ttir.broadcast"(%858) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %860 = "ttir.broadcast"(%859) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %861 = "ttir.multiply"(%857, %860) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %862 = "ttir.reshape"(%arg79) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %863 = "ttir.broadcast"(%862) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %864 = "ttir.broadcast"(%863) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %865 = "ttir.add"(%861, %864) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %866 = "ttir.dot_general"(%865, %arg74) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %867 = "ttir.dot_general"(%865, %arg75) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %868 = "ttir.dot_general"(%865, %arg76) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %869 = "ttir.reshape"(%866) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %870 = "ttir.permute"(%869) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %871 = "ttir.reshape"(%867) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %872 = "ttir.permute"(%871) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %873 = "ttir.reshape"(%868) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %874 = "ttir.permute"(%873) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %875 = "ttir.permute"(%872) <{permutation = array<i64: 0, 1, 3, 2>}> : (tensor<8x12x197x64xf32>) -> tensor<8x12x64x197xf32>
+        %876 = "ttir.dot_general"(%870, %875) <{batch_dims_lhs = array<i64: 0, 1>, batch_dims_rhs = array<i64: 0, 1>, contract_dims_lhs = array<i64: 3>, contract_dims_rhs = array<i64: 2>}> : (tensor<8x12x197x64xf32>, tensor<8x12x64x197xf32>) -> tensor<8x12x197x197xf32>
+        %877 = "ttir.sqrt"(%5) : (tensor<f32>) -> tensor<f32>
+        %878 = "ttir.typecast"(%877) <{conservative_folding = false}> : (tensor<f32>) -> tensor<f32>
+        %879 = "ttir.reshape"(%878) <{shape = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1x1xf32>
+        %880 = "ttir.broadcast"(%879) <{broadcast_dimensions = array<i64: 8, 12, 197, 197>}> : (tensor<1x1x1x1xf32>) -> tensor<8x12x197x197xf32>
+        %881 = "ttir.div"(%876, %880) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %882 = "ttir.max"(%881) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<8x12x197x197xf32>) -> tensor<8x12x197xf32>
+        %883 = "ttir.reshape"(%4) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %884 = "ttir.broadcast"(%883) <{broadcast_dimensions = array<i64: 8, 12, 197>}> : (tensor<1x1x1xf32>) -> tensor<8x12x197xf32>
+        %885 = "ttir.maximum"(%884, %882) : (tensor<8x12x197xf32>, tensor<8x12x197xf32>) -> tensor<8x12x197xf32>
+        %886 = "ttir.reshape"(%885) <{shape = [8 : i32, 12 : i32, 197 : i32, 1 : i32]}> : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+        %887 = "ttir.broadcast"(%886) <{broadcast_dimensions = array<i64: 1, 1, 1, 1>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x1xf32>
+        %888 = "ttir.broadcast"(%887) <{broadcast_dimensions = array<i64: 1, 1, 1, 197>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+        %889 = "ttir.subtract"(%881, %888) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %890 = "ttir.exp"(%889) : (tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %891 = "ttir.sum"(%890) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<8x12x197x197xf32>) -> tensor<8x12x197xf32>
+        %892 = "ttir.reshape"(%891) <{shape = [8 : i32, 12 : i32, 197 : i32, 1 : i32]}> : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+        %893 = "ttir.broadcast"(%892) <{broadcast_dimensions = array<i64: 1, 1, 1, 1>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x1xf32>
+        %894 = "ttir.broadcast"(%893) <{broadcast_dimensions = array<i64: 1, 1, 1, 197>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+        %895 = "ttir.div"(%890, %894) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %896 = "ttir.dot_general"(%895, %874) <{batch_dims_lhs = array<i64: 0, 1>, batch_dims_rhs = array<i64: 0, 1>, contract_dims_lhs = array<i64: 3>, contract_dims_rhs = array<i64: 2>}> : (tensor<8x12x197x197xf32>, tensor<8x12x197x64xf32>) -> tensor<8x12x197x64xf32>
+        %897 = "ttir.permute"(%896) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x12x197x64xf32>) -> tensor<8x197x12x64xf32>
+        %898 = "ttir.reshape"(%897) <{shape = [8 : i32, 197 : i32, 768 : i32]}> : (tensor<8x197x12x64xf32>) -> tensor<8x197x768xf32>
+        %899 = "ttir.dot_general"(%898, %arg77) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %900 = "ttir.add"(%834, %899) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %901 = "ttir.sum"(%900) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %902 = "ttir.reshape"(%901) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %903 = "ttir.broadcast"(%902) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %904 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %905 = "ttir.broadcast"(%904) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %906 = "ttir.div"(%903, %905) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %907 = "ttir.broadcast"(%906) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %908 = "ttir.subtract"(%900, %907) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %909 = "ttir.multiply"(%908, %908) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %910 = "ttir.sum"(%909) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %911 = "ttir.reshape"(%910) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %912 = "ttir.broadcast"(%911) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %913 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %914 = "ttir.broadcast"(%913) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %915 = "ttir.div"(%912, %914) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %916 = "ttir.broadcast"(%906) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %917 = "ttir.subtract"(%900, %916) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %918 = "ttir.reshape"(%6) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %919 = "ttir.broadcast"(%918) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %920 = "ttir.add"(%915, %919) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %921 = "ttir.sqrt"(%920) : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %922 = "ttir.broadcast"(%921) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %923 = "ttir.div"(%917, %922) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %924 = "ttir.reshape"(%arg82) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %925 = "ttir.broadcast"(%924) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %926 = "ttir.broadcast"(%925) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %927 = "ttir.multiply"(%923, %926) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %928 = "ttir.reshape"(%arg83) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %929 = "ttir.broadcast"(%928) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %930 = "ttir.broadcast"(%929) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %931 = "ttir.add"(%927, %930) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %932 = "ttir.dot_general"(%931, %arg80) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x3072xf32>) -> tensor<8x197x3072xf32>
+        %933 = "ttir.multiply"(%932, %932) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %934 = "ttir.multiply"(%933, %932) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %935 = "ttir.reshape"(%3) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %936 = "ttir.broadcast"(%935) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %937 = "ttir.multiply"(%936, %934) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %938 = "ttir.add"(%932, %937) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %939 = "ttir.reshape"(%2) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %940 = "ttir.broadcast"(%939) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %941 = "ttir.multiply"(%940, %938) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %942 = "ttir.tanh"(%941) : (tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %943 = "ttir.reshape"(%1) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %944 = "ttir.broadcast"(%943) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %945 = "ttir.add"(%944, %942) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %946 = "ttir.reshape"(%0) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %947 = "ttir.broadcast"(%946) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %948 = "ttir.multiply"(%947, %945) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %949 = "ttir.multiply"(%932, %948) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %950 = "ttir.dot_general"(%949, %arg81) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x3072xf32>, tensor<3072x768xf32>) -> tensor<8x197x768xf32>
+        %951 = "ttir.add"(%900, %950) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %952 = "ttir.sum"(%951) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %953 = "ttir.reshape"(%952) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %954 = "ttir.broadcast"(%953) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %955 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %956 = "ttir.broadcast"(%955) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %957 = "ttir.div"(%954, %956) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %958 = "ttir.broadcast"(%957) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %959 = "ttir.subtract"(%951, %958) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %960 = "ttir.multiply"(%959, %959) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %961 = "ttir.sum"(%960) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %962 = "ttir.reshape"(%961) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %963 = "ttir.broadcast"(%962) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %964 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %965 = "ttir.broadcast"(%964) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %966 = "ttir.div"(%963, %965) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %967 = "ttir.broadcast"(%957) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %968 = "ttir.subtract"(%951, %967) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %969 = "ttir.reshape"(%6) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %970 = "ttir.broadcast"(%969) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %971 = "ttir.add"(%966, %970) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %972 = "ttir.sqrt"(%971) : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %973 = "ttir.broadcast"(%972) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %974 = "ttir.div"(%968, %973) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %975 = "ttir.reshape"(%arg88) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %976 = "ttir.broadcast"(%975) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %977 = "ttir.broadcast"(%976) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %978 = "ttir.multiply"(%974, %977) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %979 = "ttir.reshape"(%arg89) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %980 = "ttir.broadcast"(%979) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %981 = "ttir.broadcast"(%980) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %982 = "ttir.add"(%978, %981) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %983 = "ttir.dot_general"(%982, %arg84) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %984 = "ttir.dot_general"(%982, %arg85) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %985 = "ttir.dot_general"(%982, %arg86) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %986 = "ttir.reshape"(%983) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %987 = "ttir.permute"(%986) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %988 = "ttir.reshape"(%984) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %989 = "ttir.permute"(%988) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %990 = "ttir.reshape"(%985) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %991 = "ttir.permute"(%990) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %992 = "ttir.permute"(%989) <{permutation = array<i64: 0, 1, 3, 2>}> : (tensor<8x12x197x64xf32>) -> tensor<8x12x64x197xf32>
+        %993 = "ttir.dot_general"(%987, %992) <{batch_dims_lhs = array<i64: 0, 1>, batch_dims_rhs = array<i64: 0, 1>, contract_dims_lhs = array<i64: 3>, contract_dims_rhs = array<i64: 2>}> : (tensor<8x12x197x64xf32>, tensor<8x12x64x197xf32>) -> tensor<8x12x197x197xf32>
+        %994 = "ttir.sqrt"(%5) : (tensor<f32>) -> tensor<f32>
+        %995 = "ttir.typecast"(%994) <{conservative_folding = false}> : (tensor<f32>) -> tensor<f32>
+        %996 = "ttir.reshape"(%995) <{shape = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1x1xf32>
+        %997 = "ttir.broadcast"(%996) <{broadcast_dimensions = array<i64: 8, 12, 197, 197>}> : (tensor<1x1x1x1xf32>) -> tensor<8x12x197x197xf32>
+        %998 = "ttir.div"(%993, %997) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %999 = "ttir.max"(%998) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<8x12x197x197xf32>) -> tensor<8x12x197xf32>
+        %1000 = "ttir.reshape"(%4) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1001 = "ttir.broadcast"(%1000) <{broadcast_dimensions = array<i64: 8, 12, 197>}> : (tensor<1x1x1xf32>) -> tensor<8x12x197xf32>
+        %1002 = "ttir.maximum"(%1001, %999) : (tensor<8x12x197xf32>, tensor<8x12x197xf32>) -> tensor<8x12x197xf32>
+        %1003 = "ttir.reshape"(%1002) <{shape = [8 : i32, 12 : i32, 197 : i32, 1 : i32]}> : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+        %1004 = "ttir.broadcast"(%1003) <{broadcast_dimensions = array<i64: 1, 1, 1, 1>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x1xf32>
+        %1005 = "ttir.broadcast"(%1004) <{broadcast_dimensions = array<i64: 1, 1, 1, 197>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+        %1006 = "ttir.subtract"(%998, %1005) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %1007 = "ttir.exp"(%1006) : (tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %1008 = "ttir.sum"(%1007) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<8x12x197x197xf32>) -> tensor<8x12x197xf32>
+        %1009 = "ttir.reshape"(%1008) <{shape = [8 : i32, 12 : i32, 197 : i32, 1 : i32]}> : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+        %1010 = "ttir.broadcast"(%1009) <{broadcast_dimensions = array<i64: 1, 1, 1, 1>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x1xf32>
+        %1011 = "ttir.broadcast"(%1010) <{broadcast_dimensions = array<i64: 1, 1, 1, 197>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+        %1012 = "ttir.div"(%1007, %1011) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %1013 = "ttir.dot_general"(%1012, %991) <{batch_dims_lhs = array<i64: 0, 1>, batch_dims_rhs = array<i64: 0, 1>, contract_dims_lhs = array<i64: 3>, contract_dims_rhs = array<i64: 2>}> : (tensor<8x12x197x197xf32>, tensor<8x12x197x64xf32>) -> tensor<8x12x197x64xf32>
+        %1014 = "ttir.permute"(%1013) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x12x197x64xf32>) -> tensor<8x197x12x64xf32>
+        %1015 = "ttir.reshape"(%1014) <{shape = [8 : i32, 197 : i32, 768 : i32]}> : (tensor<8x197x12x64xf32>) -> tensor<8x197x768xf32>
+        %1016 = "ttir.dot_general"(%1015, %arg87) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %1017 = "ttir.add"(%951, %1016) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1018 = "ttir.sum"(%1017) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %1019 = "ttir.reshape"(%1018) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %1020 = "ttir.broadcast"(%1019) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1021 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1022 = "ttir.broadcast"(%1021) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %1023 = "ttir.div"(%1020, %1022) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1024 = "ttir.broadcast"(%1023) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %1025 = "ttir.subtract"(%1017, %1024) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1026 = "ttir.multiply"(%1025, %1025) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1027 = "ttir.sum"(%1026) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %1028 = "ttir.reshape"(%1027) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %1029 = "ttir.broadcast"(%1028) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1030 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1031 = "ttir.broadcast"(%1030) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %1032 = "ttir.div"(%1029, %1031) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1033 = "ttir.broadcast"(%1023) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %1034 = "ttir.subtract"(%1017, %1033) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1035 = "ttir.reshape"(%6) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1036 = "ttir.broadcast"(%1035) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %1037 = "ttir.add"(%1032, %1036) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1038 = "ttir.sqrt"(%1037) : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1039 = "ttir.broadcast"(%1038) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %1040 = "ttir.div"(%1034, %1039) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1041 = "ttir.reshape"(%arg92) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %1042 = "ttir.broadcast"(%1041) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %1043 = "ttir.broadcast"(%1042) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %1044 = "ttir.multiply"(%1040, %1043) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1045 = "ttir.reshape"(%arg93) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %1046 = "ttir.broadcast"(%1045) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %1047 = "ttir.broadcast"(%1046) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %1048 = "ttir.add"(%1044, %1047) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1049 = "ttir.dot_general"(%1048, %arg90) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x3072xf32>) -> tensor<8x197x3072xf32>
+        %1050 = "ttir.multiply"(%1049, %1049) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1051 = "ttir.multiply"(%1050, %1049) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1052 = "ttir.reshape"(%3) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1053 = "ttir.broadcast"(%1052) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %1054 = "ttir.multiply"(%1053, %1051) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1055 = "ttir.add"(%1049, %1054) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1056 = "ttir.reshape"(%2) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1057 = "ttir.broadcast"(%1056) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %1058 = "ttir.multiply"(%1057, %1055) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1059 = "ttir.tanh"(%1058) : (tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1060 = "ttir.reshape"(%1) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1061 = "ttir.broadcast"(%1060) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %1062 = "ttir.add"(%1061, %1059) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1063 = "ttir.reshape"(%0) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1064 = "ttir.broadcast"(%1063) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %1065 = "ttir.multiply"(%1064, %1062) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1066 = "ttir.multiply"(%1049, %1065) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1067 = "ttir.dot_general"(%1066, %arg91) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x3072xf32>, tensor<3072x768xf32>) -> tensor<8x197x768xf32>
+        %1068 = "ttir.add"(%1017, %1067) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1069 = "ttir.sum"(%1068) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %1070 = "ttir.reshape"(%1069) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %1071 = "ttir.broadcast"(%1070) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1072 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1073 = "ttir.broadcast"(%1072) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %1074 = "ttir.div"(%1071, %1073) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1075 = "ttir.broadcast"(%1074) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %1076 = "ttir.subtract"(%1068, %1075) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1077 = "ttir.multiply"(%1076, %1076) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1078 = "ttir.sum"(%1077) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %1079 = "ttir.reshape"(%1078) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %1080 = "ttir.broadcast"(%1079) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1081 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1082 = "ttir.broadcast"(%1081) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %1083 = "ttir.div"(%1080, %1082) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1084 = "ttir.broadcast"(%1074) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %1085 = "ttir.subtract"(%1068, %1084) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1086 = "ttir.reshape"(%6) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1087 = "ttir.broadcast"(%1086) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %1088 = "ttir.add"(%1083, %1087) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1089 = "ttir.sqrt"(%1088) : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1090 = "ttir.broadcast"(%1089) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %1091 = "ttir.div"(%1085, %1090) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1092 = "ttir.reshape"(%arg98) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %1093 = "ttir.broadcast"(%1092) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %1094 = "ttir.broadcast"(%1093) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %1095 = "ttir.multiply"(%1091, %1094) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1096 = "ttir.reshape"(%arg99) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %1097 = "ttir.broadcast"(%1096) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %1098 = "ttir.broadcast"(%1097) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %1099 = "ttir.add"(%1095, %1098) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1100 = "ttir.dot_general"(%1099, %arg94) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %1101 = "ttir.dot_general"(%1099, %arg95) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %1102 = "ttir.dot_general"(%1099, %arg96) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %1103 = "ttir.reshape"(%1100) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %1104 = "ttir.permute"(%1103) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %1105 = "ttir.reshape"(%1101) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %1106 = "ttir.permute"(%1105) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %1107 = "ttir.reshape"(%1102) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %1108 = "ttir.permute"(%1107) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %1109 = "ttir.permute"(%1106) <{permutation = array<i64: 0, 1, 3, 2>}> : (tensor<8x12x197x64xf32>) -> tensor<8x12x64x197xf32>
+        %1110 = "ttir.dot_general"(%1104, %1109) <{batch_dims_lhs = array<i64: 0, 1>, batch_dims_rhs = array<i64: 0, 1>, contract_dims_lhs = array<i64: 3>, contract_dims_rhs = array<i64: 2>}> : (tensor<8x12x197x64xf32>, tensor<8x12x64x197xf32>) -> tensor<8x12x197x197xf32>
+        %1111 = "ttir.sqrt"(%5) : (tensor<f32>) -> tensor<f32>
+        %1112 = "ttir.typecast"(%1111) <{conservative_folding = false}> : (tensor<f32>) -> tensor<f32>
+        %1113 = "ttir.reshape"(%1112) <{shape = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1x1xf32>
+        %1114 = "ttir.broadcast"(%1113) <{broadcast_dimensions = array<i64: 8, 12, 197, 197>}> : (tensor<1x1x1x1xf32>) -> tensor<8x12x197x197xf32>
+        %1115 = "ttir.div"(%1110, %1114) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %1116 = "ttir.max"(%1115) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<8x12x197x197xf32>) -> tensor<8x12x197xf32>
+        %1117 = "ttir.reshape"(%4) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1118 = "ttir.broadcast"(%1117) <{broadcast_dimensions = array<i64: 8, 12, 197>}> : (tensor<1x1x1xf32>) -> tensor<8x12x197xf32>
+        %1119 = "ttir.maximum"(%1118, %1116) : (tensor<8x12x197xf32>, tensor<8x12x197xf32>) -> tensor<8x12x197xf32>
+        %1120 = "ttir.reshape"(%1119) <{shape = [8 : i32, 12 : i32, 197 : i32, 1 : i32]}> : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+        %1121 = "ttir.broadcast"(%1120) <{broadcast_dimensions = array<i64: 1, 1, 1, 1>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x1xf32>
+        %1122 = "ttir.broadcast"(%1121) <{broadcast_dimensions = array<i64: 1, 1, 1, 197>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+        %1123 = "ttir.subtract"(%1115, %1122) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %1124 = "ttir.exp"(%1123) : (tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %1125 = "ttir.sum"(%1124) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<8x12x197x197xf32>) -> tensor<8x12x197xf32>
+        %1126 = "ttir.reshape"(%1125) <{shape = [8 : i32, 12 : i32, 197 : i32, 1 : i32]}> : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+        %1127 = "ttir.broadcast"(%1126) <{broadcast_dimensions = array<i64: 1, 1, 1, 1>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x1xf32>
+        %1128 = "ttir.broadcast"(%1127) <{broadcast_dimensions = array<i64: 1, 1, 1, 197>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+        %1129 = "ttir.div"(%1124, %1128) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %1130 = "ttir.dot_general"(%1129, %1108) <{batch_dims_lhs = array<i64: 0, 1>, batch_dims_rhs = array<i64: 0, 1>, contract_dims_lhs = array<i64: 3>, contract_dims_rhs = array<i64: 2>}> : (tensor<8x12x197x197xf32>, tensor<8x12x197x64xf32>) -> tensor<8x12x197x64xf32>
+        %1131 = "ttir.permute"(%1130) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x12x197x64xf32>) -> tensor<8x197x12x64xf32>
+        %1132 = "ttir.reshape"(%1131) <{shape = [8 : i32, 197 : i32, 768 : i32]}> : (tensor<8x197x12x64xf32>) -> tensor<8x197x768xf32>
+        %1133 = "ttir.dot_general"(%1132, %arg97) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %1134 = "ttir.add"(%1068, %1133) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1135 = "ttir.sum"(%1134) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %1136 = "ttir.reshape"(%1135) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %1137 = "ttir.broadcast"(%1136) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1138 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1139 = "ttir.broadcast"(%1138) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %1140 = "ttir.div"(%1137, %1139) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1141 = "ttir.broadcast"(%1140) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %1142 = "ttir.subtract"(%1134, %1141) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1143 = "ttir.multiply"(%1142, %1142) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1144 = "ttir.sum"(%1143) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %1145 = "ttir.reshape"(%1144) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %1146 = "ttir.broadcast"(%1145) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1147 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1148 = "ttir.broadcast"(%1147) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %1149 = "ttir.div"(%1146, %1148) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1150 = "ttir.broadcast"(%1140) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %1151 = "ttir.subtract"(%1134, %1150) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1152 = "ttir.reshape"(%6) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1153 = "ttir.broadcast"(%1152) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %1154 = "ttir.add"(%1149, %1153) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1155 = "ttir.sqrt"(%1154) : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1156 = "ttir.broadcast"(%1155) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %1157 = "ttir.div"(%1151, %1156) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1158 = "ttir.reshape"(%arg102) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %1159 = "ttir.broadcast"(%1158) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %1160 = "ttir.broadcast"(%1159) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %1161 = "ttir.multiply"(%1157, %1160) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1162 = "ttir.reshape"(%arg103) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %1163 = "ttir.broadcast"(%1162) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %1164 = "ttir.broadcast"(%1163) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %1165 = "ttir.add"(%1161, %1164) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1166 = "ttir.dot_general"(%1165, %arg100) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x3072xf32>) -> tensor<8x197x3072xf32>
+        %1167 = "ttir.multiply"(%1166, %1166) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1168 = "ttir.multiply"(%1167, %1166) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1169 = "ttir.reshape"(%3) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1170 = "ttir.broadcast"(%1169) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %1171 = "ttir.multiply"(%1170, %1168) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1172 = "ttir.add"(%1166, %1171) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1173 = "ttir.reshape"(%2) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1174 = "ttir.broadcast"(%1173) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %1175 = "ttir.multiply"(%1174, %1172) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1176 = "ttir.tanh"(%1175) : (tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1177 = "ttir.reshape"(%1) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1178 = "ttir.broadcast"(%1177) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %1179 = "ttir.add"(%1178, %1176) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1180 = "ttir.reshape"(%0) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1181 = "ttir.broadcast"(%1180) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %1182 = "ttir.multiply"(%1181, %1179) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1183 = "ttir.multiply"(%1166, %1182) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1184 = "ttir.dot_general"(%1183, %arg101) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x3072xf32>, tensor<3072x768xf32>) -> tensor<8x197x768xf32>
+        %1185 = "ttir.add"(%1134, %1184) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1186 = "ttir.sum"(%1185) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %1187 = "ttir.reshape"(%1186) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %1188 = "ttir.broadcast"(%1187) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1189 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1190 = "ttir.broadcast"(%1189) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %1191 = "ttir.div"(%1188, %1190) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1192 = "ttir.broadcast"(%1191) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %1193 = "ttir.subtract"(%1185, %1192) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1194 = "ttir.multiply"(%1193, %1193) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1195 = "ttir.sum"(%1194) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %1196 = "ttir.reshape"(%1195) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %1197 = "ttir.broadcast"(%1196) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1198 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1199 = "ttir.broadcast"(%1198) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %1200 = "ttir.div"(%1197, %1199) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1201 = "ttir.broadcast"(%1191) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %1202 = "ttir.subtract"(%1185, %1201) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1203 = "ttir.reshape"(%6) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1204 = "ttir.broadcast"(%1203) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %1205 = "ttir.add"(%1200, %1204) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1206 = "ttir.sqrt"(%1205) : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1207 = "ttir.broadcast"(%1206) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %1208 = "ttir.div"(%1202, %1207) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1209 = "ttir.reshape"(%arg108) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %1210 = "ttir.broadcast"(%1209) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %1211 = "ttir.broadcast"(%1210) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %1212 = "ttir.multiply"(%1208, %1211) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1213 = "ttir.reshape"(%arg109) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %1214 = "ttir.broadcast"(%1213) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %1215 = "ttir.broadcast"(%1214) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %1216 = "ttir.add"(%1212, %1215) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1217 = "ttir.dot_general"(%1216, %arg104) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %1218 = "ttir.dot_general"(%1216, %arg105) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %1219 = "ttir.dot_general"(%1216, %arg106) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %1220 = "ttir.reshape"(%1217) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %1221 = "ttir.permute"(%1220) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %1222 = "ttir.reshape"(%1218) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %1223 = "ttir.permute"(%1222) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %1224 = "ttir.reshape"(%1219) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %1225 = "ttir.permute"(%1224) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %1226 = "ttir.permute"(%1223) <{permutation = array<i64: 0, 1, 3, 2>}> : (tensor<8x12x197x64xf32>) -> tensor<8x12x64x197xf32>
+        %1227 = "ttir.dot_general"(%1221, %1226) <{batch_dims_lhs = array<i64: 0, 1>, batch_dims_rhs = array<i64: 0, 1>, contract_dims_lhs = array<i64: 3>, contract_dims_rhs = array<i64: 2>}> : (tensor<8x12x197x64xf32>, tensor<8x12x64x197xf32>) -> tensor<8x12x197x197xf32>
+        %1228 = "ttir.sqrt"(%5) : (tensor<f32>) -> tensor<f32>
+        %1229 = "ttir.typecast"(%1228) <{conservative_folding = false}> : (tensor<f32>) -> tensor<f32>
+        %1230 = "ttir.reshape"(%1229) <{shape = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1x1xf32>
+        %1231 = "ttir.broadcast"(%1230) <{broadcast_dimensions = array<i64: 8, 12, 197, 197>}> : (tensor<1x1x1x1xf32>) -> tensor<8x12x197x197xf32>
+        %1232 = "ttir.div"(%1227, %1231) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %1233 = "ttir.max"(%1232) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<8x12x197x197xf32>) -> tensor<8x12x197xf32>
+        %1234 = "ttir.reshape"(%4) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1235 = "ttir.broadcast"(%1234) <{broadcast_dimensions = array<i64: 8, 12, 197>}> : (tensor<1x1x1xf32>) -> tensor<8x12x197xf32>
+        %1236 = "ttir.maximum"(%1235, %1233) : (tensor<8x12x197xf32>, tensor<8x12x197xf32>) -> tensor<8x12x197xf32>
+        %1237 = "ttir.reshape"(%1236) <{shape = [8 : i32, 12 : i32, 197 : i32, 1 : i32]}> : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+        %1238 = "ttir.broadcast"(%1237) <{broadcast_dimensions = array<i64: 1, 1, 1, 1>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x1xf32>
+        %1239 = "ttir.broadcast"(%1238) <{broadcast_dimensions = array<i64: 1, 1, 1, 197>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+        %1240 = "ttir.subtract"(%1232, %1239) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %1241 = "ttir.exp"(%1240) : (tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %1242 = "ttir.sum"(%1241) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<8x12x197x197xf32>) -> tensor<8x12x197xf32>
+        %1243 = "ttir.reshape"(%1242) <{shape = [8 : i32, 12 : i32, 197 : i32, 1 : i32]}> : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+        %1244 = "ttir.broadcast"(%1243) <{broadcast_dimensions = array<i64: 1, 1, 1, 1>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x1xf32>
+        %1245 = "ttir.broadcast"(%1244) <{broadcast_dimensions = array<i64: 1, 1, 1, 197>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+        %1246 = "ttir.div"(%1241, %1245) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %1247 = "ttir.dot_general"(%1246, %1225) <{batch_dims_lhs = array<i64: 0, 1>, batch_dims_rhs = array<i64: 0, 1>, contract_dims_lhs = array<i64: 3>, contract_dims_rhs = array<i64: 2>}> : (tensor<8x12x197x197xf32>, tensor<8x12x197x64xf32>) -> tensor<8x12x197x64xf32>
+        %1248 = "ttir.permute"(%1247) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x12x197x64xf32>) -> tensor<8x197x12x64xf32>
+        %1249 = "ttir.reshape"(%1248) <{shape = [8 : i32, 197 : i32, 768 : i32]}> : (tensor<8x197x12x64xf32>) -> tensor<8x197x768xf32>
+        %1250 = "ttir.dot_general"(%1249, %arg107) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %1251 = "ttir.add"(%1185, %1250) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1252 = "ttir.sum"(%1251) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %1253 = "ttir.reshape"(%1252) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %1254 = "ttir.broadcast"(%1253) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1255 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1256 = "ttir.broadcast"(%1255) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %1257 = "ttir.div"(%1254, %1256) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1258 = "ttir.broadcast"(%1257) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %1259 = "ttir.subtract"(%1251, %1258) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1260 = "ttir.multiply"(%1259, %1259) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1261 = "ttir.sum"(%1260) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %1262 = "ttir.reshape"(%1261) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %1263 = "ttir.broadcast"(%1262) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1264 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1265 = "ttir.broadcast"(%1264) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %1266 = "ttir.div"(%1263, %1265) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1267 = "ttir.broadcast"(%1257) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %1268 = "ttir.subtract"(%1251, %1267) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1269 = "ttir.reshape"(%6) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1270 = "ttir.broadcast"(%1269) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %1271 = "ttir.add"(%1266, %1270) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1272 = "ttir.sqrt"(%1271) : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1273 = "ttir.broadcast"(%1272) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %1274 = "ttir.div"(%1268, %1273) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1275 = "ttir.reshape"(%arg112) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %1276 = "ttir.broadcast"(%1275) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %1277 = "ttir.broadcast"(%1276) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %1278 = "ttir.multiply"(%1274, %1277) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1279 = "ttir.reshape"(%arg113) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %1280 = "ttir.broadcast"(%1279) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %1281 = "ttir.broadcast"(%1280) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %1282 = "ttir.add"(%1278, %1281) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1283 = "ttir.dot_general"(%1282, %arg110) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x3072xf32>) -> tensor<8x197x3072xf32>
+        %1284 = "ttir.multiply"(%1283, %1283) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1285 = "ttir.multiply"(%1284, %1283) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1286 = "ttir.reshape"(%3) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1287 = "ttir.broadcast"(%1286) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %1288 = "ttir.multiply"(%1287, %1285) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1289 = "ttir.add"(%1283, %1288) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1290 = "ttir.reshape"(%2) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1291 = "ttir.broadcast"(%1290) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %1292 = "ttir.multiply"(%1291, %1289) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1293 = "ttir.tanh"(%1292) : (tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1294 = "ttir.reshape"(%1) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1295 = "ttir.broadcast"(%1294) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %1296 = "ttir.add"(%1295, %1293) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1297 = "ttir.reshape"(%0) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1298 = "ttir.broadcast"(%1297) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %1299 = "ttir.multiply"(%1298, %1296) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1300 = "ttir.multiply"(%1283, %1299) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1301 = "ttir.dot_general"(%1300, %arg111) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x3072xf32>, tensor<3072x768xf32>) -> tensor<8x197x768xf32>
+        %1302 = "ttir.add"(%1251, %1301) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1303 = "ttir.sum"(%1302) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %1304 = "ttir.reshape"(%1303) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %1305 = "ttir.broadcast"(%1304) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1306 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1307 = "ttir.broadcast"(%1306) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %1308 = "ttir.div"(%1305, %1307) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1309 = "ttir.broadcast"(%1308) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %1310 = "ttir.subtract"(%1302, %1309) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1311 = "ttir.multiply"(%1310, %1310) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1312 = "ttir.sum"(%1311) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %1313 = "ttir.reshape"(%1312) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %1314 = "ttir.broadcast"(%1313) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1315 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1316 = "ttir.broadcast"(%1315) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %1317 = "ttir.div"(%1314, %1316) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1318 = "ttir.broadcast"(%1308) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %1319 = "ttir.subtract"(%1302, %1318) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1320 = "ttir.reshape"(%6) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1321 = "ttir.broadcast"(%1320) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %1322 = "ttir.add"(%1317, %1321) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1323 = "ttir.sqrt"(%1322) : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1324 = "ttir.broadcast"(%1323) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %1325 = "ttir.div"(%1319, %1324) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1326 = "ttir.reshape"(%arg118) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %1327 = "ttir.broadcast"(%1326) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %1328 = "ttir.broadcast"(%1327) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %1329 = "ttir.multiply"(%1325, %1328) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1330 = "ttir.reshape"(%arg119) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %1331 = "ttir.broadcast"(%1330) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %1332 = "ttir.broadcast"(%1331) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %1333 = "ttir.add"(%1329, %1332) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1334 = "ttir.dot_general"(%1333, %arg114) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %1335 = "ttir.dot_general"(%1333, %arg115) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %1336 = "ttir.dot_general"(%1333, %arg116) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %1337 = "ttir.reshape"(%1334) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %1338 = "ttir.permute"(%1337) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %1339 = "ttir.reshape"(%1335) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %1340 = "ttir.permute"(%1339) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %1341 = "ttir.reshape"(%1336) <{shape = [8 : i32, 197 : i32, 12 : i32, 64 : i32]}> : (tensor<8x197x768xf32>) -> tensor<8x197x12x64xf32>
+        %1342 = "ttir.permute"(%1341) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x197x12x64xf32>) -> tensor<8x12x197x64xf32>
+        %1343 = "ttir.permute"(%1340) <{permutation = array<i64: 0, 1, 3, 2>}> : (tensor<8x12x197x64xf32>) -> tensor<8x12x64x197xf32>
+        %1344 = "ttir.dot_general"(%1338, %1343) <{batch_dims_lhs = array<i64: 0, 1>, batch_dims_rhs = array<i64: 0, 1>, contract_dims_lhs = array<i64: 3>, contract_dims_rhs = array<i64: 2>}> : (tensor<8x12x197x64xf32>, tensor<8x12x64x197xf32>) -> tensor<8x12x197x197xf32>
+        %1345 = "ttir.sqrt"(%5) : (tensor<f32>) -> tensor<f32>
+        %1346 = "ttir.typecast"(%1345) <{conservative_folding = false}> : (tensor<f32>) -> tensor<f32>
+        %1347 = "ttir.reshape"(%1346) <{shape = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1x1xf32>
+        %1348 = "ttir.broadcast"(%1347) <{broadcast_dimensions = array<i64: 8, 12, 197, 197>}> : (tensor<1x1x1x1xf32>) -> tensor<8x12x197x197xf32>
+        %1349 = "ttir.div"(%1344, %1348) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %1350 = "ttir.max"(%1349) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<8x12x197x197xf32>) -> tensor<8x12x197xf32>
+        %1351 = "ttir.reshape"(%4) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1352 = "ttir.broadcast"(%1351) <{broadcast_dimensions = array<i64: 8, 12, 197>}> : (tensor<1x1x1xf32>) -> tensor<8x12x197xf32>
+        %1353 = "ttir.maximum"(%1352, %1350) : (tensor<8x12x197xf32>, tensor<8x12x197xf32>) -> tensor<8x12x197xf32>
+        %1354 = "ttir.reshape"(%1353) <{shape = [8 : i32, 12 : i32, 197 : i32, 1 : i32]}> : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+        %1355 = "ttir.broadcast"(%1354) <{broadcast_dimensions = array<i64: 1, 1, 1, 1>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x1xf32>
+        %1356 = "ttir.broadcast"(%1355) <{broadcast_dimensions = array<i64: 1, 1, 1, 197>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+        %1357 = "ttir.subtract"(%1349, %1356) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %1358 = "ttir.exp"(%1357) : (tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %1359 = "ttir.sum"(%1358) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<8x12x197x197xf32>) -> tensor<8x12x197xf32>
+        %1360 = "ttir.reshape"(%1359) <{shape = [8 : i32, 12 : i32, 197 : i32, 1 : i32]}> : (tensor<8x12x197xf32>) -> tensor<8x12x197x1xf32>
+        %1361 = "ttir.broadcast"(%1360) <{broadcast_dimensions = array<i64: 1, 1, 1, 1>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x1xf32>
+        %1362 = "ttir.broadcast"(%1361) <{broadcast_dimensions = array<i64: 1, 1, 1, 197>}> : (tensor<8x12x197x1xf32>) -> tensor<8x12x197x197xf32>
+        %1363 = "ttir.div"(%1358, %1362) : (tensor<8x12x197x197xf32>, tensor<8x12x197x197xf32>) -> tensor<8x12x197x197xf32>
+        %1364 = "ttir.dot_general"(%1363, %1342) <{batch_dims_lhs = array<i64: 0, 1>, batch_dims_rhs = array<i64: 0, 1>, contract_dims_lhs = array<i64: 3>, contract_dims_rhs = array<i64: 2>}> : (tensor<8x12x197x197xf32>, tensor<8x12x197x64xf32>) -> tensor<8x12x197x64xf32>
+        %1365 = "ttir.permute"(%1364) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<8x12x197x64xf32>) -> tensor<8x197x12x64xf32>
+        %1366 = "ttir.reshape"(%1365) <{shape = [8 : i32, 197 : i32, 768 : i32]}> : (tensor<8x197x12x64xf32>) -> tensor<8x197x768xf32>
+        %1367 = "ttir.dot_general"(%1366, %arg117) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x768xf32>) -> tensor<8x197x768xf32>
+        %1368 = "ttir.add"(%1302, %1367) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1369 = "ttir.sum"(%1368) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %1370 = "ttir.reshape"(%1369) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %1371 = "ttir.broadcast"(%1370) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1372 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1373 = "ttir.broadcast"(%1372) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %1374 = "ttir.div"(%1371, %1373) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1375 = "ttir.broadcast"(%1374) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %1376 = "ttir.subtract"(%1368, %1375) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1377 = "ttir.multiply"(%1376, %1376) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1378 = "ttir.sum"(%1377) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<8x197x768xf32>) -> tensor<8x197xf32>
+        %1379 = "ttir.reshape"(%1378) <{shape = [8 : i32, 197 : i32, 1 : i32]}> : (tensor<8x197xf32>) -> tensor<8x197x1xf32>
+        %1380 = "ttir.broadcast"(%1379) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1381 = "ttir.reshape"(%7) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1382 = "ttir.broadcast"(%1381) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %1383 = "ttir.div"(%1380, %1382) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1384 = "ttir.broadcast"(%1374) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %1385 = "ttir.subtract"(%1368, %1384) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1386 = "ttir.reshape"(%6) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1387 = "ttir.broadcast"(%1386) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x1xf32>) -> tensor<8x197x1xf32>
+        %1388 = "ttir.add"(%1383, %1387) : (tensor<8x197x1xf32>, tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1389 = "ttir.sqrt"(%1388) : (tensor<8x197x1xf32>) -> tensor<8x197x1xf32>
+        %1390 = "ttir.broadcast"(%1389) <{broadcast_dimensions = array<i64: 1, 1, 768>}> : (tensor<8x197x1xf32>) -> tensor<8x197x768xf32>
+        %1391 = "ttir.div"(%1385, %1390) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1392 = "ttir.reshape"(%arg122) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %1393 = "ttir.broadcast"(%1392) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %1394 = "ttir.broadcast"(%1393) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %1395 = "ttir.multiply"(%1391, %1394) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1396 = "ttir.reshape"(%arg123) <{shape = [1 : i32, 1 : i32, 768 : i32]}> : (tensor<768xf32>) -> tensor<1x1x768xf32>
+        %1397 = "ttir.broadcast"(%1396) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x1x768xf32>) -> tensor<1x1x768xf32>
+        %1398 = "ttir.broadcast"(%1397) <{broadcast_dimensions = array<i64: 8, 197, 1>}> : (tensor<1x1x768xf32>) -> tensor<8x197x768xf32>
+        %1399 = "ttir.add"(%1395, %1398) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        %1400 = "ttir.dot_general"(%1399, %arg120) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x768xf32>, tensor<768x3072xf32>) -> tensor<8x197x3072xf32>
+        %1401 = "ttir.multiply"(%1400, %1400) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1402 = "ttir.multiply"(%1401, %1400) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1403 = "ttir.reshape"(%3) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1404 = "ttir.broadcast"(%1403) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %1405 = "ttir.multiply"(%1404, %1402) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1406 = "ttir.add"(%1400, %1405) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1407 = "ttir.reshape"(%2) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1408 = "ttir.broadcast"(%1407) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %1409 = "ttir.multiply"(%1408, %1406) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1410 = "ttir.tanh"(%1409) : (tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1411 = "ttir.reshape"(%1) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1412 = "ttir.broadcast"(%1411) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %1413 = "ttir.add"(%1412, %1410) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1414 = "ttir.reshape"(%0) <{shape = [1 : i32, 1 : i32, 1 : i32]}> : (tensor<f32>) -> tensor<1x1x1xf32>
+        %1415 = "ttir.broadcast"(%1414) <{broadcast_dimensions = array<i64: 8, 197, 3072>}> : (tensor<1x1x1xf32>) -> tensor<8x197x3072xf32>
+        %1416 = "ttir.multiply"(%1415, %1413) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1417 = "ttir.multiply"(%1400, %1416) : (tensor<8x197x3072xf32>, tensor<8x197x3072xf32>) -> tensor<8x197x3072xf32>
+        %1418 = "ttir.dot_general"(%1417, %arg121) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 2>, contract_dims_rhs = array<i64: 0>}> : (tensor<8x197x3072xf32>, tensor<3072x768xf32>) -> tensor<8x197x768xf32>
+        %1419 = "ttir.add"(%1368, %1418) : (tensor<8x197x768xf32>, tensor<8x197x768xf32>) -> tensor<8x197x768xf32>
+        return %1419 : tensor<8x197x768xf32>
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
Stacked on the BERT MLIR PR (#<BERT PR number>). Rebase to main after that merges.

Extends the MLIR-to-Polaris frontend to a second real model, ViT-base,
using compiler-generated TTIR (tt-xla → StableHLO → ttmlir-opt).

## Changes
- **Concat** (StableHLO `concatenate` + TTIR `concat`) with `dim → axis`,
  needed for ViT's class-token prepend.
- **Conv** handler (StableHLO `convolution` → Polaris Conv) for upcoming
  CNN models (VGG/UNet). Not exercised by ViT (linear patch-embed), added
  for coverage.
- Real ViT-base TTIR example (`vit.ttir.mlir`) + intermediate StableHLO,
  wired into `mlir_workloads.yaml`.
- Unit tests: 97 MatMuls (96 + patch-embed), cls-token Concat, shape inference.

## Validation
| Path | matrix n150 | vs MLIR |
|---|---:|---:|
| MLIR (real TTIR) | 6,352,422 | — |
| ONNX (reference) | 6,352,477 | **0.001%** |
| TTNN (silicon-correlated) | 6,700,331 | **5.2%** |

Matrix cycles (compute) match the analytical ONNX reference exactly and the
silicon-correlated TTNN within 5%, confirming correct workload reconstruction
from compiler IR.